### PR TITLE
Fix compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.o

--- a/arcadia/aregion.cpp
+++ b/arcadia/aregion.cpp
@@ -2239,6 +2239,8 @@ void ARegionList::IcosahedralNeighSetup(ARegion *r, ARegionArray *ar)
 	scale = ar->x / 10;
 
 	r->ZeroNeighbors();
+	y = r->yloc;
+	x = r->xloc;
 	// x2 is the x-coord of this hex inside its "wedge"
 	if (y < 5 * scale)
 		x2 = x % (2 * scale);

--- a/arcadia/aregion.cpp
+++ b/arcadia/aregion.cpp
@@ -2878,7 +2878,7 @@ int lastocean = -1;
 // add/remove beaches.
         for(int k=0; k<6; k++) {
             if(!neighbors[k]) continue;
-            if(!TerrainDefs[neighbors[k]->type].similar_type == R_OCEAN) {
+            if(!(TerrainDefs[neighbors[k]->type].similar_type == R_OCEAN)) {
                 hexside[k]->type = H_DUMMY; //gets rid of beaches
                 continue;
             }

--- a/arcadia/aregion.cpp
+++ b/arcadia/aregion.cpp
@@ -2256,7 +2256,7 @@ void ARegionList::IcosahedralNeighSetup(ARegion *r, ARegionArray *ar)
 	}
 	// but if that fails, use the special icosahedral connections:
 	if (!r->neighbors[D_NORTH]) {
-		if (y > 0 & y < 3 * scale)
+		if (y > 0 && y < 3 * scale)
 		{
 			if (y == 2) {
 				neighX = 0;
@@ -2342,7 +2342,7 @@ void ARegionList::IcosahedralNeighSetup(ARegion *r, ARegionArray *ar)
 		r->neighbors[D_SOUTH] = ar->GetRegion(x, y + 2);
 	}
 	if (!r->neighbors[D_SOUTH]) {
-		if (y2 > 0 & y2 < 3 * scale)
+		if (y2 > 0 && y2 < 3 * scale)
 		{
 			if (y2 == 2) {
 				neighX = 10 * scale - 1;

--- a/arcadia/aregion.cpp
+++ b/arcadia/aregion.cpp
@@ -92,7 +92,7 @@ TownInfo::~TownInfo()
 	if (name) delete name;
 }
 
-void TownInfo::Readin(Ainfile *f, ATL_VER &v)
+void TownInfo::Readin(Ainfile *f, ATL_VER&)
 {
 	name = f->GetStr();
 	pop = f->GetInt();

--- a/arcadia/aregion.cpp
+++ b/arcadia/aregion.cpp
@@ -1949,11 +1949,14 @@ int ARegion::CanTax(Unit *u)
 		Object *obj = (Object *) elem;
 		forlist ((&obj->units)) {
 			Unit *u2 = (Unit *) elem;
-			if (u2->guard == GUARD_GUARD && u2->IsReallyAlive())
-			    if(u2->type == U_GUARD || u2->type == U_GUARDMAGE) {
-			        if(town) return 0; //guards prevent taxing in towns
-			        if(u2->faction->ethnicity != u->faction->ethnicity) return 0; //guards prevent other ethnicities taxing
-				} else if (u2->GetAttitude(this, u) <= A_NEUTRAL) return 0;
+			if (u2->guard == GUARD_GUARD && u2->IsReallyAlive()) {
+				if (u2->type == U_GUARD || u2->type == U_GUARDMAGE) {
+					if (town) return 0; //guards prevent taxing in towns
+					if (u2->faction->ethnicity != u->faction->ethnicity) return 0; //guards prevent other ethnicities taxing
+				} else {
+					if (u2->GetAttitude(this, u) <= A_NEUTRAL) return 0;
+				}
+			}
 		}
 	}
 	

--- a/arcadia/aregion.cpp
+++ b/arcadia/aregion.cpp
@@ -153,7 +153,7 @@ void ARegion::ZeroNeighbors()
 	}
 }
 
-void ARegion::SetName(char *c)
+void ARegion::SetName(char const *c)
 {
 	if(name) delete name;
 	name = new AString(c);
@@ -1876,7 +1876,7 @@ int ARegion::HasCityGuard()
 	return 0;
 }
 
-int ARegion::NotifySpell(Unit *caster, char *spell, ARegionList *pRegs)
+int ARegion::NotifySpell(Unit *caster, char const *spell, ARegionList *pRegs)
 {
 	AList flist;
 	unsigned int i;
@@ -2576,7 +2576,7 @@ ARegion *ARegionArray::GetRegion(int xx, int yy)
 	return(regions[xx / 2 + yy * x / 2]);
 }
 
-void ARegionArray::SetName(char *name)
+void ARegionArray::SetName(char const *name)
 {
 	if(name) {
 		strName = new AString(name);

--- a/arcadia/aregion.h
+++ b/arcadia/aregion.h
@@ -68,8 +68,8 @@ struct Product
 class TerrainType
 {
 	public:
-		char *name;
-		char *type;
+		char const *name;
+		char const *type;
 		char marker;
 		int similar_type;
 
@@ -119,7 +119,7 @@ class Location : public AListElem
 Location *GetUnit(AList *, int);
 
 int AGetName(int town);
-char *AGetNameString(int name);
+char const *AGetNameString(int name);
 
 class ARegionPtr : public AListElem
 {
@@ -185,7 +185,7 @@ class ARegion : public AListElem
 		void Setup();
 
 		void ZeroNeighbors();
-		void SetName(char *);
+		void SetName(char const *);
 
 		void Writeout(Aoutfile *);
 		void Readin(Ainfile *, AList *, ATL_VER v);
@@ -230,7 +230,7 @@ class ARegion : public AListElem
 		int CanPillage(Unit *);
 		int ForbiddenShip(Object *);
 		int HasCityGuard();
-		int NotifySpell(Unit *, char *, ARegionList *pRegs);
+		int NotifySpell(Unit *, char const *, ARegionList *pRegs);
 		void NotifyCity(Unit *, AString& oldname, AString& newname);
 
 		void DefaultOrders(int peasantfac);
@@ -379,7 +379,7 @@ class ARegionArray
 
 		void SetRegion(int, int, ARegion *);
 		ARegion *GetRegion(int, int);
-		void SetName(char *name);
+		void SetName(char const *name);
 
 		int x;
 		int y;
@@ -468,12 +468,12 @@ class ARegionList : public AList
 		// Public world creation stuff
 		//
 		void CreateLevels(int numLevels);
-		void CreateAbyssLevel(int level, char *name);
-		void CreateNexusLevel(int level, int xSize, int ySize, char *name);
+		void CreateAbyssLevel(int level, char const *name);
+		void CreateNexusLevel(int level, int xSize, int ySize, char const *name);
 		void CreateSurfaceLevel(int level, int xSize, int ySize, char *name);
 		void CreateIslandLevel(int level, int nPlayers, char *name);
-		void CreateUnderworldLevel(int level, int xSize, int ySize, char *name);
-		void CreateUnderdeepLevel(int level, int xSize, int ySize, char *name);
+		void CreateUnderworldLevel(int level, int xSize, int ySize, char const *name);
+		void CreateUnderdeepLevel(int level, int xSize, int ySize, char const *name);
 		void AddQuestLevel(int xSize, int ySize, char *name, int type);
 
 		void MakeShaftLinks(int levelFrom, int levelTo, int odds);

--- a/arcadia/army1.cpp
+++ b/arcadia/army1.cpp
@@ -2543,7 +2543,6 @@ cout << " !";
     // penalties are now between 0 and 2, depending on racial fractions in the army.
     for(int i=0; i<RA_NA; i++) racecount[i] = 0;
     
-    int max = unity;
 #ifdef DEBUG2
 cout << "@";
 #endif

--- a/arcadia/army1.cpp
+++ b/arcadia/army1.cpp
@@ -267,7 +267,7 @@ Soldier * Army::GetAttacker(int attackernum)
     return 0;
 }
 
-int Army::GetTarget(Army *attackers, int attackerform, int attackType, int *targetform, char* special, Battle *b)
+int Army::GetTarget(Army *attackers, int attackerform, int attackType, int *targetform, char const * special, Battle *b)
 //this sequence gets an enemy soldier to attack.
 //"this" is the army of the defending unit.
 {
@@ -505,8 +505,8 @@ int Hits(int a,int d)
 	return 0;
 }
 
-int Army::DoAnAttack(char *special, int numAttacks, int race, int attackType, int attackLev, 
-                  int flags, int weaponClass, char *effect, int mountBonus, Army *attackers, int attackerform, Battle *b, int strength)
+int Army::DoAnAttack(char const *special, int numAttacks, int race, int attackType, int attackLev, 
+                  int flags, int weaponClass, char const *effect, int mountBonus, Army *attackers, int attackerform, Battle *b, int strength)
 		/* The army in question is the army DEFENDING!
 		   */
 

--- a/arcadia/army1.h
+++ b/arcadia/army1.h
@@ -59,11 +59,11 @@ class Army
 		Soldier * GetAttacker(int attackernum); //attackernum should be from 0 to CanAttack()-1. 
                                       //For some reason this can't be set constant - may want to check this if problems.
         
-        int ShieldIsUseful(char *special) const;
-        int IsSpecialTarget(char *special) const;
-        int GetTarget(Army *attackers, int formation, int attackType, int *targetform, char* special, Battle *b);                                      
-		int DoAnAttack(char *special, int numAttacks, int race, int attackType, int attackLevel, 
-                  int flags, int weaponClass, char *effect, int mountBonus, Army *attackers, int formation, Battle *b,
+        int ShieldIsUseful(char const *special) const;
+        int IsSpecialTarget(char const *special) const;
+        int GetTarget(Army *attackers, int formation, int attackType, int *targetform, char const * special, Battle *b);                                      
+		int DoAnAttack(char const *special, int numAttacks, int race, int attackType, int attackLevel, 
+                  int flags, int weaponClass, char const *effect, int mountBonus, Army *attackers, int formation, Battle *b,
                   int strength = 1);
 
         AList armytext;

--- a/arcadia/astring.cpp
+++ b/arcadia/astring.cpp
@@ -161,7 +161,7 @@ AString AString::operator+(const AString &s)
 		temp[i++] = s.str[j];
 	}
 	AString temp2 = AString(temp);
-	delete temp;
+	delete[] temp;
 	return temp2;
 }
 
@@ -310,13 +310,13 @@ AString *AString::getlegal()
 	}
 
 	if (!j) {
-		delete temp;
+		delete[] temp;
 		return 0;
 	}
 
 	*temp2 = '\0';
 	AString * retval = new AString(temp);
-	delete temp;
+	delete[] temp;
 	return retval;
 }
 
@@ -372,6 +372,6 @@ istream & operator >>(istream & is,AString & s)
 	s.len = strlen(buf);
 	s.str = new char[s.len + 1];
 	strcpy(s.str,buf);
-	delete buf;
+	delete[] buf;
 	return is;
 }

--- a/arcadia/astring.h
+++ b/arcadia/astring.h
@@ -68,7 +68,6 @@ public:
 private:
 
 	int len;
-	int size;
 	char *str;
 	int isEqual(const char *);
 };

--- a/arcadia/battle1.cpp
+++ b/arcadia/battle1.cpp
@@ -159,7 +159,7 @@ int Game::CanAttack(ARegion * r,AList * afacs,Unit * u) {
 }
 
 void Game::GetSides(ARegion *r, AList &afacs, AList &dfacs, AList &atts,
-		AList &defs, Unit *att, Unit *tar, int ass, int adv)
+		AList &defs, Unit *att, Unit *tar, int ass, int )
 {
     att->crossbridge = 0;
     tar->crossbridge = 0;

--- a/arcadia/economy.cpp
+++ b/arcadia/economy.cpp
@@ -1002,7 +1002,7 @@ void ARegion::UpdateEditRegion()
 	}
 }
 
-void ARegion::SetupEditRegion(int canmakecity)
+void ARegion::SetupEditRegion(int)
 {
 //Direct copy of SetupPop() except calls AddEditTown() instead of AddTown()
 	TerrainType *typer = &(TerrainDefs[type]);

--- a/arcadia/economy.cpp
+++ b/arcadia/economy.cpp
@@ -1248,7 +1248,8 @@ int ARegion::TownHabitat()
 	if(caravan) build++;
 	if(build > 2) build = 2;
 	
-	hab = (build++ * build + 1) * hab * hab + basepopulation / 4 + 50;
+	build++;
+	hab = (build * build + 1) * hab * hab + basepopulation / 4 + 50;
 	
 	// Lake Effect
 	if(LakeEffect()) hab += 100;

--- a/arcadia/economy.cpp
+++ b/arcadia/economy.cpp
@@ -1229,7 +1229,7 @@ int ARegion::TownHabitat()
 		if(ItemDefs[ObjectDefs[obj->type].productionAided].flags & IT_FOOD) farm++;
 		if(ObjectDefs[obj->type].productionAided == I_SILVER) inn++;
 		if(ObjectDefs[obj->type].productionAided == I_HERBS) temple++;
-		if(ObjectDefs[obj->type].name == "Bank") bank++;
+		if(obj->type == O_OBANK) bank++;
 		if((ObjectDefs[obj->type].flags & ObjectType::TRANSPORT)
 			&& (ItemDefs[ObjectDefs[obj->type].productionAided].flags & IT_MOUNT)) caravan++;
 	}

--- a/arcadia/economy.cpp
+++ b/arcadia/economy.cpp
@@ -416,9 +416,6 @@ void ARegion::SetupCityMarket()
 				}
 			}
 		}
-		int canProduce = 0;
-		// Check if the locals can produce this item
-		if(canProduceHere) canProduce = locals->CanProduce(i);
 		int isUseful = 0;
 		// Check if the item is useful to the locals
 		isUseful = locals->CanUse(i);

--- a/arcadia/edit.cpp
+++ b/arcadia/edit.cpp
@@ -2613,7 +2613,7 @@ void Game::ImportMapFile(AString *filename, int level)
 }
 
 
-void ARegion::SetEthnicity(int ethnicity, ARegionList *pRegs)
+void ARegion::SetEthnicity(int ethnicity, ARegionList* )
 {
 Awrite(EthnicityString(ethnicity));
     int chance = getrandom(100);

--- a/arcadia/extra.cpp
+++ b/arcadia/extra.cpp
@@ -160,7 +160,7 @@ Faction *Game::CheckVictory(AString *victoryline)
 	for(int i=0; i<RA_NA; i++) {
 	    if(race_present != -1) {
 	        if(faction_present[i]) return NULL;  //two ethnicities, no winner.
-	    } else if(faction_present) race_present = i;
+	    } else if(faction_present[i]) race_present = i;
 	}
 	
 	if(race_present == -1) return GetFaction(&factions,monfaction); //there appear to be no player factions left :(

--- a/arcadia/faction.cpp
+++ b/arcadia/faction.cpp
@@ -26,7 +26,7 @@
 #include "gamedata.h"
 #include "game.h"
 
