### PR TITLE
Fix using assignation instead of compare

### DIFF
--- a/arcadia/map.cpp
+++ b/arcadia/map.cpp
@@ -549,7 +549,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			}
 			for (int i=0; i<sz; i++) {
 				int dir = getrandom(NDIRS);
-				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir = NDIRS-1))
+				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
 					&& (getrandom(4) < 3)) continue;				

--- a/basic/map.cpp
+++ b/basic/map.cpp
@@ -484,7 +484,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			}
 			for (int i=0; i<sz; i++) {
 				int dir = getrandom(NDIRS);
-				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir = NDIRS-1))
+				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
 					&& (getrandom(4) < 3)) continue;				

--- a/fracas/map.cpp
+++ b/fracas/map.cpp
@@ -484,7 +484,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			}
 			for (int i=0; i<sz; i++) {
 				int dir = getrandom(NDIRS);
-				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir = NDIRS-1))
+				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
 					&& (getrandom(4) < 3)) continue;				

--- a/havilah/map.cpp
+++ b/havilah/map.cpp
@@ -492,7 +492,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			}
 			for (int i=0; i<sz; i++) {
 				int dir = getrandom(NDIRS);
-				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir = NDIRS-1))
+				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
 					&& (getrandom(4) < 3)) continue;				

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -629,7 +629,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 				}
 				for (int i=0; i<sz; i++) {
 					int dir = getrandom(NDIRS);
-					if ((reg->yloc < yoff*2) && ((dir < 2) || (dir = NDIRS-1))
+					if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 						&& (getrandom(4) < 3)) continue;
 					if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
 						&& (getrandom(4) < 3)) continue;				

--- a/standard/map.cpp
+++ b/standard/map.cpp
@@ -484,7 +484,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			}
 			for (int i=0; i<sz; i++) {
 				int dir = getrandom(NDIRS);
-				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == NDIRS-1))
+				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
 					&& (getrandom(4) < 3)) continue;				


### PR DESCRIPTION
This piece of code did an assignation instead of a comparation. This
small check is there to make lands to the very north less likely to
expand further to the north, as following check does the same with
southern lands.