### PR TITLE
Gate_Lore RANDOM LEVEL weight bug

### DIFF
--- a/spells.cpp
+++ b/spells.cpp
@@ -1703,7 +1703,7 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 	}
 
 	int maxweight = 10;
-	if (order->gate != -1) level -= 2;
+	if (order->gate != -1 && order->gate != -2) level -= 2;
 	switch (level) {
 		case 1:
 			maxweight = 15;


### PR DESCRIPTION
Gate_Lore RANDOM LEVEL should use same weight limits than Gate_Lore
RANDOM. Now it uses the limits of Gate_Lore GATE, with a fallback value
of 10 when it is casted at level 2 (Gate_Lore GATE is not possible at
level 2 thus it was not contemplated).