### PR TITLE
Use of non-array delete

### DIFF
--- a/astring.cpp
+++ b/astring.cpp
@@ -79,7 +79,7 @@ AString::AString(char c)
 
 AString::~AString()
 {
-	if (str) delete str;
+	if (str) delete[] str;
 	str = NULL;
 }
 
@@ -93,7 +93,7 @@ AString::AString(const AString &s)
 AString & AString::operator=(const AString &s)
 {
 	len = s.len;
-	if (str) delete str;
+	if (str) delete[] str;
 	str = new char[len + 1];
 	strcpy(str,s.str);
 	return *this;
@@ -103,7 +103,7 @@ AString & AString::operator=(const char *c)
 {
 	len = 0;
 	if (c) len = strlen(c);
-	if (str) delete str;
+	if (str) delete[] str;
 	str = new char[len + 1];
 	if (c) strcpy(str,c);
 	return *this;
@@ -175,7 +175,7 @@ AString &AString::operator+=(const AString &s)
 	for (int j=0; j<s.len+1; j++) {
 		temp[i++] = s.str[j];
 	}
-	delete str;
+	delete[] str;
 	str = temp;
 	len = len + s.len;
 	return *this;
@@ -212,7 +212,7 @@ AString *AString::gettoken()
 			place++;
 		} else {
 			/* Unmatched "" return 0 */
-			delete str;
+			delete[] str;
 			str = new char[1];
 			len = 0;
 			str[0] = '\0';
@@ -226,7 +226,7 @@ AString *AString::gettoken()
 	}
 	buf[place2] = '\0';
 	if (place == len || str[place] == ';') {
-		delete str;
+		delete[] str;
 		str = new char[1];
 		len = 0;
 		str[0] = '\0';
@@ -241,7 +241,7 @@ AString *AString::gettoken()
 	}
 	buf2[place2] = '\0';
 	len = newlen;
-	delete str;
+	delete[] str;
 	str = buf2;
 	return new AString(buf);
 }
@@ -297,7 +297,7 @@ AString *AString::getlegal()
 	}
 
 	if (!j) {
-		delete temp;
+		delete[] temp;
 		return 0;
 	}
 

--- a/game.cpp
+++ b/game.cpp
@@ -1335,7 +1335,7 @@ Unit *Game::GetNewUnit(Faction *fac, int an)
 		Unit **temp = new Unit*[maxppunits+10000];
 		memcpy(temp, ppUnits, maxppunits*sizeof(Unit *));
 		maxppunits += 10000;
-		delete ppUnits;
+		delete[] ppUnits;
 		ppUnits = temp;
 	}
 


### PR DESCRIPTION
While most implementations do the right thing for delete on scalars, it's still a bug not to use delete[]. Especially on an array of objects (destructors need to be called), as in the case of GetNewUnit (game.cpp).
