### PR TITLE
Bug with moving too early to building with BUILD command

### DIFF
--- a/game.h
+++ b/game.h
@@ -555,6 +555,7 @@ private:
 	void RunUnitProduce(ARegion *, Unit *);
 	void Run1BuildOrder(ARegion *, Object *, Unit *);
 	void RunBuildShipOrder(ARegion *, Object *, Unit *);
+	void AddNewBuildings(ARegion *);
 	void RunBuildHelpers(ARegion *);
 	int ShipConstruction(ARegion *, Unit *, Unit *, int, int, int);
 	void CreateShip(ARegion *, Unit *, int);

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -748,6 +748,50 @@ void Game::RunBuildShipOrder(ARegion * r,Object * obj,Unit * u)
 	u->monthorders = 0;
 }
 
+void Game::AddNewBuildings(ARegion *r)
+{
+	int i;
+	forlist((&r->objects)) {
+		Object *obj = (Object *) elem;
+		forlist ((&obj->units)) {
+			Unit *u = (Unit *) elem;
+			if (u->monthorders) {
+				if (u->monthorders->type == O_BUILD) {
+					BuildOrder *o = (BuildOrder *)u->monthorders;
+
+					// If BUILD order was marked for creating new building
+					// in parse phase, it is time to create one now.
+					if (o->new_building != -1) {
+						for (i = 1; i < 100; i++) {
+							if (!r->GetObject(i)) {
+								break;
+							}
+						}
+						if (i < 100) {
+							Object * obj = new Object(r);
+							obj->type = o->new_building;
+							obj->incomplete = ObjectDefs[obj->type].cost;
+							obj->num = i;
+							obj->SetName(new AString("Building"));
+							u->build = obj->num;
+							r->objects.Add(obj);
+
+							// This moves unit to a new building.
+							// This unit might be processed again but from new object.
+							u->MoveUnit(obj);
+							// This why we need to unset new_building so it will not
+							// try to create new object again.
+							o->new_building = -1;
+						} else {
+							u->Error("BUILD: The region is full.");
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
 void Game::RunBuildHelpers(ARegion *r)
 {
 	forlist((&r->objects)) {
@@ -1029,6 +1073,7 @@ void Game::RunMonthOrders()
 		ARegion * r = (ARegion *) elem;
 		RunIdleOrders(r);
 		RunStudyOrders(r);
+		AddNewBuildings(r);
 		RunBuildHelpers(r);
 		RunProduceOrders(r);
 	}

--- a/orders.cpp
+++ b/orders.cpp
@@ -228,6 +228,7 @@ AttackOrder::~AttackOrder()
 BuildOrder::BuildOrder()
 {
 	type = O_BUILD;
+	new_building = -1;
 }
 
 BuildOrder::~BuildOrder()

--- a/orders.h
+++ b/orders.h
@@ -252,6 +252,7 @@ class BuildOrder : public Order {
 		~BuildOrder();
 
 		UnitId * target;
+		int new_building;
 		int needtocomplete;
 };
 

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -1540,7 +1540,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 {
 	AString * token = o->gettoken();
 	BuildOrder * order = new BuildOrder;
-	int maxbuild, i;
+	int maxbuild;
 
 	// 'incomplete' for ships:
 	maxbuild = 0;
@@ -1615,22 +1615,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 						ParseError(pCheck, unit, 0, "BUILD: Can't build that.");
 						return;
 					}
-					for (i = 1; i < 100; i++)
-						if (!reg->GetObject(i))
-							break;
-					if (i < 100) {
-						Object * obj = new Object(reg);
-						obj->type = ot;
-						obj->incomplete = ObjectDefs[obj->type].cost;
-						obj->num = i;
-						obj->SetName(new AString("Building"));
-						unit->build = obj->num;
-						unit->object->region->objects.Add(obj);
-						unit->MoveUnit(obj);
-					} else {
-						unit->Error("BUILD: The region is full.");
-						return;
-					}
+					order->new_building = ot;
 				}
 			}
 			order->target = NULL; // Not helping anyone...


### PR DESCRIPTION
(fixed by Artyomtrityak in New Origins)

when you're in the building, you're the owner and doing 2 orders:

destroy
build "something"

it does not work
Engine tries to destroy new building, you're trying to build and breaks

+ Building [2] : Road S.
  * Unit (69), Testets (3)

unit 61
destroy
build tower

Errors during turn:
Unit (61): BUILD: Nothing to build.

Events during turn:
Unit (61): Destroys Building [3].
