### PR TITLE
Fix prevent_sail_through workaround

### DIFF
--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -291,47 +291,12 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 			(TerrainDefs[newreg->type].similar_type != R_OCEAN)) {
 			cap->Error("SAIL: Can't sail inland.");
 			stop = 1;
-		} else if (Globals->PREVENT_SAIL_THROUGH &&
-				(TerrainDefs[reg->type].similar_type != R_OCEAN) &&
-				(fleet->flying < 1) &&
-				(fleet->prevdir != -1) &&
-				(fleet->prevdir != x->dir)) {
-			// Check to see if sailing THROUGH land!
-			// always allow retracing steps
-			int blocked1 = 0;
-			int blocked2 = 0;
-			int d1 = fleet->prevdir;
-			int d2 = x->dir;
-			if (d1 > d2) {
-				int tmp = d1;
-				d1 = d2;
-				d2 = tmp;
-			}
-			for (int k = d1+1; k < d2; k++) {
-				ARegion *land1 = reg->neighbors[k];
-				if ((!land1) ||
-						(TerrainDefs[land1->type].similar_type !=
-						 R_OCEAN))
-					blocked1 = 1;
-			}
-			int sides = NDIRS - 2 - (d2 - d1 - 1);
-			for (int l = d2+1; l <= d2 + sides; l++) {
-				int dl = l;
-				if (dl >= NDIRS) dl -= NDIRS;
-				ARegion *land2 = reg->neighbors[dl];
-				if ((!land2) ||
-						(TerrainDefs[land2->type].similar_type !=
-						 R_OCEAN))
-					blocked2 = 1;
-			}
-			if ((blocked1) && (blocked2))
-			{
-				cap->Error(AString("SAIL: Could not sail ") +
-						DirectionStrs[x->dir] + AString(" from ") +
-						reg->ShortPrint(&regions) +
-						". Cannot sail through land.");
-				stop = 1;
-			}
+		} else if (fleet->SailThroughCheck(x->dir) < 1) {
+			cap->Error(AString("SAIL: Could not sail ") +
+					DirectionStrs[x->dir] + AString(" from ") +
+					reg->ShortPrint(&regions) +
+					". Cannot sail through land.");
+			stop = 1;
 		}
 
 		if (!stop) {

--- a/object.h
+++ b/object.h
@@ -121,6 +121,7 @@ class Object : public AListElem
 		AString FleetDefinition();
 		int FleetCapacity();
 		int FleetLoad();
+		int SailThroughCheck(int dir);
 		int FleetSailingSkill(int);
 		int GetFleetSize();
 		int GetFleetSpeed(int);

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -2675,9 +2675,12 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 
 			// give into existing fleet or form new fleet?
 			newfleet = 0;
+			
 			// target is not in fleet or not fleet owner
 			if (!(t->object->IsFleet()) ||
 				(t->num != t->object->GetOwner()->num)) newfleet = 1;
+				
+			// Set fleet variable to target fleet	
 			if (newfleet == 1) {
 				// create a new fleet
 				fleet = new Object(r);
@@ -2687,6 +2690,10 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 				t->object->region->AddFleet(fleet);
 				t->MoveUnit(fleet);
 			}
+			else {
+				fleet = t->object;
+			}
+			
 			if (ItemDefs[o->item].max_inventory) {
 				cur = t->object->GetNumShips(o->item) + amt;
 				if (cur > ItemDefs[o->item].max_inventory) {
@@ -2695,6 +2702,25 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 					return 0;
 				}
 			}
+			
+			// Check if fleets are compatible
+			if ((Globals->PREVENT_SAIL_THROUGH) &&
+					(!Globals->ALLOW_TRIVIAL_PORTAGE) &&
+					// flying ships are always transferrable
+					(ItemDefs[o->item].fly == 0)) {
+				// if target fleet had not sailed, just copy shore from source
+				if (fleet->prevdir == -1) {
+					fleet->prevdir = s->object->prevdir;
+				} else {
+					// check that source ship is compatible with its new fleet
+					if (s->object->SailThroughCheck(fleet->prevdir) == 0) {
+						u->Error(ord +
+								": Ships cannot be transferred through land.");
+						return 0;
+					}
+				}
+			}
+
 			s->Event(AString("Transfers ") + ItemString(o->item, amt) + " to " +
 				*t->object->name + ".");
 			if (s->faction != t->faction) {


### PR DESCRIPTION
Fix a workaround on PREVENT_SAIL_THROUGH by giving the ships to a new
fleet. Now ships can only be given between compatible fleets (those in
the same shore). If target fleet has no restrictions, it will inherit
restrictions of the source fleet, if any.

Code checking for ships SailThrough check has been moved to
Object::SailThroughCheck()
