### PR TITLE
removed duplicate unitname from share event message

### DIFF
--- a/unit.cpp
+++ b/unit.cpp
@@ -968,11 +968,11 @@ void Unit::ConsumeShared(int item, int n)
 					continue;
 				if (u->items.GetNum(item) >= n) {
 					u->items.SetNum(item, u->items.GetNum(item) - n);
-					u->Event(*(u->name) + " shares " + ItemString(item, n) +
+					u->Event(AString("Shares ") + ItemString(item, n) +
 							" with " + *name + ".");
 					return;
 				}
-				u->Event(*(u->name) + " shares " +
+				u->Event(AString("Shares ") +
 						ItemString(item, u->items.GetNum(item)) +
 						" with " + *name + ".");
 				n -= u->items.GetNum(item);


### PR DESCRIPTION
tactical reserve (3454): tactical reserve (3454) shares 52 silver [SILV] with scout (13178).
becomes:
tactical reserve (3454): Shares 52 silver [SILV] with scout (13178).