### PR TITLE
Updated description for FORGET to reflect the defined ruleset

### DIFF
--- a/genrules.cpp
+++ b/genrules.cpp
@@ -5049,8 +5049,26 @@ int Game::GenRules(const AString &rules, const AString &css,
 	f.ClassTagText("div", "rule", "");
 	f.LinkRef("forget");
 	f.TagText("h4", "FORGET [skill]");
-	temp = "Forget the given skill. This order is useful for normal units "
-		"who wish to learn a new skill, but already know a different skill.";
+	temp = "Forget the given skill. This order is useful for ";
+	if (Globals->SKILL_LIMIT_NONLEADERS) {
+		temp += "normal units who wish to learn a new skill, but already "
+			"know a different skill and for ";
+	}
+	temp += "a mage";
+	if (Globals->APPRENTICES_EXIST) {
+		if (Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT) {
+			temp += ", ";
+		}
+		else {
+			temp += ", or ";
+		}
+		temp += Globals->APPRENTICE_NAME;
+	}
+	if (Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT) {
+		temp += ", or quartermaster";
+	}
+	temp += " who wish to become a normal "
+		"unit in order to be able to change faction points or other reasons.";
 	f.Paragraph(temp);
 	f.Paragraph("Example:");
 	temp = "Forget knowledge of Mining.";

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -5052,7 +5052,7 @@ int Game::GenRules(const AString &rules, const AString &css,
 	temp = "Forget the given skill. This order is useful for ";
 	if (Globals->SKILL_LIMIT_NONLEADERS) {
 		temp += "normal units who wish to learn a new skill, but already "
-			"know a different skill and for ";
+			"know a different skill. It can also be used for ";
 	}
 	temp += "a mage";
 	if (Globals->APPRENTICES_EXIST) {
@@ -5068,7 +5068,8 @@ int Game::GenRules(const AString &rules, const AString &css,
 		temp += ", or quartermaster";
 	}
 	temp += " who wish to become a normal "
-		"unit in order to be able to change faction points or other reasons.";
+		"unit. A common reason for this is to be able to change faction "
+		"points.";
 	f.Paragraph(temp);
 	f.Paragraph("Example:");
 	temp = "Forget knowledge of Mining.";


### PR DESCRIPTION
Ensured we check SKILL_LIMIT_NONLEADERS before stating that normal units can know only one skill.
Added another example when FORGET may come in handy.