### PR TITLE
Non-instant building destruction

### DIFF
--- a/basic/rules.cpp
+++ b/basic/rules.cpp
@@ -245,6 +245,9 @@ static GameDefs g = {
 	1,	// WORLD_EVENTS
 	0,	//FACTION_STATISTICS
 	FactionActivityRules::DEFAULT,	// FACTION_ACTIVITY
+	DestroyBehavior::INSTANT,	// DESTROY_BEHAVIOR
+	200,	// MIN_DESTROY_POINTS,
+	33,	// MAX_DESTROY_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/fracas/rules.cpp
+++ b/fracas/rules.cpp
@@ -248,6 +248,9 @@ static GameDefs g = {
 	1,	// WORLD_EVENTS
 	0,	//FACTION_STATISTICS
 	FactionActivityRules::DEFAULT,	// FACTION_ACTIVITY
+	DestroyBehavior::INSTANT,	// DESTROY_BEHAVIOR
+	200,	// MIN_DESTROY_POINTS,
+	34,	// MAX_DESTROY_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/gamedefs.h
+++ b/gamedefs.h
@@ -80,6 +80,12 @@ enum FactionActivityRules {
 	MARTIAL_MERGED = 2	// Common point pool for War and Trade activity, but counted per region - do what you want in a region.
 };
 
+enum DestroyBehavior {
+	INSTANT    = 0,	// default behavior,any unit can instantly destroy any building
+	PER_FIGURE = 1,	// one man will destroy one building strucure point, it is assumed that destroy power is 1
+	PER_SKILL  = 2	// use building skill as a basis how much can be destroyed. The formula is: destroy power = max(1, BUILDING skill level)
+};
+
 class GameDefs {
 public:
 	char const *RULESET_NAME;
@@ -771,6 +777,18 @@ public:
 
 	// How to count faction activit. See FactionActivty enum for more details.
 	FactionActivityRules FACTION_ACTIVITY;
+
+	// how buildings are destroyed, read more in DestroyBehavior enum
+	DestroyBehavior DESTROY_BEHAVIOR;
+
+	// set folowing value when DESTROY_BEHAVIOR is not INSTANT
+	// how much structure points can be destroyed per turn
+	// MAX_DESTROY_PERCENT accepts values from [1..100]
+	// MIN_DESTROY_POINTS accepts [0..infinity]
+	// formula:
+	//     turn destroyable points = max(MIN_DESTROY_POINTS, Max Structure Points * MAX_DESTROY_PERCENT / 100)
+	int MIN_DESTROY_POINTS;
+	int MAX_DESTROY_PERCENT;
 };
 
 extern GameDefs *Globals;

--- a/havilah/rules.cpp
+++ b/havilah/rules.cpp
@@ -253,6 +253,9 @@ static GameDefs g = {
 	1,	// WORLD_EVENTS
 	0,	//FACTION_STATISTICS
 	FactionActivityRules::DEFAULT,	// FACTION_ACTIVITY
+	DestroyBehavior::INSTANT,	// DESTROY_BEHAVIOR
+	200,	// MIN_DESTROY_POINTS,
+	34,	// MAX_DESTROY_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/kingdoms/rules.cpp
+++ b/kingdoms/rules.cpp
@@ -246,6 +246,9 @@ static GameDefs g = {
 	1,	// WORLD_EVENTS
 	0,	//FACTION_STATISTICS
 	FactionActivityRules::DEFAULT,	// FACTION_ACTIVITY
+	DestroyBehavior::INSTANT,	// DESTROY_BEHAVIOR
+	200,	// MIN_DESTROY_POINTS,
+	34,	// MAX_DESTROY_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/neworigins/rules.cpp
+++ b/neworigins/rules.cpp
@@ -252,6 +252,9 @@ static GameDefs g = {
 	1,	// WORLD_EVENTS
 	1,	//FACTION_STATISTICS
 	FactionActivityRules::DEFAULT,	// FACTION_ACTIVITY
+	DestroyBehavior::PER_SKILL,	// DESTROY_BEHAVIOR
+	200,	// MIN_DESTROY_POINTS,
+	34,	// MAX_DESTROY_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/object.cpp
+++ b/object.cpp
@@ -87,6 +87,7 @@ Object::Object(ARegion *reg)
 	region = reg;
 	prevdir = -1;
 	flying = 0;
+	destroyed = 0;
 	movepoints = Globals->PHASED_MOVE_OFFSET % Globals->MAX_SPEED;
 	ships.Empty();
 }

--- a/object.h
+++ b/object.h
@@ -141,6 +141,7 @@ class Object : public AListElem
 		int mages;
 		int shipno;
 		int movepoints;
+		int destroyed;	// how much points was destroyed so far this turn
 		AList units;
 		AList ships;
 };

--- a/standard/rules.cpp
+++ b/standard/rules.cpp
@@ -245,6 +245,9 @@ static GameDefs g = {
 	0,	// WORLD_EVENTS
 	0,	//FACTION_STATISTICS
 	FactionActivityRules::DEFAULT,	// FACTION_ACTIVITY
+	DestroyBehavior::INSTANT,	// DESTROY_BEHAVIOR
+	200,	// MIN_DESTROY_POINTS,
+	34,	// MAX_DESTROY_PERCENT
 };
 
 GameDefs *Globals = &g;


### PR DESCRIPTION
There are 3 options for how buildings can be destroyed:
1. Instantly (standard)
2. Per figure - one figure will contribute to removing one structural point
3. Per skill - each figure will contribute to remove as many structural points as it knows `BUIL` skill

When `PER_FIGURE` or `PER_SKILL` is used, max % of removed structural points (from the complete building) and min amount of removed points, can be specified. Such way small structures can be removed in one turn, but larger structures would need several turns even if w whole several thousand army is performing destrucion.

This solves #69 