### PR TITLE
Bugfix in study to level order

### DIFF
--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -1583,7 +1583,7 @@ void Game::Do1StudyOrder(Unit *u,Object *obj)
 		u->Event(str);
 		// study to level order
 		if (o->level != -1) {
-			if (u->GetSkill(sk) < o->level) {
+			if (u->GetRealSkill(sk) < o->level) {
 				TurnOrder *tOrder = new TurnOrder;
 				AString order;
 				tOrder->repeating = 0;


### PR DESCRIPTION
When a unit with an AMTS has the order "study obse 5" it stops studying as soon as it reaches OBSE-3. This is caused because void Game::Do1StudyOrder() checks if the target level has been reached using Unit::GetSkill(), but this function adds modifiers to the skill.

Unit::GetRealSkill() has to be used instead.