### PR TITLE
Rules say no fractional food

### DIFF
--- a/genrules.cpp
+++ b/genrules.cpp
@@ -2467,7 +2467,7 @@ int Game::GenRules(const AString &rules, const AString &css,
 			if (ItemDefs[i].flags & ItemType::DISABLED) continue;
 			if (!(ItemDefs[i].type & IT_FOOD)) continue;
 			if (last != -1) {
-				if (j > 0) temp += ", ";
+				if (j > 1) temp += ", ";
 				temp += ItemDefs[last].names;
 			}
 			last = i;
@@ -2477,7 +2477,11 @@ int Game::GenRules(const AString &rules, const AString &css,
 		temp += ItemDefs[last].names;
 		temp += " for each ";
 		temp += Globals->UPKEEP_FOOD_VALUE;
-		temp += " silver of maintenance owed. ";
+		if (Globals->MAINTENANCE_COST % Globals->UPKEEP_FOOD_VALUE)
+                    temp += " silver (or fraction thereof) of maintenance owed. "
+                        "Fractional portions of food may not be shared with other units. ";
+		else
+                    temp += " silver of maintenance owed. ";
 		if (Globals->UPKEEP_MINIMUM_FOOD > 0) {
 			temp += "A unit must be given at least ";
 			temp +=	Globals->UPKEEP_MINIMUM_FOOD;


### PR DESCRIPTION
This adds to neworigins.html a statement that fractional food is discarded, as requested by dbourne.  While doing that, I noticed that there is a spurious comma before the list of food items that may be used for maintenance, this commit also removes that extra comma.

commit 0f2428932ce17f6ba652afce74178d843b304715 (HEAD -> rules-say-no-fractional-food, origin/rules-say-no-fractional-food)
Author: Stan Heckman <sheckman@whiskerlabs.com>
Date:   Wed Sep 21 16:47:41 2022 +0000

    Explain in rules that fractional food is lost.
    
    If (and only if) amount of maintenance provided by one unit of food is
    greater than the amount of maintenance required to support one peasant,
    adds "(or fraction thereof)" and "Fractional portions of food may not be
    shared with other units" to neworigins.html.
    
    Also fixes a bug that put an additional comma before the list of food
    items.
    
    This fix was tested as follows:
    
    $ make neworigins-rules
    $ grep -B1 -A9 "This fee is generally" neworigins/html/neworigins.html
    <This showed the expected new text.  Good.>
    <The extra comma was removed.  Good.>
    
    $ sed -i /UPKEEP_FOOD_VALUE$/s/30/10/ neworigins/rules.cpp
    $ make neworigins
    $ make neworigins-rules
    $ grep -B1 -A9 "This fee is generally" neworigins/html/neworigins.html
    <This showed the older, shorter text.  Good.>
    <The extra comma was removed.  Good.>
