### PR TITLE
Bug: Fix men on horse can tax without riding

### DIFF
--- a/unit.cpp
+++ b/unit.cpp
@@ -2045,7 +2045,7 @@ int Unit::Taxers(int numtaxers)
 			taxers += numMounts;
 		}
 		else if (Globals->WHO_CAN_TAX & GameDefs::TAX_HORSE_AND_RIDING_SKILL) {
-			weapontax += numMounts;
+			weapontax += numUsableMounts;
 			taxers += numUsableMounts;
 		}
 


### PR DESCRIPTION
If unit has horses but does not have RIDING skill, it should not be possible to tax with `GameDefs::TAX_HORSE_AND_RIDING_SKILL` setting and without `GameDefs::TAX_HORSE` setting