-char *as[] = {
+char const *as[] = {
 	"Hostile",
 	"Unfriendly",
 	"Neutral",
@@ -34,25 +34,25 @@ char *as[] = {
 	"Ally"
 };
 
-char **AttitudeStrs = as;
+char const **AttitudeStrs = as;
 
-char *fs[] = {
+char const *fs[] = {
 	"War",
 	"Trade",
 	"Heroes"
 };
 
-char **FactionStrs = fs;
+char const **FactionStrs = fs;
 
 // LLS - fix up the template strings
-char *tp[] = {
+char const *tp[] = {
 	"off",
 	"short",
 	"long",
 	"map"
 };
 
-char **TemplateStrs = tp;
+char const **TemplateStrs = tp;
 
 int ParseTemplate(AString *token)
 {

--- a/arcadia/faction.cpp
+++ b/arcadia/faction.cpp
@@ -109,7 +109,7 @@ void Attitude::Writeout(Aoutfile *f)
 	f->PutInt(attitude);
 }
 
-void Attitude::Readin(Ainfile *f, ATL_VER v)
+void Attitude::Readin(Ainfile *f, ATL_VER)
 {
 	factionnum = f->GetInt();
 	attitude = f->GetInt();

--- a/arcadia/faction.h
+++ b/arcadia/faction.h
@@ -78,11 +78,11 @@ enum {
     QUIT_GAME_OVER,
 };
 
-extern char ** AttitudeStrs;
-extern char ** FactionStrs;
+extern char const ** AttitudeStrs;
+extern char const ** FactionStrs;
 
 // LLS - include strings for the template enum
-extern char **TemplateStrs;
+extern char const **TemplateStrs;
 int ParseTemplate(AString *);
 
 int ParseAttitude(AString *);

--- a/arcadia/fileio.cpp
+++ b/arcadia/fileio.cpp
@@ -191,7 +191,7 @@ void Aoutfile::PutInt(int x)
 	*file << F_ENDLINE;
 }
 
-void Aoutfile::PutStr(char *s)
+void Aoutfile::PutStr(char const *s)
 {
 	*file << s << F_ENDLINE;
 }

--- a/arcadia/fileio.h
+++ b/arcadia/fileio.h
@@ -56,7 +56,7 @@ class Aoutfile {
 		int OpenByName(const AString &, int append = 0);
 		void Close();
 
-		void PutStr(char *);
+		void PutStr(char const *);
 		void PutStr(const AString &);
 		void PutInt(int);
 

--- a/arcadia/formation1.cpp
+++ b/arcadia/formation1.cpp
@@ -355,7 +355,7 @@ int Formation::Engaged(Army *itsarmy) const
     return 0;
 }
 
-void Formation::Sort(Army *itsarmy, Battle *b, int regtype)
+void Formation::Sort(Army *itsarmy, Battle *b, int)
 {
     int i=0;
     int missort=0;

--- a/arcadia/formation1.h
+++ b/arcadia/formation1.h
@@ -107,7 +107,7 @@ class Formation
 		void Regenerate(Battle *b) const;
 
 		//Magic Targetting:
-		int CheckSpecialTarget(char *, int soldiernum) const; //This is in specials.cpp
+		int CheckSpecialTarget(char const *, int soldiernum) const; //This is in specials.cpp
 		
 		//Formation Phase methods
 		int Engaged(Army *itsarmy) const;

--- a/arcadia/game.cpp
+++ b/arcadia/game.cpp
@@ -2191,17 +2191,17 @@ int Game::AllowedTrades(Faction *pFac)
 	return allowedTrades[points];
 }
 
-int Game::UpgradeMajorVersion(int savedVersion)
+int Game::UpgradeMajorVersion(int)
 {
 	return 0;
 }
 
-int Game::UpgradeMinorVersion(int savedVersion)
+int Game::UpgradeMinorVersion(int)
 {
 	return 1;
 }
 
-int Game::UpgradePatchLevel(int savedVersion)
+int Game::UpgradePatchLevel(int)
 {
 	return 1;
 }

--- a/arcadia/game.h
+++ b/arcadia/game.h
@@ -245,59 +245,59 @@ private:
 	// Functions to allow enabling/disabling parts of the data tables
 	void EnableSkill(int sk); // Enabled a disabled skill
 	void DisableSkill(int sk);  // Prevents skill being studied or used
-	void ModifySkillDependancy(int sk, int i, char *dep, int lev);
+	void ModifySkillDependancy(int sk, int i, char const *dep, int lev);
 	void ModifyBaseSkills(int base, int, int = -1, int = -1, int = -1, int = -1);
 	void ModifySkillFlags(int sk, int flags);
 	void ModifySkillCost(int sk, int cost);
 	void ModifySkillSpecial(int sk, char *special);
-	void ModifySkillRange(int sk, char *range);
-	void ModifySkillName(int sk, char *name, char *abbr);	
+	void ModifySkillRange(int sk, char const *range);
+	void ModifySkillName(int sk, char const *name, char const *abbr);	
 
 	void EnableItem(int it); // Enables a disabled item
 	void DisableItem(int it); // Prevents item being generated/produced
 	void ModifyItemFlags(int it, int flags);
 	void ModifyItemType(int it, int type);
 	void ModifyItemWeight(int it, int weight);
-	void ModifyItemName(int it, char *name, char *names, char *abr);	
+	void ModifyItemName(int it, char const *name, char const *names, char const *abr);	
 	void ModifyItemBasePrice(int it, int price);
 	void ModifyItemCapacities(int it, int walk, int ride, int fly, int swim);
 	void ModifyItemProductionBooster(int it, int item, int bonus);
 	void ModifyItemHitch(int it, int item, int bonus);
-	void ModifyItemProductionSkill(int it, char *sk, int lev);
+	void ModifyItemProductionSkill(int it, char const *sk, int lev);
 	void ModifyItemProductionOutput(int it, int months, int count);
 	void ModifyItemProductionInput(int it, int i, int input, int amount);
-	void ModifyItemMagicSkill(int it, char *sk, int lev);
+	void ModifyItemMagicSkill(int it, char const *sk, int lev);
 	void ModifyItemMagicOutput(int it, int count);
 	void ModifyItemMagicInput(int it, int i, int input, int amount);
-	void ModifyItemEscapeSkill(int it, char *sk, int val);
+	void ModifyItemEscapeSkill(int it, char const *sk, int val);
 
-	void ModifyRaceSkillLevels(char *race, int special, int def);
+	void ModifyRaceSkillLevels(char const *race, int special, int def);
 	void ModifyRaceHits(char *race, int num);
-	void ModifyRaceSkills(char *race, int i, char *sk);
-	void ModifyRaceSkills(char *r, char *sk1,
-		char *sk2 = NULL, char *sk3 = NULL, char *sk4 = NULL,
-		char *sk5 = NULL, char *sk6 = NULL);
+	void ModifyRaceSkills(char const *race, int i, char const *sk);
+	void ModifyRaceSkills(char const *r, char const *sk1,
+		char const *sk2 = NULL, char const *sk3 = NULL, char const *sk4 = NULL,
+		char const *sk5 = NULL, char const *sk6 = NULL);
 
-	void ModifyMonsterAttackLevel(char *mon, int lev);
-	void ModifyMonsterDefense(char *mon, int defenseType, int level);
-	void ModifyMonsterAttacksAndHits(char *mon, int num, int hits, int regen);
-	void ModifyMonsterSkills(char *mon, int tact, int stealth, int obs);
-	void ModifyMonsterSpecial(char *mon, char *special, int lev);
-	void ModifyMonsterSpoils(char *mon, int silver, int spoilType);
-	void ModifyMonsterThreat(char *mon, int num, int hostileChance);
+	void ModifyMonsterAttackLevel(char const *mon, int lev);
+	void ModifyMonsterDefense(char const *mon, int defenseType, int level);
+	void ModifyMonsterAttacksAndHits(char const *mon, int num, int hits, int regen);
+	void ModifyMonsterSkills(char const *mon, int tact, int stealth, int obs);
+	void ModifyMonsterSpecial(char const *mon, char const *special, int lev);
+	void ModifyMonsterSpoils(char const *mon, int silver, int spoilType);
+	void ModifyMonsterThreat(char const *mon, int num, int hostileChance);
 
 	void ModifyWeaponSkills(char *weap, char *baseSkill, char *orSkill);
 	void ModifyWeaponFlags(char *weap, int flags);
-	void ModifyWeaponAttack(char *weap, int wclass, int attackType, int numAtt);
-	void ModifyWeaponBonuses(char *weap, int attack, int defense, int vsMount);
+	void ModifyWeaponAttack(char const *weap, int wclass, int attackType, int numAtt);
+	void ModifyWeaponBonuses(char const *weap, int attack, int defense, int vsMount);
 
-	void ModifyArmorFlags(char *armor, int flags);
+	void ModifyArmorFlags(char const *armor, int flags);
 	void ModifyArmorSaveFrom(char *armor, int from);
 	void ModifyArmorSaveValue(char *armor, int wclass, int val);
-	void ModifyArmorSaveAll(char *armor, int from, int, int, int);
+	void ModifyArmorSaveAll(char const *armor, int from, int, int, int);
 
 	void ModifyMountSkill(char *mount, char *skill);
-	void ModifyMountBonuses(char *mount, int min, int max, int hampered);
+	void ModifyMountBonuses(char const *mount, int min, int max, int hampered);
 	void ModifyMountSpecial(char *mount, char *special, int level);
 
 	void EnableObject(int ob); // Enables a disabled object
@@ -307,7 +307,7 @@ private:
 	void ModifyObjectDecay(int ob, int maxMaint, int maxMonthDecay, int mFact);
 	void ModifyObjectProduction(int ob, int it);
 	void ModifyObjectMonster(int ob, int monster);
-	void ModifyObjectConstruction(int ob, int it, int num, char *sk, int lev);
+	void ModifyObjectConstruction(int ob, int it, int num, char const *sk, int lev);
 	void ModifyObjectManpower(int ob, int prot, int cap, int sail, int mages);
 	void ModifyObjectDefence(int ob, int co, int en, int sp, int we, int ri, int ra);
 
@@ -331,20 +331,20 @@ private:
 	void ModifySpecialEffectFlags(char *special, int effectflags);
 	void ModifySpecialShields(char *special, int index, int type);
 	void ModifySpecialDefenseMods(char *special, int index, int type, int val);
-	void ModifySpecialDamage(char *special, int index, int type, int min,
-			int val, int flags, int cls, char *effect);
+	void ModifySpecialDamage(char const *special, int index, int type, int min,
+			int val, int flags, int cls, char const *effect);
 
-	void ModifyEffectFlags(char *effect, int flags);
+	void ModifyEffectFlags(char const *effect, int flags);
 	void ModifyEffectAttackMod(char *effect, int val);
 	void ModifyEffectDefenseMod(char *effect, int index, int type, int val);
 	void ModifyEffectCancelEffect(char *effect, char *uneffect);
 
-	void ModifyRangeFlags(char *range, int flags);
-	void ModifyRangeClass(char *range, int rclass);
-	void ModifyRangeMultiplier(char *range, int mult);
+	void ModifyRangeFlags(char const *range, int flags);
+	void ModifyRangeClass(char const *range, int rclass);
+	void ModifyRangeMultiplier(char const *range, int mult);
 	void ModifyRangeLevelPenalty(char *range, int pen);
 
-	void ModifyAttribMod(char *mod, int index, int flags, char *ident,
+	void ModifyAttribMod(char const *mod, int index, int flags, char const *ident,
 			int type, int val);
 
 	AList factions;

--- a/arcadia/gamedefs.cpp
+++ b/arcadia/gamedefs.cpp
@@ -24,7 +24,7 @@
 // END A3HEADER
 #include "gamedefs.h"
 
-char *dr[] = {
+char const *dr[] = {
   "North",
   "Northeast",
   "Southeast",
@@ -33,9 +33,9 @@ char *dr[] = {
   "Northwest"
 };
 
-char ** DirectionStrs = dr;
+char const ** DirectionStrs = dr;
 
-char *da[] = {
+char const *da[] = {
     "N",
     "NE",
     "SE",
@@ -44,9 +44,9 @@ char *da[] = {
     "NW"
 };
 
-char ** DirectionAbrs = da;
+char const ** DirectionAbrs = da;
 
-char *mn[] = {
+char const *mn[] = {
   "January",
   "February",
   "March",
@@ -61,13 +61,13 @@ char *mn[] = {
   "December"
 };
 
-char ** MonthNames = mn;
+char const ** MonthNames = mn;
 
-char *weath[] = {
+char const *weath[] = {
 	"clear",
 	"winter",
 	"monsoon season",
 	"blizzard"
 };
 
-char ** SeasonNames = weath;
+char const ** SeasonNames = weath;

--- a/arcadia/gamedefs.h
+++ b/arcadia/gamedefs.h
@@ -39,12 +39,12 @@ enum {
 	NDIRS
 };
 
-extern char **DirectionStrs;
-extern char **DirectionAbrs;
+extern char const **DirectionStrs;
+extern char const **DirectionAbrs;
 
-extern char **MonthNames;
+extern char const **MonthNames;
 
-extern char **SeasonNames;
+extern char const **SeasonNames;
 
 extern int *allowedMages;
 extern int allowedMagesSize;
@@ -68,7 +68,7 @@ extern int NUMMAN;
 
 class GameDefs {
 public:
-	char *RULESET_NAME;
+	char const *RULESET_NAME;
 	ATL_VER RULESET_VERSION;
 
 	int FOOT_SPEED;
@@ -302,7 +302,7 @@ public:
 	int APPRENTICES_EXIST;
 
 	// What is the name of the world?
-	char *WORLD_NAME;
+	char const *WORLD_NAME;
 
 	// Does the nexus allow gating out of it
 	int NEXUS_GATE_OUT;

--- a/arcadia/genrules.cpp
+++ b/arcadia/genrules.cpp
@@ -1154,7 +1154,7 @@ int Game::GenRules(const AString &rules, const AString &css,
 				"safety is given.";
 		f.Paragraph(temp);
 		int num_methods = 1 + (Globals->GATES_EXIST?1:0) + (may_sail?1:0);
-		char *methods[] = {"You must go ", "The first is ", "The second is "};
+		char const *methods[] = {"You must go ", "The first is ", "The second is "};
 		int method = 1;
 		if (num_methods == 1) method = 0;
 		temp = AString("There ") + (num_methods == 1?"is ":"are ") +

--- a/arcadia/hexside.cpp
+++ b/arcadia/hexside.cpp
@@ -205,7 +205,7 @@ void Unit::CrossHexside(ARegion *fromreg, ARegion *toreg)
 }
 
 
-/*
+#if 0
 void Game::SetupObjectMirrors()
 {
 	forlist(&regions) {
@@ -225,15 +225,15 @@ void Game::SetupObjectMirrors()
 	}
 
 }
-*/
+#endif
 
 
-/*
-/* Hexside Patch 030825 BS *//*
+#if 0
+/* Hexside Patch 030825 BS */
 void Game::HexsideCompatibility(ARegion *r, Object *obj)
 {
 // If building a hexside object should remove any other hexside object, do it here.
-/* Harbour Removes Beach *//*
+/* Harbour Removes Beach */
     if(obj->type==O_HARBOUR) {
         forlist(&r->objects) {
 		    Object *o = (Object *) elem;        
@@ -247,7 +247,7 @@ void Game::HexsideCompatibility(ARegion *r, Object *obj)
 
 
 
-/* Hexside Patch 030825 BS *//*
+/* Hexside Patch 030825 BS */
 int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit * u)
 {
     int dir = obj->hexside;
@@ -267,7 +267,7 @@ int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit * u)
         }   
     }
 /* Object Specific Stuff. May code into gamedata.cpp at some stage */
-/* Ship may be built on sailable hexside object of correct depth, or ocean ships on ocean edge*//*
+/* Ship may be built on sailable hexside object of correct depth, or ocean ships on ocean edge*/
     if (obj->IsBoat()) {
         if(TerrainDefs[r->neighbors[dir]->type].similar_type == R_OCEAN && ObjectDefs[obj->type].sailable > 1) return 1;
     	forlist (&r->objects) {
@@ -283,7 +283,7 @@ int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit * u)
 
 
 
-/* Bridge cannot go to ocean and must go over river or ravine *//*
+/* Bridge cannot go to ocean and must go over river or ravine */
    if (obj->type == O_BRIDGE) {
         if(TerrainDefs[r->neighbors[dir]->type].similar_type == R_OCEAN) return 0;
     	forlist (&r->objects) {
@@ -294,12 +294,12 @@ int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit * u)
         }
    return 0;
    }
-/* Road cannot go to ocean *//*
+/* Road cannot go to ocean */
    if (obj->type == O_ROAD) {
         if(TerrainDefs[r->neighbors[dir]->type].similar_type == R_OCEAN) return 0;
    return 1;
    }
-/* Wall cannot go to river edge. To do: Should not go to river mouth */   /*
+/* Wall cannot go to river edge. To do: Should not go to river mouth */
    if (obj->type == O_IWALL) {
     	forlist (&r->objects) {
     	    Object *o = (Object *) elem;
@@ -309,7 +309,7 @@ int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit * u)
         }
    return 1;
    }
-/* Harbour must go on beach */   /*
+/* Harbour must go on beach */
    if (obj->type == O_HARBOUR) {
     	forlist (&r->objects) {
     	    Object *o = (Object *) elem;
@@ -319,10 +319,10 @@ int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit * u)
         }
    return 0;
    }   
-/* Anything else should not be built */   /*
+/* Anything else should not be built */
 return 0;
 }
 
 
+#endif
 
-*/

--- a/arcadia/items.cpp
+++ b/arcadia/items.cpp
@@ -33,7 +33,7 @@
 //#define DEBUG
 #endif
 
-BattleItemType *FindBattleItem(char *abbr)
+BattleItemType *FindBattleItem(char const *abbr)
 {
 	if (abbr == NULL) return NULL;
 	for (int i = 0; i < NUMBATTLEITEMS; i++) {
@@ -44,7 +44,7 @@ BattleItemType *FindBattleItem(char *abbr)
 	return NULL;
 }
 
-ArmorType *FindArmor(char *abbr)
+ArmorType *FindArmor(char const *abbr)
 {
 	if (abbr == NULL) return NULL;
 	for (int i = 0; i < NUMARMORS; i++) {
@@ -55,7 +55,7 @@ ArmorType *FindArmor(char *abbr)
 	return NULL;
 }
 
-WeaponType *FindWeapon(char *abbr)
+WeaponType *FindWeapon(char const *abbr)
 {
 	if (abbr == NULL) return NULL;
 	for (int i = 0; i < NUMWEAPONS; i++) {
@@ -66,7 +66,7 @@ WeaponType *FindWeapon(char *abbr)
 	return NULL;
 }
 
-MountType *FindMount(char *abbr)
+MountType *FindMount(char const *abbr)
 {
 	if (abbr == NULL) return NULL;
 	for (int i = 0; i < NUMMOUNTS; i++) {
@@ -77,7 +77,7 @@ MountType *FindMount(char *abbr)
 	return NULL;
 }
 
-MonType *FindMonster(char *abbr, int illusion)
+MonType *FindMonster(char const *abbr, int illusion)
 {
 	if (abbr == NULL) return NULL;
 	AString tag = (illusion ? "i" : "");
@@ -91,7 +91,7 @@ MonType *FindMonster(char *abbr, int illusion)
 	return NULL;
 }
 
-ManType *FindRace(char *abbr)
+ManType *FindRace(char const *abbr)
 {
 	if (abbr == NULL) return NULL;
 	for (int i = 0; i < NUMMAN; i++) {
@@ -319,7 +319,7 @@ AString ItemString(int type, int num, int flags, int unitclass)
 	return temp;
 }
 
-AString EffectStr(char *effect)
+AString EffectStr(char const *effect)
 {
 	AString temp, temp2;
 	int comma = 0;
@@ -364,7 +364,7 @@ AString EffectStr(char *effect)
 	return temp;
 }
 
-AString ShowSpecial(char *special, int level, int expandLevel, int fromItem)
+AString ShowSpecial(char const *special, int level, int expandLevel, int fromItem)
 {
 	AString temp;
 	int comma = 0;
@@ -903,7 +903,7 @@ AString *ItemDescription(int item, int full)
 			if(atts > 0) {
 				if(atts >= WeaponType::NUM_ATTACKS_HALF_SKILL) {
 					int max = WeaponType::NUM_ATTACKS_HALF_SKILL;
-					char *attd = "half the skill level (rounded up)";
+					char const *attd = "half the skill level (rounded up)";
 					if(atts >= WeaponType::NUM_ATTACKS_SKILL) {
 						max = WeaponType::NUM_ATTACKS_SKILL;
 						attd = "the skill level";

--- a/arcadia/items.h
+++ b/arcadia/items.h
@@ -74,9 +74,9 @@ struct Materials
 class ItemType
 {
 	public:
-		char *name;
-		char *names;
-		char *abr;
+		char const *name;
+		char const *names;
+		char const *abr;
 
 		enum {
 			CANTGIVE = 0x1,
@@ -97,13 +97,13 @@ class ItemType
 		};
 		int flags;
 
-		char *pSkill; // production skill
+		char const *pSkill; // production skill
 		int pLevel; // production skill level
 		int pMonths; // Man months required for production
 		int pOut; // How many of the item we get
 		Materials pInput[4];
 
-		char *mSkill; // magical production skill
+		char const *mSkill; // magical production skill
 		int mLevel; // magical production skill level
 		int mOut; // How many of the item are conjured
 		Materials mInput[4];
@@ -136,7 +136,7 @@ class ItemType
 			LOSS_CHANCE = 0x10,		// flat chance of loss.
 		};
 		int escape;
-		char *esc_skill;
+		char const *esc_skill;
 		int esc_val; // level for has_skill, a constant (big = less loss) for all others
 };
 
@@ -154,7 +154,7 @@ enum {
 class ManType
 {
 	public:
-		char *abbr;
+		char const *abbr;
 		int terrain;
 		int ethnicity;
 		int hits;
@@ -162,8 +162,8 @@ class ManType
 		int defaultlevel;
 		int specialexperlevel;
 		int defaultexperlevel;
-		char *skills[6];
-		char *mage_skills[6];
+		char const *skills[6];
+		char const *mage_skills[6];
 		
 		int CanProduce(int);
 		int CanUse(int);
@@ -185,15 +185,15 @@ class MonType
 		int stealth;
 		int obs;
 
-		char *special;
+		char const *special;
 		int specialLevel;
 
 		int silver;
 		int spoiltype;
 		int hostile; /* Percent */
 		int number;
-		char *name;
-		char *abbr;
+		char const *name;
+		char const *abbr;
 };
 
 extern MonType *MonDefs;
@@ -214,7 +214,7 @@ enum {
 class WeaponType
 {
 	public:
-		char *abbr;
+		char const *abbr;
 
 		enum {
 			NEEDSKILL = 0x1, // No bonus or use unless skilled
@@ -232,8 +232,8 @@ class WeaponType
 		};
 		int flags;
 
-		char *baseSkill;
-		char *orSkill;
+		char const *baseSkill;
+		char const *orSkill;
 
 		int weapClass;
 		int attackType;
@@ -266,7 +266,7 @@ extern WeaponType *WeaponDefs;
 class ArmorType
 {
 	public:
-		char *abbr;
+		char const *abbr;
 
 		enum {
 			USEINASSASSINATE = 0x1,
@@ -288,12 +288,12 @@ extern ArmorType *ArmorDefs;
 class MountType
 {
 	public:
-		char *abbr;
+		char const *abbr;
 
 		//
 		// This is the skill needed to use this mount.
 		//
-		char *skill;
+		char const *skill;
 
 		//
 		// This is the minimum bonus (and minimal skill level) for this mount.
@@ -312,7 +312,7 @@ class MountType
 
 		// If the mount has a special effect it generates when ridden in
 		// combat
-		char *mountSpecial;
+		char const *mountSpecial;
 		int specialLev;
 };
 
@@ -321,7 +321,7 @@ extern MountType *MountDefs;
 class BattleItemType
 {
 	public:
-		char *abbr;
+		char const *abbr;
 
 		enum {
 			MAGEONLY = 0x1,
@@ -331,7 +331,7 @@ class BattleItemType
 		};
 
 		int flags;
-		char *special;
+		char const *special;
 		int skillLevel;
 };
 
@@ -344,12 +344,12 @@ extern int ParseTransportableItem(AString *);
 extern int LookupItem(AString *);
 extern int IsPrimary(int item);
 
-extern BattleItemType *FindBattleItem(char *abbr);
-extern ArmorType *FindArmor(char *abbr);
-extern WeaponType *FindWeapon(char *abbr);
-extern MountType *FindMount(char *abbr);
-extern MonType *FindMonster(char *abbr, int illusion);
-extern ManType *FindRace(char *abbr);
+extern BattleItemType *FindBattleItem(char const *abbr);
+extern ArmorType *FindArmor(char const *abbr);
+extern WeaponType *FindWeapon(char const *abbr);
+extern MountType *FindMount(char const *abbr);
+extern MonType *FindMonster(char const *abbr, int illusion);
+extern ManType *FindRace(char const *abbr);
 extern AString AttType(int atype);
 extern AString EffectStr(char *effect);
 extern AString EthnicityString(int atype);
@@ -396,7 +396,7 @@ class ItemList : public AList
 		void Selling(int, int); /* type, number */
 };
 
-extern AString ShowSpecial(char *special, int level, int expandLevel,
+extern AString ShowSpecial(char const *special, int level, int expandLevel,
 		int fromItem);
 
 #endif

--- a/arcadia/magic.cpp
+++ b/arcadia/magic.cpp
@@ -308,7 +308,7 @@ void Game::DistributeFog()
 	}
 }
 
-int Unit::GetCastCost(int skill, int extracost, int multiplier, int levelpenalty)
+int Unit::GetCastCost(int skill, int, int multiplier, int levelpenalty)
 {
 //this needs to match the cost in the skillshows.cpp file.
 
@@ -594,7 +594,7 @@ void Game::SetupGuardsmenAttitudes()
 //Quest stuff
 //--------------------------
 
-void Game::ResolveExits(ARegion *reg, Unit *u)
+void Game::ResolveExits(ARegion*, Unit *u)
 {
     Awrite("Reseeding Random Number Generator");
     if(!u) return;

--- a/arcadia/map.cpp
+++ b/arcadia/map.cpp
@@ -1497,5 +1497,5 @@ void ARegionList::FinalSetupGates()
 			r->gatemonth = nmon;
 		}
 	}
-	delete used;
+	delete[] used;
 }

--- a/arcadia/map.cpp
+++ b/arcadia/map.cpp
@@ -47,7 +47,7 @@ int ARegion::CheckSea(int dir, int range, int remainocean)
 }
 
 
-void ARegionList::CreateAbyssLevel(int level, char *name)
+void ARegionList::CreateAbyssLevel(int level, char const *name)
 {
 	MakeRegions(level, 4, 4);
 	pRegionArrays[level]->SetName(name);
@@ -99,7 +99,7 @@ void ARegionList::CreateAbyssLevel(int level, char *name)
 }
 
 
-void ARegionList::CreateNexusLevel(int level, int xSize, int ySize, char *name)
+void ARegionList::CreateNexusLevel(int level, int xSize, int ySize, char const *name)
 {
 	MakeRegions(level, xSize, ySize);
 	AddHexsides(pRegionArrays[level]);
@@ -195,7 +195,7 @@ void ARegionList::CreateIslandLevel(int level, int nPlayers, char *name)
 }
 
 void ARegionList::CreateUnderworldLevel(int level, int xSize, int ySize,
-		char *name)
+		char const *name)
 {
 	MakeRegions(level, xSize, ySize);
 
@@ -244,7 +244,7 @@ void ARegionList::CheckHexsides(ARegionArray *pRegs)
 }
 
 void ARegionList::CreateUnderdeepLevel(int level, int xSize, int ySize,
-		char *name)
+		char const *name)
 {
 	MakeRegions(level, xSize, ySize);
 

--- a/arcadia/modify.cpp
+++ b/arcadia/modify.cpp
@@ -66,7 +66,7 @@ void Game::DisableSkill(int sk)
 \arg \c *dep The skill required in the dependency (eg. FORC, if sk is FIRE)
 \arg \c lev The level of skill required in the dependency
 */
-void Game::ModifySkillDependancy(int sk, int i, char *dep, int lev)
+void Game::ModifySkillDependancy(int sk, int i, char const *dep, int lev)
 {
 	if(sk < 0 || sk > (NSKILLS-1)) return;
 	if(i < 0 || i >= (int)(sizeof(SkillDefs[sk].depends)/sizeof(SkillDepend)))
@@ -133,14 +133,14 @@ See skills.h for the full list.
 \arg \c sk One of the values from the NSKILLS enum in gamedata.h
 \arg \c cost An amount of silver
 */
-void Game::ModifySkillRange(int sk, char *range)
+void Game::ModifySkillRange(int sk, char const *range)
 {
 	if(sk < 0 || sk > (NSKILLS-1)) return;
 	if (range && (FindRange(range) == NULL)) return;
 	SkillDefs[sk].range = range;
 }
 
-void Game::ModifySkillName(int sk, char *name, char *abbr)
+void Game::ModifySkillName(int sk, char const *name, char const *abbr)
 {
 	if(sk < 0 || sk > (NSKILLS-1)) return;
 	SkillDefs[sk].name = name;
@@ -213,7 +213,7 @@ Prices tend to go up in cities, and down in the boonies.
 \arg \c type The base price of the object
 */
 
-void Game::ModifyItemName(int it, char *name, char *names, char *abr)
+void Game::ModifyItemName(int it, char const *name, char const *names, char const *abr)
 {
 	if(it < 0 || it > (NITEMS-1)) return;
 	ItemDefs[it].name = name;
@@ -289,7 +289,7 @@ Set this to NULL if the item cannot be produced through normal means.
 \arg \c lev How much skill is needed to produce the item 
                 (eg. PARM requires ARMO of level 3)
 */
-void Game::ModifyItemProductionSkill(int it, char *sk, int lev)
+void Game::ModifyItemProductionSkill(int it, char const *sk, int lev)
 {
 	if(it < 0 || it > (NITEMS-1)) return;
 	if (sk && (FindSkill(sk) == NULL)) return;
@@ -343,7 +343,7 @@ no magical skill can produce this item.
 \arg \c *sk The skill as a string, eg. "CRMA", "CRRI", etc.
 \arg \c lev How much skill is needed to produce the item
 */
-void Game::ModifyItemMagicSkill(int it, char *sk, int lev)
+void Game::ModifyItemMagicSkill(int it, char const *sk, int lev)
 {
 	if(it < 0 || it > (NITEMS-1)) return;
 	if (sk && (FindSkill(sk) == NULL)) return;
@@ -384,7 +384,7 @@ void Game::ModifyItemMagicInput(int it, int i, int input, int amount)
 	ItemDefs[it].mInput[i].amt = amount;
 }
 
-void Game::ModifyItemEscapeSkill(int it, char *sk, int val)
+void Game::ModifyItemEscapeSkill(int it, char const *sk, int val)
 {
 	if(it < 0 || it > (NITEMS-1)) return;
 	if (sk && (FindSkill(sk) == NULL)) return;
@@ -401,7 +401,7 @@ For orcs, it's 4 and 1; for leaders it's 5 and 5 (although it could be 0 and 5)
 \arg \c spec The level of any specialised skills that the race knows. 
 \arg \c def The default maximum level of any skill
 */
-void Game::ModifyRaceSkillLevels(char *r, int spec, int def)
+void Game::ModifyRaceSkillLevels(char const *r, int spec, int def)
 {
 	ManType *mt = FindRace(r);
 	if (mt == NULL) return;
@@ -431,7 +431,7 @@ void Game::ModifyRaceHits(char *r, int num)
 \arg \c i Which slot is being changed (there are six, from 0-5)
 \arg \c *sk The skill to be added to the race's specialised skill list, eg. "LUMB"
 */
-void Game::ModifyRaceSkills(char *r, int i, char *sk)
+void Game::ModifyRaceSkills(char const *r, int i, char const *sk)
 {
 	ManType *mt = FindRace(r);
 	if (mt == NULL) return;
@@ -440,7 +440,7 @@ void Game::ModifyRaceSkills(char *r, int i, char *sk)
 	mt->skills[i] = sk;
 }
 
-void Game::ModifyRaceSkills(char *r, char *sk1, char *sk2, char *sk3, char *sk4, char *sk5, char *sk6)
+void Game::ModifyRaceSkills(char const *r, char const *sk1, char const *sk2, char const *sk3, char const *sk4, char const *sk5, char const *sk6)
 {
 	ManType *mt = FindRace(r);
 	if (mt == NULL) return;
@@ -463,7 +463,7 @@ void Game::ModifyRaceSkills(char *r, char *sk1, char *sk2, char *sk3, char *sk4,
 \arg \c *mon The monster being changed (eg. "BALR")
 \arg \c lev The attacking level of the monster.
 */
-void Game::ModifyMonsterAttackLevel(char *mon, int lev)
+void Game::ModifyMonsterAttackLevel(char const *mon, int lev)
 {
 	MonType *pM = FindMonster(mon, 0);
 	if (pM == NULL) return;
@@ -477,7 +477,7 @@ void Game::ModifyMonsterAttackLevel(char *mon, int lev)
 \arg \c defenseType The type of attack being defended against (eg. ATTACK_COMBAT)
 \arg \c level The new defense level of the monster
 */
-void Game::ModifyMonsterDefense(char *mon, int defenseType, int level)
+void Game::ModifyMonsterDefense(char const *mon, int defenseType, int level)
 {
 	MonType *pM = FindMonster(mon, 0);
 	if (pM == NULL) return;
@@ -492,7 +492,7 @@ void Game::ModifyMonsterDefense(char *mon, int defenseType, int level)
 \arg \c hits The number of hits that the monster can take before dying
 \arg \c regen The number of hits that the monster gets back per round of combat
 */
-void Game::ModifyMonsterAttacksAndHits(char *mon, int num, int hits, int regen)
+void Game::ModifyMonsterAttacksAndHits(char const *mon, int num, int hits, int regen)
 {
 	MonType *pM = FindMonster(mon, 0);
 	if (pM == NULL) return;
@@ -512,7 +512,7 @@ cumulative with the unit's current score.
 \arg \c stealth The monster's stealth score
 \arg \c obs The monster's observation score
 */
-void Game::ModifyMonsterSkills(char *mon, int tact, int stealth, int obs)
+void Game::ModifyMonsterSkills(char const *mon, int tact, int stealth, int obs)
 {
 	MonType *pM = FindMonster(mon, 0);
 	if (pM == NULL) return;
@@ -530,7 +530,7 @@ void Game::ModifyMonsterSkills(char *mon, int tact, int stealth, int obs)
 \arg \c *special The name of the special attack (eg. "hellfire", "black_wind")
 \arg \c lev The level that the special is cast at
 */
-void Game::ModifyMonsterSpecial(char *mon, char *special, int lev)
+void Game::ModifyMonsterSpecial(char const *mon, char const *special, int lev)
 {
 	MonType *pM = FindMonster(mon, 0);
 	if (pM == NULL) return;
@@ -547,7 +547,7 @@ Set the item type to -1 if you don't want items given out.
 \arg \c silver The base value of the silver and items that are given out
 \arg \c spoilType The type of items that are given out as spoils
 */
-void Game::ModifyMonsterSpoils(char *mon, int silver, int spoilType)
+void Game::ModifyMonsterSpoils(char const *mon, int silver, int spoilType)
 {
 	MonType *pM = FindMonster(mon, 0);
 	if (pM == NULL) return;
@@ -563,7 +563,7 @@ void Game::ModifyMonsterSpoils(char *mon, int silver, int spoilType)
 \arg \c num The maximum number of monsters that will appear
 \arg \c hostileChance The percentage chance that a monster will attack someone
 */
-void Game::ModifyMonsterThreat(char *mon, int num, int hostileChance)
+void Game::ModifyMonsterThreat(char const *mon, int num, int hostileChance)
 {
 	MonType *pM = FindMonster(mon, 0);
 	if (pM == NULL) return;
@@ -610,7 +610,7 @@ void Game::ModifyWeaponFlags(char *weap, int flags)
 \arg \c wclass The class of the weapon, eg. ARMOR_PIERCING, SLASHING
 \arg \c attackType The type of attack, eg. ATTACK_RANGED, ATTACK_COMBAT
 */
-void Game::ModifyWeaponAttack(char *weap, int wclass, int attackType,
+void Game::ModifyWeaponAttack(char const *weap, int wclass, int attackType,
 		int numAtt)
 {
 	WeaponType *pw = FindWeapon(weap);
@@ -630,7 +630,7 @@ void Game::ModifyWeaponAttack(char *weap, int wclass, int attackType,
 \arg \c defense The weapon's bonus in defense
 \arg \c vsMount The weapon's bonus against mounted opponents
 */
-void Game::ModifyWeaponBonuses(char *weap, int attack, int defense, int vsMount)
+void Game::ModifyWeaponBonuses(char const *weap, int attack, int defense, int vsMount)
 {
 	WeaponType *pw = FindWeapon(weap);
 	if (pw == NULL) return;
@@ -644,7 +644,7 @@ void Game::ModifyWeaponBonuses(char *weap, int attack, int defense, int vsMount)
 \arg \c *armor The armor's name, eg. "CLAR"
 \arg \c flags The flags to apply to the armor.
 */
-void Game::ModifyArmorFlags(char *armor, int flags)
+void Game::ModifyArmorFlags(char const *armor, int flags)
 {
 	ArmorType *pa = FindArmor(armor);
 	if (pa == NULL) return;
@@ -682,7 +682,7 @@ void Game::ModifyArmorSaveValue(char *armor, int wclass, int val)
 }
 
 
-void Game::ModifyArmorSaveAll(char *armor, int from, int melee, int armourpiercing, int magic)
+void Game::ModifyArmorSaveAll(char const *armor, int from, int melee, int armourpiercing, int magic)
 {
 	ArmorType *pa = FindArmor(armor);
 	if (pa == NULL) return;
@@ -719,7 +719,7 @@ void Game::ModifyMountSkill(char *mount, char *skill)
 \arg \c hampered The bonus given when a mount is hampered 
 								(eg. WING horses underground/in tunnels?)
 */
-void Game::ModifyMountBonuses(char *mount, int min, int max, int hampered)
+void Game::ModifyMountBonuses(char const *mount, int min, int max, int hampered)
 {
 	MountType *pm = FindMount(mount);
 	if (pm == NULL) return;
@@ -798,7 +798,7 @@ void Game::ModifyObjectMonster(int ob, int monster)
 	ObjectDefs[ob].monster = monster;
 }
 
-void Game::ModifyObjectConstruction(int ob, int it, int num, char *sk, int lev)
+void Game::ModifyObjectConstruction(int ob, int it, int num, char const *sk, int lev)
 {
 	if(ob < 0 || ob > (NOBJECTS-1)) return;
 	if((it < -1 && it != I_WOOD_OR_STONE) || it > (NITEMS -1))
@@ -1014,8 +1014,8 @@ void Game::ModifySpecialDefenseMods(char *special, int index, int type, int val)
 	sp->defs[index].val = val;
 }
 
-void Game::ModifySpecialDamage(char *special, int index, int type, int min,
-		int val, int flags, int cls, char *effect)
+void Game::ModifySpecialDamage(char const *special, int index, int type, int min,
+		int val, int flags, int cls, char const *effect)
 {
 	SpecialType *sp = FindSpecial(special);
 	if (sp == NULL) return;
@@ -1032,7 +1032,7 @@ void Game::ModifySpecialDamage(char *special, int index, int type, int min,
 	sp->damage[index].effect = effect;
 }
 
-void Game::ModifyEffectFlags(char *effect, int flags)
+void Game::ModifyEffectFlags(char const *effect, int flags)
 {
 	EffectType *ep = FindEffect(effect);
 	if (ep == NULL) return;
@@ -1064,14 +1064,14 @@ void Game::ModifyEffectCancelEffect(char *effect, char *uneffect)
 	ep->cancelEffect = uneffect;
 }
 
-void Game::ModifyRangeFlags(char *range, int flags)
+void Game::ModifyRangeFlags(char const *range, int flags)
 {
 	RangeType *rp = FindRange(range);
 	if (rp == NULL) return;
 	rp->flags = flags;
 }
 
-void Game::ModifyRangeClass(char *range, int rclass)
+void Game::ModifyRangeClass(char const *range, int rclass)
 {
 	RangeType *rp = FindRange(range);
 	if (rp == NULL) return;
@@ -1079,7 +1079,7 @@ void Game::ModifyRangeClass(char *range, int rclass)
 	rp->rangeClass = rclass;
 }
 
-void Game::ModifyRangeMultiplier(char *range, int mult)
+void Game::ModifyRangeMultiplier(char const *range, int mult)
 {
 	RangeType *rp = FindRange(range);
 	if (rp == NULL) return;
@@ -1095,7 +1095,7 @@ void Game::ModifyRangeLevelPenalty(char *range, int pen)
 	rp->crossLevelPenalty = pen;
 }
 
-void Game::ModifyAttribMod(char *mod, int index, int flags, char *ident,
+void Game::ModifyAttribMod(char const *mod, int index, int flags, char const *ident,
 		int type, int val)
 {
 	AttribModType *mp = FindAttrib(mod);

--- a/arcadia/monthorders.cpp
+++ b/arcadia/monthorders.cpp
@@ -725,7 +725,7 @@ void Game::Do1TeachOrder(ARegion * reg,Unit * unit)
 }
 
 /* Hexside Patch 030825 BS */
-int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit * u)
+int Game::HexsideCanGoThere(ARegion * r,Object * obj,Unit*)
 {
     int dir = obj->hexside;
     if(dir < 0 || dir > 5) return 0;
@@ -943,7 +943,7 @@ void Game::Run1BuildOrder(ARegion * r,Object * obj,Unit * u)
 	u->monthorders = 0;
 }
 
-void Game::Run1BuildHexsideOrder(ARegion * r,Object * obj,Unit * u)
+void Game::Run1BuildHexsideOrder(ARegion * r,Object*,Unit * u)
 {
     int quiet = u->monthorders->quiet;
 

--- a/arcadia/monthorders.cpp
+++ b/arcadia/monthorders.cpp
@@ -32,6 +32,8 @@
 //#define DEBUG
 #endif
 
+// replace with [[maybe_unused]] when c++17 is supported
+#define MAYBE_UNUSED __attribute__ ((unused))
 
 #include "game.h"
 #include "gamedata.h"
@@ -649,7 +651,7 @@ void Game::Do1TeachOrder(ARegion * reg,Unit * unit)
 			Unit * u = reg->GetUnitId(id,unit->faction->num);
 
 			//int sk = ((StudyOrder *) u->monthorders)->skill;
-            int sk;
+            MAYBE_UNUSED int sk;
             if(Globals->ARCADIA_MAGIC && u->IsMage() && u->herostudyorders) {
                sk = ((StudyOrder *) u->herostudyorders)->skill;
             } else sk = ((StudyOrder *) u->monthorders)->skill;
@@ -695,7 +697,7 @@ void Game::Do1TeachOrder(ARegion * reg,Unit * unit)
     			Unit * u = reg->GetUnitId(id,unit->faction->num);
 
     			//int sk = ((StudyOrder *) u->monthorders)->skill;
-                int sk;
+                MAYBE_UNUSED int sk;
                 if(Globals->ARCADIA_MAGIC && u->IsMage() && u->herostudyorders) {
                    sk = ((StudyOrder *) u->herostudyorders)->skill;
                 } else sk = ((StudyOrder *) u->monthorders)->skill;

--- a/arcadia/npc.cpp
+++ b/arcadia/npc.cpp
@@ -297,7 +297,7 @@ void Game::MakeLMon(Object *pObj)
 	u->MoveUnit(pObj);
 }
 
-Unit *Game::MakeManUnit(Faction *fac, ARegion *pReg, int num, int level, int weaponlevel, int armor, int behind)
+Unit *Game::MakeManUnit(Faction *fac, ARegion *pReg, int num, int level, int, int armor, int behind)
 {
 	Unit *u = GetNewUnit(fac);
 	ManType *men = FindRace(ItemDefs[pReg->race].abr);

--- a/arcadia/object.cpp
+++ b/arcadia/object.cpp
@@ -246,7 +246,7 @@ Unit *Object::GetUnitId(UnitId *id, int faction)
 	}
 }
 
-int Object::CanEnter(ARegion *reg, Unit *u)
+int Object::CanEnter(ARegion*, Unit *u)
 {
 	if(!(ObjectDefs[type].flags & ObjectType::CANENTER) &&
 			(u->type == U_MAGE || u->type == U_NORMAL ||

--- a/arcadia/object.h
+++ b/arcadia/object.h
@@ -39,7 +39,7 @@ class Object;
 
 class HexsideType {
 	public:
-		char *name;
+		char const *name;
 		enum {
 			DISABLED	= 0x001,
 			CANMODIFY	= 0x020
@@ -48,7 +48,7 @@ class HexsideType {
 
 		int item;
 		int cost;
-		char *skill;
+		char const *skill;
 		int level;	
 
 		int sailable;
@@ -86,7 +86,7 @@ class Hexside
 
 class ObjectType {
 	public:
-		char *name;
+		char const *name;
 		enum {
 			DISABLED	= 0x001,
 			NOMONSTERGROWTH	= 0x002,
@@ -107,7 +107,7 @@ class ObjectType {
 
 		int item;
 		int cost;
-		char *skill;
+		char const *skill;
 		int level;
 
 		int maxMaintenance;

--- a/arcadia/orders.cpp
+++ b/arcadia/orders.cpp
@@ -24,7 +24,7 @@
 // END A3HEADER
 #include "orders.h"
 
-char *od[] = {
+char const *od[] = {
 	"#atlantis",
 	"#end",
 	"unit",
@@ -109,7 +109,7 @@ char *od[] = {
 	"work",
 };
 
-char **OrderStrs = od;
+char const **OrderStrs = od;
 
 int Parse1Order(AString *token)
 {

--- a/arcadia/orders.h
+++ b/arcadia/orders.h
@@ -159,7 +159,7 @@ enum {
 /* Enter is MOVE_ENTER + num of object */
 #define MOVE_ENTER 100
 
-extern char ** OrderStrs;
+extern char const ** OrderStrs;
 
 int Parse1Order(AString *);
 

--- a/arcadia/parseorders.cpp
+++ b/arcadia/parseorders.cpp
@@ -1238,7 +1238,7 @@ void Game::ProcessPrepareOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 		return;
 	}
 
-	if (!bt->flags & BattleItemType::SPECIAL) {
+	if (!(bt->flags & BattleItemType::SPECIAL)) {
 		ParseError(pCheck, u, 0, "PREPARE: That item cannot be prepared.");
 		return;
 	}
@@ -3870,7 +3870,7 @@ void Game::ProcessIdleOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 
 void Game::ProcessTransportOrder(Unit *u, AString *o, OrdersCheck *pCheck, int isquiet)
 {
-    if(!Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT) {
+    if(!(Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT)) {
         ParseError(pCheck, u, 0, "TRANSPORT: Invalid order.");
         return;
     }
@@ -3935,7 +3935,7 @@ void Game::ProcessTransportOrder(Unit *u, AString *o, OrdersCheck *pCheck, int i
 
 void Game::ProcessDistributeOrder(Unit *u, AString *o, OrdersCheck *pCheck, int isquiet)
 {
-    if(!Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT) {
+    if(!(Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT)) {
         ParseError(pCheck, u, 0, "DISTRIBUTE: Invalid order.");
         return;
     }

--- a/arcadia/parseorders.cpp
+++ b/arcadia/parseorders.cpp
@@ -2181,7 +2181,7 @@ void Game::ProcessStudyOrder(Unit *u, AString *o, OrdersCheck *pCheck, int isqui
 	    delete token;	
 	} else ord->level = 0; //STUDY order mod end	
 	
-	if(pCheck || u->IsMage() && Globals->ARCADIA_MAGIC) {
+	if(pCheck || (u->IsMage() && Globals->ARCADIA_MAGIC)) {
 	    if(u->herostudyorders) {
 	        delete u->herostudyorders;
             AString err = "STUDY: Overwriting previous ";

--- a/arcadia/parseorders.cpp
+++ b/arcadia/parseorders.cpp
@@ -2477,7 +2477,6 @@ AString *Game::ProcessTurnOrder(Unit *unit, Aorders *f, OrdersCheck *pCheck,
 	tOrder->repeating = repeat;
 
 	AString *order, *token;
-	int atsign;
 
 	while (turnDepth) {
 		// get the next line
@@ -2495,7 +2494,6 @@ AString *Game::ProcessTurnOrder(Unit *unit, Aorders *f, OrdersCheck *pCheck,
 			order = new AString("#end");
 		}
 		AString	saveorder = *order;
-		atsign = order->getat();
 		token = order->gettoken();
 
 		if (token) {

--- a/arcadia/parseorders.cpp
+++ b/arcadia/parseorders.cpp
@@ -1173,7 +1173,7 @@ void Game::ProcessCombatOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	}
 }
 
-void Game::ProcessCommandOrder(Unit *u, AString *o, OrdersCheck *pCheck)
+void Game::ProcessCommandOrder(Unit *u, AString*, OrdersCheck *pCheck)
 {
 	if(!pCheck) {
 		if (u->type != U_MAGE) {
@@ -1570,7 +1570,7 @@ void Game::ProcessRestartOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	}
 }
 
-void Game::ProcessDestroyOrder(Unit *u, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessDestroyOrder(Unit *u, OrdersCheck *pCheck, int)
 {
 	if(!pCheck) {
 		u->destroy = 1;             //No easy way of keeping this quiet
@@ -1719,7 +1719,7 @@ void Game::ProcessRevealOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	}
 }
 
-void Game::ProcessTaxOrder(Unit *u, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessTaxOrder(Unit *u, OrdersCheck *pCheck, int)
 {
 	if (u->taxing == TAX_PILLAGE) {
 		ParseError(pCheck, u, 0, "TAX: The unit is already pillaging.");
@@ -1737,7 +1737,7 @@ void Game::ProcessTaxOrder(Unit *u, OrdersCheck *pCheck, int isquiet)
 	u->taxing = TAX_TAX;   //no easy way to keep quiet
 }
 
-void Game::ProcessPillageOrder(Unit *u, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessPillageOrder(Unit *u, OrdersCheck *pCheck, int)
 {
 	if (u->taxing == TAX_TAX) {
 		ParseError(pCheck, u, 0, "PILLAGE: The unit is already taxing.");
@@ -1771,7 +1771,7 @@ void Game::ProcessPromoteOrder(Unit *u, AString *o, OrdersCheck *pCheck, int isq
 	}
 }
 
-void Game::ProcessLeaveOrder(Unit *u, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessLeaveOrder(Unit *u, OrdersCheck *pCheck, int)
 {
 	if(!pCheck) {
 //		if (u->monthorders && u->monthorders->type == O_BUILD) return;
@@ -1779,7 +1779,7 @@ void Game::ProcessLeaveOrder(Unit *u, OrdersCheck *pCheck, int isquiet)
 	}
 }
 
-void Game::ProcessEnterOrder(Unit *u, AString *o, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessEnterOrder(Unit *u, AString *o, OrdersCheck *pCheck, int)
 {
 	AString *token = o->gettoken();
 	if (!token) {
@@ -2317,7 +2317,7 @@ void Game::ProcessWithdrawOrder(Unit *unit, AString *o, OrdersCheck *pCheck, int
 	return;
 }
 
-void Game::ProcessMasterOrder(Unit *unit, AString *o, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessMasterOrder(Unit *unit, AString*, OrdersCheck *pCheck, int)
 {
     //MASTER not enabled for Xanaxor
 	ParseError(pCheck, unit, 0, "MASTER is not a valid order.");
@@ -3122,7 +3122,7 @@ void Game::ProcessDescribeOrder(Unit *unit, AString *o, OrdersCheck *pCheck, int
 	ParseError(pCheck, unit, 0, "DESCRIBE: Can't describe that.");
 }
 
-void Game::ProcessLabelOrder(Unit *unit, AString *o, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessLabelOrder(Unit *unit, AString *o, OrdersCheck *pCheck, int)
 {
 	AString *token = o->gettoken();
 	if(!pCheck) {
@@ -3279,7 +3279,7 @@ void Game::ProcessNameOrder(Unit *unit, AString *o, OrdersCheck *pCheck, int isq
 	ParseError(pCheck, unit, 0, "NAME: Can't name that.");
 }
 
-void Game::ProcessGuardOrder(Unit *u, AString *o, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessGuardOrder(Unit *u, AString *o, OrdersCheck *pCheck, int)
 {
 	/* This is an instant order */
 	AString *token = o->gettoken();
@@ -3853,7 +3853,7 @@ void Game::ProcessEvictOrder(Unit *u, AString *o, OrdersCheck *pCheck, int isqui
 	}
 }
 
-void Game::ProcessIdleOrder(Unit *u, AString *o, OrdersCheck *pCheck)
+void Game::ProcessIdleOrder(Unit *u, AString*, OrdersCheck *pCheck)
 {
 	if (u->monthorders || (Globals->TAX_PILLAGE_MONTH_LONG &&
 		((u->taxing == TAX_TAX) || (u->taxing == TAX_PILLAGE)))) {

--- a/arcadia/runorders.cpp
+++ b/arcadia/runorders.cpp
@@ -3314,7 +3314,7 @@ int Game::DoSendOrder(ARegion *r, Unit *u, SendOrder *o)
 	}
 	
 	Unit *tar = NULL;
-    ARegion *reg;
+    ARegion *reg = NULL;
 	if(o->direction >= 0) {
         if(o->direction < NDIRS && r->neighbors[o->direction])
             reg = r->neighbors[o->direction];

--- a/arcadia/runorders.cpp
+++ b/arcadia/runorders.cpp
@@ -440,7 +440,7 @@ AList *Game::CanSeeSteal(ARegion *r, Unit *u)
 	return retval;
 }
 
-void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
+void Game::Do1Assassinate(ARegion *r, Object*, Unit *u)
 {
     if(u->dead) return; //Arcadia mod because assassin orders cannot be removed.
 
@@ -548,7 +548,7 @@ cout << "Returned to Do1Assassinate" << endl;
 #endif
 }
 
-void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
+void Game::Do1Steal(ARegion *r, Object*, Unit *u)
 {
     if(u->dead) return; //Arcadia mod because assassin orders cannot be removed.
     
@@ -2450,7 +2450,7 @@ int Game::DoWithdrawOrder(ARegion *r, Unit *u, WithdrawOrder *o)
 	return 0;
 }
 
-int Game::DoWishdrawOrder(ARegion *r, Unit *u, WishdrawOrder *o)
+int Game::DoWishdrawOrder(ARegion*, Unit *u, WishdrawOrder *o)
 {
 	int itm = o->item;
 	int amt = o->amount;
@@ -2477,7 +2477,7 @@ int Game::DoWishdrawOrder(ARegion *r, Unit *u, WishdrawOrder *o)
 	return 0;
 }
 
-int Game::DoWishskillOrder(ARegion *r, Unit *u, WishskillOrder *o)
+int Game::DoWishskillOrder(ARegion*, Unit *u, WishskillOrder *o)
 {
 	int sk = o->skill;
 	int days = o->knowledge * u->GetMen();

--- a/arcadia/skills.cpp
+++ b/arcadia/skills.cpp
@@ -26,7 +26,7 @@
 #include "items.h"
 #include "gamedata.h"
 
-RangeType *FindRange(char *range)
+RangeType *FindRange(char const *range)
 {
     if (range == NULL) return NULL;
     for (int i = 0; i < NUMRANGES; i++) {
@@ -37,7 +37,7 @@ RangeType *FindRange(char *range)
     return NULL;
 }
 
-SpecialType *FindSpecial(char *key)
+SpecialType *FindSpecial(char const *key)
 {
     if (key == NULL) return NULL;
     for (int i = 0; i < NUMSPECIALS; i++) {
@@ -48,7 +48,7 @@ SpecialType *FindSpecial(char *key)
     return NULL;
 }
 
-EffectType *FindEffect(char *effect)
+EffectType *FindEffect(char const *effect)
 {
     if (effect == NULL) return NULL;
     for (int i = 0; i < NUMEFFECTS; i++) {
@@ -59,7 +59,7 @@ EffectType *FindEffect(char *effect)
     return NULL;
 }
 
-AttribModType *FindAttrib(char *attrib)
+AttribModType *FindAttrib(char const *attrib)
 {
     if (attrib == NULL) return NULL;
 	for (int i = 0; i < NUMATTRIBMODS; i++) {
@@ -70,7 +70,7 @@ AttribModType *FindAttrib(char *attrib)
 	return NULL;
 }
 
-SkillType *FindSkill(char *skname)
+SkillType *FindSkill(char const *skname)
 {
 	if (skname == NULL) return NULL;
 	for (int i = 0; i < NSKILLS; i++) {
@@ -123,7 +123,7 @@ int SkillCost(int skill)
 	return SkillDefs[skill].cost;
 }
 
-int IsSpeciality(char *skill, int race)
+int IsSpeciality(char const *skill, int race)
 {
 	ManType *mt = FindRace(ItemDefs[race].abr);
 
@@ -148,7 +148,7 @@ int IsSpeciality(char *skill, int race)
 	return 0;
 }
 
-int SkillMax(char *skill, int race)
+int SkillMax(char const *skill, int race)
 //there seems to be a lot of overlap between use of this to find unit's max skill level, and use of IsASpeciality(). Maybe combine them sometime
 {
 	ManType *mt = FindRace(ItemDefs[race].abr);

--- a/arcadia/skills.h
+++ b/arcadia/skills.h
@@ -59,15 +59,15 @@ class SkillList;
 
 struct SkillDepend
 {
-	char *skill;
+	char const *skill;
 	int level;
 };
 
 class SkillType
 {
 	public:
-		char * name;
-		char * abbr;
+		char const * name;
+		char const * abbr;
 		int cost;
 
 		enum {
@@ -94,10 +94,10 @@ class SkillType
 		//
 		// special for combat spells only
 		//
-		char *special;
+		char const *special;
 
 		// range class for ranged skills (-1 for all others)
-		char *range;
+		char const *range;
 
 		int baseskill;
 
@@ -109,7 +109,7 @@ class SkillType
 };
 extern SkillType *SkillDefs;
 
-SkillType *FindSkill(char *skname);
+SkillType *FindSkill(char const *skname);
 int LookupSkill(AString *);
 int ParseSkill(AString *);
 AString SkillStrs(int);
@@ -124,8 +124,8 @@ class ShowType {
 extern ShowType * ShowDefs;
 
 int SkillCost(int); /* skill */
-int IsSpeciality(char *,int); /* skill, race */
-int SkillMax(char *,int); /* skill, race */
+int IsSpeciality(char const *,int); /* skill, race */
+int SkillMax(char const *,int); /* skill, race */
 int SkillExperMax(char *,int); /* skill, race */
 int GetLevelByDays(int);
 int GetLevelByDays(int, int);
@@ -187,7 +187,7 @@ class DamageType {
 		int value;
 		int flags;
 		int dclass;
-		char *effect;
+		char const *effect;
 };
 
 class ShieldType {
@@ -204,8 +204,8 @@ class DefenseMod {
 
 class SpecialType {
 	public:
-		char *key;
-		char *specialname;
+		char const *key;
+		char const *specialname;
 
 		enum {
 			HIT_BUILDINGIF		= 0x0001,	/* mutually exclusive (1) */
@@ -226,7 +226,7 @@ class SpecialType {
 
 		int buildings[3];
 		int targets[7];
-		char *effects[3];
+		char const *effects[3];
 
 		enum {
 			FX_SHIELD	=	0x001,
@@ -243,25 +243,25 @@ class SpecialType {
 
 		int shield[4];
 		DefenseMod defs[4];
-		char *shielddesc;
+		char const *shielddesc;
 
 		DamageType damage[4];
-		char *spelldesc;
-		char *spelldesc2;
-		char *spelltarget;
+		char const *spelldesc;
+		char const *spelldesc2;
+		char const *spelltarget;
 };
 extern SpecialType *SpecialDefs;
 extern int NUMSPECIALS;
 
-extern SpecialType *FindSpecial(char *key);
+extern SpecialType *FindSpecial(char const *key);
 
 class EffectType {
 	public:
 	    int effectnum; //hack because mapping of effects in battle was not working in modified combat code - don't know why. These need to numbered sequentially from zero, and must be less or equal effects than size of effect array in soldiers.h
-		char *name;
+		char const *name;
 		int attackVal;
 		DefenseMod defMods[4];
-		char *cancelEffect;
+		char const *cancelEffect;
 
 		enum {
 			EFF_ONESHOT	= 0x001,  //gets cleared at the end of combat round (Arcadian system only)
@@ -274,11 +274,11 @@ class EffectType {
 extern EffectType *EffectDefs;
 extern int NUMEFFECTS;
 
-extern EffectType *FindEffect(char *effect);
+extern EffectType *FindEffect(char const *effect);
 
 class RangeType {
 	public:
-		char *key;
+		char const *key;
 		enum {
 			RNG_NEXUS_TARGET = 0x0001,	// Can cast *to* Nexus
 			RNG_NEXUS_SOURCE = 0x0002,	// Can cast *from* Nexus
@@ -303,7 +303,7 @@ class RangeType {
 extern RangeType *RangeDefs;
 extern int NUMRANGES;
 
-extern RangeType *FindRange(char *range);
+extern RangeType *FindRange(char const *range);
 
 class AttribModItem {
 	public:
@@ -317,7 +317,7 @@ class AttribModItem {
 		};
 		int flags;
 
-		char *ident;
+		char const *ident;
 
 		enum {
 			CONSTANT,
@@ -333,7 +333,7 @@ class AttribModItem {
 
 class AttribModType {
 	public:
-		char *key;
+		char const *key;
 
 		enum {
 			CHECK_MONSTERS = 0x01,
@@ -347,6 +347,6 @@ class AttribModType {
 extern AttribModType *AttribDefs;
 extern int NUMATTRIBMODS;
 
-extern AttribModType *FindAttrib(char *attrib);
+extern AttribModType *FindAttrib(char const *attrib);
 
 #endif

--- a/arcadia/skillshows.cpp
+++ b/arcadia/skillshows.cpp
@@ -354,16 +354,16 @@ AString *ShowSkill::Report(Faction *f)
 			if(level == 1) {
 				*str += "This skill enables the mage to magically heal units "
 					"after battle. ";
-            }
-            *str += AString("A mage at this level can heal up to ") + HealDefs[level].num + 
-					" casualties, with a " + HealDefs[level].rate + 
-                    " percent rate of success. No order "
+			}
+			*str += AString("A mage at this level can heal up to ") + HealDefs[level].num +
+					" casualties, with a " + HealDefs[level].rate +
+					" percent rate of success. No order "
 					"is necessary to use this spell, it will be used "
 					"automatically when the mage is involved in battle.";
-		    if(Globals->ARCADIA_MAGIC && level == 1 && SkillDefs[skill].combat_cost > 0)
-		        *str += AString(" A mage will require one energy for every ")
-		            + 120/SkillDefs[skill].combat_cost + " casualties he "
-		            "attempts to heal.";
+			if(Globals->ARCADIA_MAGIC && level == 1 && SkillDefs[skill].combat_cost > 0)
+				*str += AString(" A mage will require one energy for every ")
+					+ 120/SkillDefs[skill].combat_cost + " casualties he "
+					"attempts to heal.";
 			break;
 		case S_GATE_LORE:
 			/* XXX -- This should be cleaner somehow. */

--- a/arcadia/soldier1.cpp
+++ b/arcadia/soldier1.cpp
@@ -561,7 +561,7 @@ void Soldier::Dead()
 	else unit->dead = unit->faction->num; //ARCADIA_MAGIC mod. Mages don't disappear, they become spirits of the dead.
 }
 
-int Soldier::HasEffect(char *eff)
+int Soldier::HasEffect(char const *eff)
 //imported direct from old code.
 {
 	if(eff == NULL) return 0;
@@ -569,7 +569,7 @@ int Soldier::HasEffect(char *eff)
 	return effects[e->effectnum];
 }
 
-void Soldier::SetEffect(char *eff, int form, Army *army)
+void Soldier::SetEffect(char const *eff, int form, Army *army)
 {
 	if(eff == NULL) return;
 	int i;
@@ -627,7 +627,7 @@ void Soldier::SetEffect(char *eff, int form, Army *army)
 	}
 }
 
-void Soldier::ClearEffect(char *eff)
+void Soldier::ClearEffect(char const *eff)
 {
 	if(eff == NULL) return;
 	int i;

--- a/arcadia/soldier1.h
+++ b/arcadia/soldier1.h
@@ -69,9 +69,9 @@ class Soldier
 		void Alive(int);
 		void Dead();
 
-		int HasEffect(char *);
-		void SetEffect(char *, int form, Army *army);
-		void ClearEffect(char *);
+		int HasEffect(char const *);
+		void SetEffect(char const *, int form, Army *army);
+		void ClearEffect(char const *);
 		void ClearOneTimeEffects(void);
 		
 		int DoSpellCost(int round, Battle *b);
@@ -98,7 +98,7 @@ class Soldier
 		int attacktype;
 		int askill;
 		int attacks;
-		char *special;
+		char const *special;
 		int slevel;
 		int exhausted;
 		int candragontalk;

--- a/arcadia/specials.cpp
+++ b/arcadia/specials.cpp
@@ -304,7 +304,7 @@ void Army::DoBindingAttack(Soldier *pAtt, Battle *b)
     }    
 }
 
-void Army::DoDragonBindingAttack(Soldier *pAtt, Battle *b, Army *atts)
+void Army::DoDragonBindingAttack(Soldier *pAtt, Battle *b, Army*)
 //'this' army is the defending army
 {
     int dragons = 0;

--- a/arcadia/specials.cpp
+++ b/arcadia/specials.cpp
@@ -58,7 +58,7 @@ void Soldier::SetupHealing()
     }
 }
 
-int Army::IsSpecialTarget(char *special) const
+int Army::IsSpecialTarget(char const *special) const
 {
 	// Search All Formations
 	for(int i=0; i<NUMFORMS; i++) {
@@ -69,7 +69,7 @@ int Army::IsSpecialTarget(char *special) const
     return 0;
 }
 
-int Formation::CheckSpecialTarget(char *special, int soldiernum) const
+int Formation::CheckSpecialTarget(char const *special, int soldiernum) const
 {
 	SpecialType *spd = FindSpecial(special);
 	int i;
@@ -174,7 +174,7 @@ int Formation::CheckSpecialTarget(char *special, int soldiernum) const
     return 1;
 }
 
-int Army::ShieldIsUseful(char *special) const
+int Army::ShieldIsUseful(char const *special) const
 {
 	SpecialType *shi;
 	shi = FindSpecial(special);

--- a/arcadia/spells.cpp
+++ b/arcadia/spells.cpp
@@ -4894,12 +4894,12 @@ int Game::RunSpiritOfDead(ARegion *r, Unit *u)
 	    return 0;
 	}
 	
-	if(!tar->faction->num == ghostfaction) {
+	if(!(tar->faction->num == ghostfaction)) {
 	    u->Error("CAST: That unit appears to be dead, but not a ghost. Please contact your GM.", 0);
 	    return 1;
 	}
 	
-	if(!tar->type == U_MAGE) {
+	if(!(tar->type == U_MAGE)) {
 	    u->Error("CAST: That unit appears to be dead, but not a mage. Please contact your GM.", 0);
 	    return 1;
 	}	

--- a/arcadia/spells.cpp
+++ b/arcadia/spells.cpp
@@ -182,7 +182,7 @@ void Unit::AddCastOrder(CastOrder *order)
     castlistorders.Add(order);
 }
 
-void Game::ProcessMindReading(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessMindReading(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
     UnitId *id = ParseUnit(o);
 
@@ -200,7 +200,7 @@ void Game::ProcessMindReading(Unit *u,AString *o, OrdersCheck *pCheck, int isqui
     u->AddCastOrder(order);
 }
 
-void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
     AString *token = o->gettoken();
 
@@ -267,7 +267,7 @@ void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet 
     delete token;
 }
 
-void Game::ProcessFogSpell(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessFogSpell(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
     AString *token = o->gettoken();
 
@@ -293,7 +293,7 @@ void Game::ProcessFogSpell(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet 
     return;
 }
 
-void Game::ProcessUnitsSpell(Unit *u,AString *o, int spell, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessUnitsSpell(Unit *u,AString *o, int spell, OrdersCheck*, int isquiet )
 {
     AString *token = o->gettoken();
     
@@ -330,7 +330,7 @@ void Game::ProcessUnitsSpell(Unit *u,AString *o, int spell, OrdersCheck *pCheck,
     }
 }
 
-void Game::ProcessChangeSpell(Unit *u,AString *o, int spell, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessChangeSpell(Unit *u,AString *o, int spell, OrdersCheck*, int isquiet )
 {
     AString *token = o->gettoken();
 
@@ -388,7 +388,7 @@ void Game::ProcessChangeSpell(Unit *u,AString *o, int spell, OrdersCheck *pCheck
     }
 }
 
-void Game::ProcessModificationSpell(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessModificationSpell(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
     AString *token = o->gettoken();
 
@@ -489,7 +489,7 @@ void Game::ProcessModificationSpell(Unit *u,AString *o, OrdersCheck *pCheck, int
 
 }
 
-void Game::ProcessRejuvenationSpell(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessRejuvenationSpell(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
     AString *token = o->gettoken();
     if(!token) {
@@ -562,7 +562,7 @@ void Game::ProcessRejuvenationSpell(Unit *u,AString *o, OrdersCheck *pCheck, int
     u->AddCastOrder(order);
 }
 
-void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
     CastIntOrder *order = new CastIntOrder;
     order->spell = S_CREATE_PHANTASMAL_DEMONS;
@@ -610,7 +610,7 @@ void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck *pCheck, int isquie
     u->AddCastOrder(order);
 }
 
-void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck*, int isquiet)
 {
 	CastIntOrder *order = new CastIntOrder;
 	order->spell = S_CREATE_PHANTASMAL_UNDEAD;
@@ -658,7 +658,7 @@ void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck *pCheck, int isquie
 	u->AddCastOrder(order);
 }
 
-void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
 	CastIntOrder *order = new CastIntOrder;
 	order->spell = S_CREATE_PHANTASMAL_BEASTS;
@@ -700,7 +700,7 @@ void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck *pCheck, int isquie
 	u->AddCastOrder(order);
 }
 
-void Game::ProcessPhanCreatures(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessPhanCreatures(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
 	CastMenOrder *order = new CastMenOrder;
 	order->spell = S_ILLUSORY_CREATURES;
@@ -772,7 +772,7 @@ void Game::ProcessPhanCreatures(Unit *u,AString *o, OrdersCheck *pCheck, int isq
 	u->AddCastOrder(order);
 }
 
-void Game::ProcessGenericSpell(Unit *u,int spell, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessGenericSpell(Unit *u,int spell, OrdersCheck*, int isquiet )
 {
 	CastOrder *order = new CastOrder;
 	order->spell = spell;
@@ -781,7 +781,7 @@ void Game::ProcessGenericSpell(Unit *u,int spell, OrdersCheck *pCheck, int isqui
 	u->AddCastOrder(order);
 }
 
-void Game::ProcessSummonCreaturesSpell(Unit *u, AString *o, int spell, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessSummonCreaturesSpell(Unit *u, AString *o, int spell, OrdersCheck*, int isquiet )
 {
 	AString *token = o->gettoken();
 	int number = -1;
@@ -796,7 +796,7 @@ void Game::ProcessSummonCreaturesSpell(Unit *u, AString *o, int spell, OrdersChe
 	u->AddCastOrder(order);
 }
 
-void Game::ProcessArtifactSpell(Unit *u, AString *o, int sk, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessArtifactSpell(Unit *u, AString *o, int sk, OrdersCheck*, int isquiet )
 {
     if(!Globals->ARCADIA_MAGIC) return;
 	AString *token = o->gettoken();
@@ -824,7 +824,7 @@ void Game::ProcessArtifactSpell(Unit *u, AString *o, int sk, OrdersCheck *pCheck
 
 
 void Game::ProcessRegionSpell(Unit *u, AString *o, int spell,
-		OrdersCheck *pCheck, int isquiet)
+		OrdersCheck*, int isquiet)
 {
 	AString *token = o->gettoken();
 	int x = -1;
@@ -902,7 +902,7 @@ void Game::ProcessRegionSpell(Unit *u, AString *o, int spell,
 	}
 }
 
-void Game::ProcessSummonMen(Unit *u, AString *o, OrdersCheck *pCheck, int isquiet)
+void Game::ProcessSummonMen(Unit *u, AString *o, OrdersCheck*, int isquiet)
 {
 	AString *token = o->gettoken();
 	if (!token) {
@@ -951,7 +951,7 @@ void Game::ProcessSummonMen(Unit *u, AString *o, OrdersCheck *pCheck, int isquie
 	u->AddCastOrder(order);
 }
 
-void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
 	AString *token = o->gettoken();
 	if (!token) {
@@ -995,7 +995,7 @@ void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck *pCheck, int is
 	}
 }
 
-void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck *pCheck, int isquiet )
+void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck*, int isquiet )
 {
 	AString *token = o->gettoken();
 
@@ -1647,7 +1647,7 @@ int Game::RunMindReading(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunEnchantArmor(ARegion *r,Unit *u)
+int Game::RunEnchantArmor(ARegion*,Unit *u)
 {
 	int level = u->GetSkill(S_ENCHANT_ARMOR);
 	int max = ItemDefs[I_MPLATE].mOut * level;
@@ -1759,7 +1759,7 @@ int Game::RunEnchantArmor(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunEnchantSwords(ARegion *r,Unit *u)
+int Game::RunEnchantSwords(ARegion*,Unit *u)
 {
 	int level = u->GetSkill(S_ENCHANT_SWORDS);
 	int max = ItemDefs[I_MSWORD].mOut * level;
@@ -1858,7 +1858,7 @@ int Game::RunEnchantSwords(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunCreateFood(ARegion *r,Unit *u)
+int Game::RunCreateFood(ARegion*,Unit *u)
 //Not adjusted for item sharing
 {
 	int level = u->GetSkill(S_CREATE_FOOD);
@@ -1994,7 +1994,7 @@ int Game::RunConstructGate(ARegion *r,Unit *u, int spell, int isquiet)
 	return 1;
 }
 
-int Game::RunEngraveRunes(ARegion *r,Object *o,Unit *u, int isquiet)
+int Game::RunEngraveRunes(ARegion*,Object *o,Unit *u, int isquiet)
 {
 	if (!o->IsBuilding()) {
 		u->Error("Runes of Warding may only be engraved on a building.", isquiet);
@@ -2103,7 +2103,7 @@ int Game::RunEngraveRunes(ARegion *r,Object *o,Unit *u, int isquiet)
 	return 1;
 }
 
-int Game::RunSummonBalrog(ARegion *r,Unit *u, int isquiet)
+int Game::RunSummonBalrog(ARegion*,Unit *u, int isquiet)
 {
 	int level = u->GetSkill(S_SUMMON_BALROG);
 	if(!Globals->ARCADIA_MAGIC) {
@@ -2125,14 +2125,14 @@ int Game::RunSummonBalrog(ARegion *r,Unit *u, int isquiet)
     return 0;
 }
 
-int Game::RunSummonDemon(ARegion *r,Unit *u)
+int Game::RunSummonDemon(ARegion*,Unit *u)
 {
 	u->items.SetNum(I_DEMON,u->items.GetNum(I_DEMON) + 1);
 	u->Event(AString("Summons ") + ItemString(I_DEMON,1) + ".");
 	return 1;
 }
 
-int Game::RunSummonImps(ARegion *r,Unit *u)
+int Game::RunSummonImps(ARegion*,Unit *u)
 {
 	int level = u->GetSkill(S_SUMMON_IMPS);
 
@@ -2141,7 +2141,7 @@ int Game::RunSummonImps(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
+int Game::RunCreateArtifact(ARegion*,Unit *u,int skill,int item)
 {
     CastOrder *order = (CastOrder *) u->activecastorder;
 
@@ -2222,7 +2222,7 @@ int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
     return 0;
 }
 
-int Game::RunSummonLich(ARegion *r,Unit *u)
+int Game::RunSummonLich(ARegion*,Unit *u)
 {
 	int level = u->GetSkill(S_SUMMON_LICH);
 
@@ -2234,7 +2234,7 @@ int Game::RunSummonLich(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunRaiseUndead(ARegion *r,Unit *u)
+int Game::RunRaiseUndead(ARegion*,Unit *u)
 {
 	int level = u->GetSkill(S_RAISE_UNDEAD);
 
@@ -2246,7 +2246,7 @@ int Game::RunRaiseUndead(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunSummonSkeletons(ARegion *r,Unit *u)
+int Game::RunSummonSkeletons(ARegion*,Unit *u)
 {
 	int level = u->GetSkill(S_SUMMON_SKELETONS);
 
@@ -2258,7 +2258,7 @@ int Game::RunSummonSkeletons(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunDragonLore(ARegion *r, Unit *u, int isquiet)
+int Game::RunDragonLore(ARegion*, Unit *u, int isquiet)
 {
 	int level = u->GetSkill(S_DRAGON_LORE);
 
@@ -2542,7 +2542,7 @@ int Game::RunInvisibility(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunPhanDemons(ARegion *r,Unit *u)
+int Game::RunPhanDemons(ARegion*,Unit *u)
 {
 	CastIntOrder *order = (CastIntOrder *) u->activecastorder;
 	int level = u->GetSkill(S_CREATE_PHANTASMAL_DEMONS);
@@ -2571,7 +2571,7 @@ int Game::RunPhanDemons(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunPhanUndead(ARegion *r,Unit *u)
+int Game::RunPhanUndead(ARegion*,Unit *u)
 {
 	CastIntOrder *order = (CastIntOrder *) u->activecastorder;
 	int level = u->GetSkill(S_CREATE_PHANTASMAL_UNDEAD);
@@ -2600,7 +2600,7 @@ int Game::RunPhanUndead(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunPhanBeasts(ARegion *r,Unit *u)
+int Game::RunPhanBeasts(ARegion*,Unit *u)
 {
 	CastIntOrder *order = (CastIntOrder *) u->activecastorder;
 	int level = u->GetSkill(S_CREATE_PHANTASMAL_BEASTS);
@@ -2629,7 +2629,7 @@ int Game::RunPhanBeasts(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunPhanCreatures(ARegion *r,Unit *u)
+int Game::RunPhanCreatures(ARegion*,Unit *u)
 {
 	CastMenOrder *order = (CastMenOrder *) u->activecastorder;
 	int level = u->GetSkill(S_ILLUSORY_CREATURES);
@@ -3075,7 +3075,7 @@ int Game::RunFarsight(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunDetectGates(ARegion *r,Object *o,Unit *u)
+int Game::RunDetectGates(ARegion *r,Object*,Unit *u)
 {
 	CastOrder *order = (CastOrder *)u->activecastorder;
 	int distance = 1;
@@ -3183,7 +3183,7 @@ int Game::RunDetectGates(ARegion *r,Object *o,Unit *u)
 	return 1;
 }
 
-int Game::RunTeleport(ARegion *r,Object *o,Unit *u)
+int Game::RunTeleport(ARegion *r,Object*,Unit *u)
 {
 	ARegion *tar;
 	int val;
@@ -3260,7 +3260,7 @@ int Game::RunTeleport(ARegion *r,Object *o,Unit *u)
 	return 1;
 }
 
-int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
+int Game::RunGateJump(ARegion *r,Object*,Unit *u)
 {
 	int level = u->GetSkill(S_GATE_LORE);
 	int nexgate = 0;
@@ -3443,7 +3443,7 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 	return 1;
 }
 
-int Game::RunPortalLore(ARegion *r,Object *o,Unit *u)
+int Game::RunPortalLore(ARegion *r,Object*,Unit *u)
 {
 	int level = u->GetSkill(S_PORTAL_LORE);
 	TeleportOrder *order = u->teleportorders;
@@ -4048,7 +4048,7 @@ int Game::RunSummonCreatures(ARegion *r, Unit *u, int skill, int item, int max)
 	return 1;
 }
 
-int Game::RunSummonHigherCreature(ARegion *r, Unit *u, int skill, int item)
+int Game::RunSummonHigherCreature(ARegion*, Unit *u, int skill, int item)
 //Arcadia code for summoning balrogs, gryffins, liches
 {
     CastOrder *order = (CastOrder *) u->activecastorder;
@@ -4117,7 +4117,7 @@ int Game::RunSummonHigherCreature(ARegion *r, Unit *u, int skill, int item)
 }
 
 
-int Game::RunFog(ARegion *r, Unit *u)
+int Game::RunFog(ARegion*, Unit *u)
 // Arcadia spell
 {
 	CastIntOrder *order = (CastIntOrder *)u->activecastorder;
@@ -4295,7 +4295,7 @@ int Game::RunSummonMen(ARegion *r, Unit *u)
 	return 1;
 }
 
-int Game::RunTransmutation(ARegion *r, Unit *u)
+int Game::RunTransmutation(ARegion*, Unit *u)
 // Arcadia spell
 {
 	int level = u->GetSkill(S_TRANSMUTATION);

--- a/arcadia/template.cpp
+++ b/arcadia/template.cpp
@@ -525,7 +525,7 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 // NEW FUNCTION DK 2000.03.07,
 // converted WriteExits
 //
-void ARegion::GetMapLine(char *buffer, int line, ARegionList *pRegs)
+void ARegion::GetMapLine(char *buffer, int line, ARegionList*)
 {
 	for (int m=0; m<MAP_WIDTH; m++) {
 		buffer[m] = ' ';

--- a/arcadia/template.cpp
+++ b/arcadia/template.cpp
@@ -40,7 +40,7 @@
 
 static void TrimWrite(Areport *f, char *buffer);
 
-static char *TemplateMap[] = {
+static char const *TemplateMap[] = {
  //12345678901234567890
   "        ____        ",   // 1
   "nw     /    \\     ne",  // 2
@@ -69,7 +69,7 @@ static int dircrd[] = {
 };
 
 //this crashes if more terrain types are added!
-static char *ter_fill[] = {
+static char const *ter_fill[] = {
  // block
  " #### ",
  " #### ",
@@ -333,7 +333,7 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 	if(Globals->WEATHER_EXISTS) {
 		GetMapLine(buffer, line, pRegs);
 
-		char* nextWeather = "";
+		char const * nextWeather = "";
 		int nxtweather = pRegs->GetWeather(this, (month + 1) % 12);
 		if (nxtweather == W_WINTER)
 			nextWeather = "winter";

--- a/arcadia/unit.cpp
+++ b/arcadia/unit.cpp
@@ -2422,12 +2422,14 @@ int Unit::Taxers(int numtaxers)
 	if (taxers > totalMen) taxers = totalMen;
 
 	// And finally for creatures
-	if (Globals->WHO_CAN_TAX & GameDefs::TAX_CREATURES)
+	if (Globals->WHO_CAN_TAX & GameDefs::TAX_CREATURES) {
 		basetax += creatures;
 		taxers += creatures;
-	if (Globals->WHO_CAN_TAX & GameDefs::TAX_ILLUSIONS)
+	}
+	if (Globals->WHO_CAN_TAX & GameDefs::TAX_ILLUSIONS) {
 		basetax += illusions;
 		taxers += illusions;
+	}
 		
 
 	if(numtaxers) return(taxers);

--- a/arcadia/unit.cpp
+++ b/arcadia/unit.cpp
@@ -1249,7 +1249,7 @@ int Unit::Study(int sk, int days, int quiet, int overflow)
 			s = (Skill *) skills.First();
 			if (s->type != sk) {
 			    //Real experience patch
-			    if(s->days >= 30*GetMen() || s->experience >= 30*GetMen()) {
+			    if(s->days >= 30*static_cast<unsigned int>(GetMen()) || s->experience >= 30*static_cast<unsigned int>(GetMen())) {
     				Error("STUDY: Can know only 1 skill.", quiet);
     				return 0;
 				}

--- a/arcadia/unit.cpp
+++ b/arcadia/unit.cpp
@@ -2561,7 +2561,7 @@ int Unit::GetMount(AString &itm, int canFly, int canRide, int ocean, int &bonus,
 		if(ItemDefs[item].fly && !canFly) {
 			if(bonus > pMnt->maxHamperedBonus)
 				bonus = pMnt->maxHamperedBonus;
-				type = 2;
+			type = 2;
 		}
 
 		// Practice the mount's skill

--- a/arcadia/unit.cpp
+++ b/arcadia/unit.cpp
@@ -179,7 +179,7 @@ void Unit::SetMonFlags()
 	tactics = TACTICS_AGGRESSIVE;
 }
 
-void Unit::MakeWMon(char *monname, int mon, int num)
+void Unit::MakeWMon(char const *monname, int mon, int num)
 {
 	AString *temp = new AString(monname);
 	SetName(temp);
@@ -2647,7 +2647,7 @@ void Unit::Message(const AString & s)
 	faction->Message(s);
 }
 
-int Unit::GetAttribute(char *attrib)
+int Unit::GetAttribute(char const *attrib)
 {
 	AttribModType *ap = FindAttrib(attrib);
 	if(ap == NULL) return 0;
@@ -2750,7 +2750,7 @@ int Unit::GetAttribute(char *attrib)
 	return base;
 }
 
-int Unit::PracticeAttribute(char *attrib)
+int Unit::PracticeAttribute(char const *attrib)
 {
 	AttribModType *ap = FindAttrib(attrib);
 	if(ap == NULL) return 0;

--- a/arcadia/unit.cpp
+++ b/arcadia/unit.cpp
@@ -231,7 +231,7 @@ void Unit::Writeout(Aoutfile *s)
 	else s->PutStr("NO_SKILL");
 }
 
-void Unit::Readin(Ainfile *s, AList *facs, ATL_VER v)
+void Unit::Readin(Ainfile *s, AList *facs, ATL_VER)
 {
 	name = s->GetStr();
 	describe = s->GetStr();
@@ -869,7 +869,7 @@ void Unit::DefaultOrders(Object *obj, int peasantfac)
 	}
 }
 
-void Unit::PostTurn(ARegion *r)
+void Unit::PostTurn(ARegion*)
 {
 	if (type == U_WMON) {
 		forlist(&items) {

--- a/arcadia/unit.cpp
+++ b/arcadia/unit.cpp
@@ -1601,7 +1601,6 @@ int Unit::MaintCost()
 	if (type == U_WMON || type == U_GUARD || type == U_GUARDMAGE) return 0;
 
 	int men = GetMen();
-	int okethnic = 0;
 	
 	if(Globals->ARCADIA_MAGIC) {	    
 	    int type = GetEthnicity();
@@ -1616,7 +1615,9 @@ int Unit::MaintCost()
         		}
         	}
 	    } else if(type != faction->ethnicity) men *= 2;  //double maintenance cost for non-ethnic men.
-	    else okethnic = 1;
+	    else {
+		    // do nothing
+	    }
 	}
 	
 	if(type == U_LEADER || type == U_MAGE) {

--- a/arcadia/unit.cpp
+++ b/arcadia/unit.cpp
@@ -1544,8 +1544,8 @@ void Unit::AdjustSkills(int overflow)
 				forlist(&skills) {
 					Skill *s = (Skill *) elem;
 					if (s->days + s->experience > max) {
-					    if(s->days >= 30 || s->experience >= 30 || maxlevel == 0) 
-						max = s->days + s->experience;
+						if(s->days >= 30 || s->experience >= 30 || maxlevel == 0)
+							max = s->days + s->experience;
 						if(s->days >= 30 || s->experience >= 30) maxlevel = 1;
 						maxskill = s;
 					}

--- a/arcadia/unit.h
+++ b/arcadia/unit.h
@@ -135,7 +135,7 @@ class Unit : public AListElem
 		~Unit();
 
 		void SetMonFlags();
-		void MakeWMon(char *,int,int);
+		void MakeWMon(char const *,int,int);
 
 		void Writeout( Aoutfile *f );
 		void Readin( Ainfile *f, AList *, ATL_VER v );
@@ -192,8 +192,8 @@ class Unit : public AListElem
 		// These are rule-set specific, in extra.cpp.
 		//
 		// LLS
-		int GetAttribute(char *ident);
-		int PracticeAttribute(char *ident);
+		int GetAttribute(char const *ident);
+		int PracticeAttribute(char const *ident);
 		int GetProductionBonus(int);
 
 /* Do study stuff so experience gets learnt after study.

--- a/arcadia/world.cpp
+++ b/arcadia/world.cpp
@@ -2460,7 +2460,7 @@ int ARegionList::GetWeather( ARegion *pReg, int month )
     }
 }
 
-int ARegion::CanBeStartingCity( ARegionArray *pRA )
+int ARegion::CanBeStartingCity( ARegionArray* )
 {
 	if(type == R_OCEAN) return 0;
     if (!IsCoastal()) return 0;

--- a/arcadia/world.cpp
+++ b/arcadia/world.cpp
@@ -33,7 +33,7 @@
 // Make sure this is correct.   The default is 1000 towns and 1000 regions.
 #define NUMBER_OF_TOWNS 1000
 
-static char *regionnames[] =
+static char const *regionnames[] =
 {
     "A'irhin",
     "A'vespol",
@@ -2094,7 +2094,7 @@ int AGetName(int town )
     return j;
 }
 
-char *AGetNameString( int name )
+char const *AGetNameString( int name )
 {
     return( regionnames[ name ] );
 }

--- a/aregion.cpp
+++ b/aregion.cpp
@@ -91,7 +91,7 @@ TownInfo::~TownInfo()
 	if (name) delete name;
 }
 
-void TownInfo::Readin(Ainfile *f, ATL_VER &v)
+void TownInfo::Readin(Ainfile *f, ATL_VER&)
 {
 	name = f->GetStr();
 	pop = f->GetInt();

--- a/astring.cpp
+++ b/astring.cpp
@@ -297,7 +297,7 @@ AString *AString::getlegal()
 	}
 
 	if (!j) {
-		delete temp;
+		delete[] temp;
 		return 0;
 	}
 

--- a/basic/world.cpp
+++ b/basic/world.cpp
@@ -2062,7 +2062,7 @@ void CountNames()
 	Awrite(AString("Regions ") + nregions);
 }
 
-int AGetName(int town, ARegion *reg)
+int AGetName(int town, ARegion*)
 {
 	int offset, number;
 	if (town) {
@@ -2458,7 +2458,7 @@ int ARegionList::GetWeather( ARegion *pReg, int month )
 	}
 }
 
-int ARegion::CanBeStartingCity( ARegionArray *pRA )
+int ARegion::CanBeStartingCity( ARegionArray* )
 {
 	if (type == R_OCEAN) return 0;
 	if (!IsCoastal()) return 0;

--- a/faction.cpp
+++ b/faction.cpp
@@ -109,7 +109,7 @@ void Attitude::Writeout(Aoutfile *f)
 	f->PutInt(attitude);
 }
 
-void Attitude::Readin(Ainfile *f, ATL_VER v)
+void Attitude::Readin(Ainfile *f, ATL_VER)
 {
 	factionnum = f->GetInt();
 	attitude = f->GetInt();

--- a/fracas/world.cpp
+++ b/fracas/world.cpp
@@ -2064,7 +2064,7 @@ void CountNames()
 	Awrite(AString("Regions ") + nregions);
 }
 
-int AGetName(int town, ARegion *reg)
+int AGetName(int town, ARegion*)
 {
 	int offset, number;
 	if (town) {
@@ -2463,7 +2463,7 @@ int ARegionList::GetWeather( ARegion *pReg, int month )
 	}
 }
 
-int ARegion::CanBeStartingCity( ARegionArray *pRA )
+int ARegion::CanBeStartingCity( ARegionArray* )
 {
 	if (type == R_OCEAN) return 0;
 	if (!IsCoastal()) return 0;

--- a/game.cpp
+++ b/game.cpp
@@ -1571,17 +1571,17 @@ int Game::AllowedTrades(Faction *pFac)
 	return allowedTrades[points];
 }
 
-int Game::UpgradeMajorVersion(int savedVersion)
+int Game::UpgradeMajorVersion(int )
 {
 	return 0;
 }
 
-int Game::UpgradeMinorVersion(int savedVersion)
+int Game::UpgradeMinorVersion(int )
 {
 	return 1;
 }
 
-int Game::UpgradePatchLevel(int savedVersion)
+int Game::UpgradePatchLevel(int )
 {
 	return 1;
 }

--- a/gamedata.cpp
+++ b/gamedata.cpp
@@ -3837,7 +3837,8 @@ static ObjectType ot[] =
 	 1250,0,0,200,
 	 -1,0,NULL,0,
 	 0,0,0,
-	 -1,-1},
+	 -1,-1,
+	 {2,2,2,2,2,2}},
 	// Added for Ceran
 	{"Dragon Cliffs",
 	 ObjectType::DISABLED | ObjectType::CANENTER | ObjectType::CANMODIFY,

--- a/havilah/world.cpp
+++ b/havilah/world.cpp
@@ -736,7 +736,7 @@ int ARegionList::GetWeather( ARegion *pReg, int month )
 	}
 }
 
-int ARegion::CanBeStartingCity( ARegionArray *pRA )
+int ARegion::CanBeStartingCity( ARegionArray* )
 {
 	if (type == R_OCEAN) return 0;
 	if (!IsCoastal()) return 0;

--- a/i_rand.cpp
+++ b/i_rand.cpp
@@ -56,7 +56,7 @@ MODIFIED:
 
 void isaac(randctx *ctx)
 {
-	register ub4 a,b,x,y,*m,*mm,*m2,*r,*mend;
+	ub4 a,b,x,y,*m,*mm,*m2,*r,*mend;
 	mm=ctx->randmem; r=ctx->randrsl;
 	a = ctx->randa; b = ctx->randb + (++ctx->randc);
 	for (m = mm, mend = m2 = m+(RANDSIZ/2); m<mend; )

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -1689,7 +1689,6 @@ void GeoMap::Generate(int spread, int smoothness)
 	while (step > 1) {
 		count++;
 		int nextstep = step/2 + step%2;
-		int showfirst = 1;
 		for (int x = 0; x <= size; x += step) {
 			for (int y = 0; y <= size; y += step) {
 				int av_ele = 0;
@@ -1760,7 +1759,6 @@ void GeoMap::Generate(int spread, int smoothness)
 			}
 		}
 		Adot();
-		showfirst = 1;
 		for (int x = 0; x <= size; x += step) {
 			for (int y = 0; y <= size; y += step) {
 				for (int i = 0; i < 2; i++) {

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -101,9 +101,10 @@ int ARegion::TerrainFactor(int value, int average)
 {
 	int retval = 0;
 	int df = abs(value-average);
-	if (df > 9)
+	if (df > 9) {
 		if (df < 15) retval = 1;
 			else retval = df - 14;
+	}
 	return retval;
 }
 

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -1659,7 +1659,7 @@ GeoMap::GeoMap(int x, int y)
 	}
 }
 
-void GeoMap::Generate(int spread, int smoothness)
+void GeoMap::Generate(int, int smoothness)
 {
 	int step = size / 2;
 	while (step > 16) step = step / 2;

--- a/kingdoms/world.cpp
+++ b/kingdoms/world.cpp
@@ -2062,7 +2062,7 @@ void CountNames()
 	Awrite(AString("Regions ") + nregions);
 }
 
-int AGetName(int town, ARegion *reg)
+int AGetName(int town, ARegion*)
 {
 	int offset, number;
 	if (town) {
@@ -2458,7 +2458,7 @@ int ARegionList::GetWeather( ARegion *pReg, int month )
 	}
 }
 
-int ARegion::CanBeStartingCity( ARegionArray *pRA )
+int ARegion::CanBeStartingCity( ARegionArray* )
 {
 	if (type == R_OCEAN) return 0;
 	if (!IsCoastal()) return 0;

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -688,7 +688,7 @@ void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
 /* Alternate processing for building item-type ship
  * objects and instantiating fleets.
  */
-void Game::RunBuildShipOrder(ARegion * r,Object * obj,Unit * u)
+void Game::RunBuildShipOrder(ARegion * r,Object*,Unit * u)
 {
 	int ship, skill, level, maxbuild, unfinished, output, percent;
 	AString skname;

--- a/object.cpp
+++ b/object.cpp
@@ -250,7 +250,7 @@ Unit *Object::GetUnitId(UnitId *id, int faction)
 	}
 }
 
-int Object::CanEnter(ARegion *reg, Unit *u)
+int Object::CanEnter(ARegion*, Unit *u)
 {
 	if (!(ObjectDefs[type].flags & ObjectType::CANENTER) &&
 			(u->type == U_MAGE || u->type == U_NORMAL ||

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -2957,7 +2957,7 @@ void Game::ProcessEvictOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	}
 }
 
-void Game::ProcessIdleOrder(Unit *u, AString *o, OrdersCheck *pCheck)
+void Game::ProcessIdleOrder(Unit *u, AString*, OrdersCheck *pCheck)
 {
 	if (u->monthorders || (Globals->TAX_PILLAGE_MONTH_LONG &&
 		((u->taxing == TAX_TAX) || (u->taxing == TAX_PILLAGE)))) {

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -362,8 +362,8 @@ void Game::ParseOrders(int faction, Aorders *f, OrdersCheck *pCheck)
 
 						if (unit->inTurnBlock)
 							ParseError(pCheck, unit, fac, "TURN: without ENDTURN");
-							if (!pCheck && unit->former && unit->former->format)
-								unit->former->oldorders.Add(new AString(saveorder));
+						if (!pCheck && unit->former && unit->former->format)
+							unit->former->oldorders.Add(new AString(saveorder));
 						if (pCheck && former) delete unit;
 						unit = former;
 					} else {

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -287,7 +287,7 @@ AList *Game::CanSeeSteal(ARegion *r, Unit *u)
 	return retval;
 }
 
-void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
+void Game::Do1Assassinate(ARegion *r, Object*, Unit *u)
 {
 	AssassinateOrder *so = (AssassinateOrder *) u->stealorders;
 	Unit *tar = r->GetUnitId(so->target, u->faction->num);
@@ -364,7 +364,7 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 	RunBattle(r, u, tar, ass);
 }
 
-void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
+void Game::Do1Steal(ARegion *r, Object*, Unit *u)
 {
 	StealOrder *so = (StealOrder *) u->stealorders;
 	Unit *tar = r->GetUnitId(so->target, u->faction->num);
@@ -984,7 +984,7 @@ void Game::RunEnterOrders(int phase)
 	}
 }
 
-void Game::Do1EnterOrder(ARegion *r, Object *in, Unit *u)
+void Game::Do1EnterOrder(ARegion *r, Object*, Unit *u)
 {
 	Object *to;
 	if (u->enter == -1) {
@@ -1015,7 +1015,7 @@ void Game::Do1EnterOrder(ARegion *r, Object *in, Unit *u)
 	u->MoveUnit(to);
 }
 
-void Game::Do1JoinOrder(ARegion *r, Object *in, Unit *u)
+void Game::Do1JoinOrder(ARegion *r, Object*, Unit *u)
 {
 	JoinOrder *jo;
 	Unit *tar, *pass;

--- a/specials.cpp
+++ b/specials.cpp
@@ -188,8 +188,8 @@ void Battle::UpdateShields(Army *a)
 	}
 }
 
-void Battle::DoSpecialAttack(int round, Soldier *a, Army *attackers,
-		Army *def, int behind)
+void Battle::DoSpecialAttack(int , Soldier *a, Army*,
+		Army *def, int )
 {
 	SpecialType *spd;
 	int i, num, tot = -1;

--- a/spells.cpp
+++ b/spells.cpp
@@ -154,7 +154,7 @@ void Game::ProcessCastOrder(Unit * u,AString * o, OrdersCheck *pCheck )
 	}
 }
 
-void Game::ProcessMindReading(Unit *u,AString *o, OrdersCheck *pCheck )
+void Game::ProcessMindReading(Unit *u,AString *o, OrdersCheck* )
 {
 	UnitId *id = ParseUnit(o);
 
@@ -172,7 +172,7 @@ void Game::ProcessMindReading(Unit *u,AString *o, OrdersCheck *pCheck )
 	u->castorders = order;
 }
 
-void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck *pCheck )
+void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck* )
 {
 	AString *token = o->gettoken();
 
@@ -220,7 +220,7 @@ void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck *pCheck )
 	delete token;
 }
 
-void Game::ProcessInvisibility(Unit *u,AString *o, OrdersCheck *pCheck )
+void Game::ProcessInvisibility(Unit *u,AString *o, OrdersCheck* )
 {
 	AString *token = o->gettoken();
 
@@ -250,7 +250,7 @@ void Game::ProcessInvisibility(Unit *u,AString *o, OrdersCheck *pCheck )
 	}
 }
 
-void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck *pCheck )
+void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck* )
 {
 	CastIntOrder *order = new CastIntOrder;
 	order->spell = S_CREATE_PHANTASMAL_DEMONS;
@@ -298,7 +298,7 @@ void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck *pCheck )
 	u->castorders = order;
 }
 
-void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck *pCheck)
+void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck*)
 {
 	CastIntOrder *order = new CastIntOrder;
 	order->spell = S_CREATE_PHANTASMAL_UNDEAD;
@@ -346,7 +346,7 @@ void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck *pCheck)
 	u->castorders = order;
 }
 
-void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck *pCheck )
+void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck* )
 {
 	CastIntOrder *order = new CastIntOrder;
 	order->spell = S_CREATE_PHANTASMAL_BEASTS;
@@ -388,7 +388,7 @@ void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck *pCheck )
 	u->castorders = order;
 }
 
-void Game::ProcessGenericSpell(Unit *u,int spell, OrdersCheck *pCheck )
+void Game::ProcessGenericSpell(Unit *u,int spell, OrdersCheck* )
 {
 	CastOrder *orders = new CastOrder;
 	orders->spell = spell;
@@ -398,7 +398,7 @@ void Game::ProcessGenericSpell(Unit *u,int spell, OrdersCheck *pCheck )
 }
 
 void Game::ProcessRegionSpell(Unit *u, AString *o, int spell,
-		OrdersCheck *pCheck)
+		OrdersCheck*)
 {
 	AString *token = o->gettoken();
 	int x = -1;
@@ -465,7 +465,7 @@ void Game::ProcessRegionSpell(Unit *u, AString *o, int spell,
 		u->castorders = order;
 }
 
-void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck *pCheck )
+void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck* )
 {
 	AString *token = o->gettoken();
 	if (!token) {
@@ -508,7 +508,7 @@ void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck *pCheck )
 	}
 }
 
-void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck *pCheck )
+void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck* )
 {
 	AString *token = o->gettoken();
 
@@ -615,7 +615,7 @@ void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck *pCheck )
 	u->Error("CAST: Invalid argument.");
 }
 
-void Game::ProcessTransmutation(Unit *u, AString *o, OrdersCheck *pCheck)
+void Game::ProcessTransmutation(Unit *u, AString *o, OrdersCheck*)
 {
 	CastTransmuteOrder *order;
 	AString *token;
@@ -942,7 +942,7 @@ int Game::RunMindReading(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunEnchant(ARegion *r,Unit *u, int skill, int item)
+int Game::RunEnchant(ARegion*,Unit *u, int skill, int item)
 {
 	int level, max, num, i, a;
 	unsigned int c;
@@ -1045,7 +1045,7 @@ int Game::RunConstructGate(ARegion *r,Unit *u, int spell)
 	return 1;
 }
 
-int Game::RunEngraveRunes(ARegion *r,Object *o,Unit *u)
+int Game::RunEngraveRunes(ARegion*,Object *o,Unit *u)
 {
 	if (o->IsFleet() || !o->IsBuilding()) {
 		u->Error("Runes of Warding may only be engraved on a building.");
@@ -1606,7 +1606,7 @@ int Game::RunFarsight(ARegion *r,Unit *u)
 	return 1;
 }
 
-int Game::RunDetectGates(ARegion *r,Object *o,Unit *u)
+int Game::RunDetectGates(ARegion *r,Object*,Unit *u)
 {
 	int level = u->GetSkill(S_GATE_LORE);
 
@@ -1642,7 +1642,7 @@ int Game::RunDetectGates(ARegion *r,Object *o,Unit *u)
 	return 1;
 }
 
-int Game::RunTeleport(ARegion *r,Object *o,Unit *u)
+int Game::RunTeleport(ARegion *r,Object*,Unit *u)
 {
 	ARegion *tar;
 	int val;
@@ -1673,7 +1673,7 @@ int Game::RunTeleport(ARegion *r,Object *o,Unit *u)
 	return 1;
 }
 
-int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
+int Game::RunGateJump(ARegion *r,Object*,Unit *u)
 {
 	int level = u->GetSkill(S_GATE_LORE);
 	int nexgate = 0;
@@ -1809,7 +1809,7 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 	return 1;
 }
 
-int Game::RunPortalLore(ARegion *r,Object *o,Unit *u)
+int Game::RunPortalLore(ARegion *r,Object*,Unit *u)
 {
 	int level = u->GetSkill(S_PORTAL_LORE);
 	TeleportOrder *order = u->teleportorders;
@@ -1888,7 +1888,7 @@ int Game::RunPortalLore(ARegion *r,Object *o,Unit *u)
 	return 1;
 }
 
-int Game::RunTransmutation(ARegion *r, Unit *u)
+int Game::RunTransmutation(ARegion*, Unit *u)
 {
 	CastTransmuteOrder *order;
 	int level, num, source;

--- a/standard/world.cpp
+++ b/standard/world.cpp
@@ -2062,7 +2062,7 @@ void CountNames()
 	Awrite(AString("Regions ") + nregions);
 }
 
-int AGetName(int town, ARegion *reg)
+int AGetName(int town, ARegion*)
 {
 	int offset, number;
 	if (town) {
@@ -2455,7 +2455,7 @@ int ARegionList::GetWeather( ARegion *pReg, int month )
 	}
 }
 
-int ARegion::CanBeStartingCity( ARegionArray *pRA )
+int ARegion::CanBeStartingCity( ARegionArray* )
 {
 	if (type == R_OCEAN) return 0;
 	if (!IsCoastal()) return 0;

--- a/template.cpp
+++ b/template.cpp
@@ -520,7 +520,7 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 // NEW FUNCTION DK 2000.03.07,
 // converted WriteExits
 //
-void ARegion::GetMapLine(char *buffer, int line, ARegionList *pRegs)
+void ARegion::GetMapLine(char *buffer, int line, ARegionList*)
 {
 
 	for (int m=0; m<MAP_WIDTH; m++) {

--- a/unit.cpp
+++ b/unit.cpp
@@ -2125,12 +2125,14 @@ int Unit::Taxers(int numtaxers)
 	if (taxers > totalMen) taxers = totalMen;
 
 	// And finally for creatures
-	if (Globals->WHO_CAN_TAX & GameDefs::TAX_CREATURES)
+	if (Globals->WHO_CAN_TAX & GameDefs::TAX_CREATURES) {
 		basetax += creatures;
 		taxers += creatures;
-	if (Globals->WHO_CAN_TAX & GameDefs::TAX_ILLUSIONS)
+	}
+	if (Globals->WHO_CAN_TAX & GameDefs::TAX_ILLUSIONS) {
 		basetax += illusions;
 		taxers += illusions;
+	}
 	
 	if (numtaxers) return(taxers);
 

--- a/unit.cpp
+++ b/unit.cpp
@@ -209,7 +209,7 @@ void Unit::Writeout(Aoutfile *s)
 	}
 }
 
-void Unit::Readin(Ainfile *s, AList *facs, ATL_VER v)
+void Unit::Readin(Ainfile *s, AList *facs, ATL_VER )
 {
 	name = s->GetStr();
 	describe = s->GetStr();
@@ -796,7 +796,7 @@ void Unit::DefaultOrders(Object *obj)
 	}
 }
 
-void Unit::PostTurn(ARegion *r)
+void Unit::PostTurn(ARegion*)
 {
 	if (type == U_WMON) {
 		forlist(&items) {


### PR DESCRIPTION
Fixed compiler warnings for gcc and clang using -Wall.

- some fixes were trivial
- some fixes existed in Atlantis and haven't been applied to Arcadia. Done.
- some required more effort...  see commit message.
