### PR TITLE
eliminate logically dead code

### DIFF
--- a/battle.cpp
+++ b/battle.cpp
@@ -444,7 +444,6 @@ void Game::GetDFacs(ARegion * r,Unit * t,AList & facs)
 						break;
 					}
 				}
-				if (AlliesIncluded == 1) break; // forlist(units)
 			}
 			if (AlliesIncluded == 1) break; // forlist (objects)
 		}

--- a/economy.cpp
+++ b/economy.cpp
@@ -1457,7 +1457,6 @@ void ARegion::Migrate()
 	int totalimm = 0;
 	forlist(&migfrom) {
 		ARegion *r = (ARegion *) elem;
-		if (!r) continue;
 		
 		// figure range
 		int xdist = r->xloc - xloc;

--- a/edit.cpp
+++ b/edit.cpp
@@ -99,7 +99,6 @@ ARegion *Game::EditGameFindRegion()
 	} while(0);
 
 	if (pStr) delete pStr;
-	if (pToken) delete pToken;
 
 	return(ret);
 }

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -459,11 +459,6 @@ void Game::ParseOrders(int faction, Aorders *f, OrdersCheck *pCheck)
 		unit = former;
 	}
 
-	if (unit && pCheck) {
-		unit->ClearOrders();
-		unit = 0;
-	}
-
 	if (pCheck) {
 		pCheck->pCheckFile->PutStr("");
 		if (!pCheck->numerrors) {

--- a/standard/map.cpp
+++ b/standard/map.cpp
@@ -700,7 +700,6 @@ void ARegionList::SetupAnchors(ARegionArray *ta)
 		while (skip > 5) {
 			f++;
 			skip -= 5;
-			if (skip < 1) skip = 1;
 		}
 		skip = 100 * ((skip+3) * f + 2) / (skip + f - 2);
 	}


### PR DESCRIPTION
Each of these changes eliminates a piece of code that can logically never run, which means they should change no behavior. I assume they are artifacts of some earlier refactorings, or the result of a misunderstanding. Shorter code is easier to read, and nobody likes to read dead code (at best it wastes time, at worst, it confuses the reader).
