### PR TITLE
Update to use C++20 (not C++11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GAME ?= standard
 
 CPLUS = g++
 CC = gcc
-CFLAGS = -g -I. -I.. -Wall -std=c++11
+CFLAGS = -g -I. -I.. -Wall -std=c++20
 
 RULESET_OBJECTS = extra.o map.o monsters.o rules.o world.o 
 

--- a/aregion.cpp
+++ b/aregion.cpp
@@ -3007,7 +3007,10 @@ void makeRivers(Map* map, ARegionArray* arr, std::vector<WaterBody*>& waterBodie
 					continue;
 				}
 
-				graph.setInclusion([ source, target, &rivers, &waterBodies ](ARegion* current, ARegion* next) {
+				// Commented out waterBodys to match that it's unused currently due
+				// to being commented out.
+				// TODO: this probably should be a game config for that check
+				graph.setInclusion([ source, target, &rivers /*, &waterBodies */ ](ARegion* current, ARegion* next) {
 					if (source->includes(next)) {
 						// river can't go through source water body
 						return false;
@@ -3254,7 +3257,7 @@ std::vector<graphs::Location2D> getPoints(const int w, const int h,
 	
 	graphs::Location2D loc;
 	do {
-		loc = { x: getrandom(w), y: getrandom(h) };
+		loc = { .x = getrandom(w), .y = getrandom(h) };
 	}
 	while (!onIsIncluded(loc));
 
@@ -3698,13 +3701,13 @@ void economy(ARegionArray* arr, const int w, const int h) {
 		std::string name = getEthnicName(makeRoll(1, w * h), etnos);
 
 		reg->ManualSetup({
-			terrain: terrain,
-			habitat: terrain->pop + 1,
-			prodWeight: 1,
-			addLair: false,
-			addSettlement: true,
-			settlementName: name,
-			settlementSize: size
+			.terrain = terrain,
+			.habitat = terrain->pop + 1,
+			.prodWeight = 1,
+			.addLair = false,
+			.addSettlement = true,
+			.settlementName = name,
+			.settlementSize = size
 		});
 
 		visited.insert(reg);
@@ -3734,13 +3737,13 @@ void economy(ARegionArray* arr, const int w, const int h) {
 			bool addLair = getrandom(100) < terrain->lairChance;
 
 			reg->ManualSetup({
-				terrain: terrain,
-				habitat: terrain->pop + 1,
-				prodWeight: 1,
-				addLair: addLair,
-				addSettlement: false,
-				settlementName: std::string(),
-				settlementSize: 0
+				.terrain = terrain,
+				.habitat = terrain->pop + 1,
+				.prodWeight = 1,
+				.addLair = addLair,
+				.addSettlement = false,
+				.settlementName = std::string(),
+				.settlementSize = 0
 			});
 		}
 	}
@@ -3874,8 +3877,8 @@ void ARegionList::AddHistoricalBuildings(ARegionArray* arr, const int w, const i
 			auto start = cities[i];
 			auto end = cities[j];
 
-			graphs::Location2D startLoc = { x: start->xloc, y: start->yloc };
-			graphs::Location2D endLoc = { x: end->xloc, y: end->yloc };
+			graphs::Location2D startLoc = { .x = start->xloc, .y = start->yloc };
+			graphs::Location2D endLoc = { .x = end->xloc, .y = end->yloc };
 
 			std::unordered_map<graphs::Location2D, graphs::Location2D> cameFrom;
 			std::unordered_map<graphs::Location2D, double> costSoFar;
@@ -3922,8 +3925,8 @@ void ARegionList::AddHistoricalBuildings(ARegionArray* arr, const int w, const i
 
 			std::string name = "Road to " + std::string(end->town->name->Str());
 
-			graphs::Location2D startLoc = { x: start->xloc, y: start->yloc };
-			graphs::Location2D endLoc = { x: end->xloc, y: end->yloc };
+			graphs::Location2D startLoc = { .x = start->xloc, .y = start->yloc };
+			graphs::Location2D endLoc = { .x = end->xloc, .y = end->yloc };
 
 			std::unordered_map<graphs::Location2D, graphs::Location2D> cameFrom;
 			std::unordered_map<graphs::Location2D, double> costSoFar;

--- a/aregion.cpp
+++ b/aregion.cpp
@@ -2913,8 +2913,8 @@ void makeRivers(Map* map, ARegionArray* arr, std::vector<WaterBody*>& waterBodie
 
 	size_t sz = waterBodies.size();
 	int distances[sz][sz];
-	for (int i = 0; i < sz; i++) {
-		for (int j = 0; j < sz; j++) {
+	for (size_t i = 0; i < sz; i++) {
+		for (size_t j = 0; j < sz; j++) {
 			distances[i][j] = INT32_MAX;
 		}
 	}
@@ -2975,13 +2975,13 @@ void makeRivers(Map* map, ARegionArray* arr, std::vector<WaterBody*>& waterBodie
 	});
 
 	int riverName = 0;
-	for (int i = 0; i < sz; i++) {
+	for (size_t i = 0; i < sz; i++) {
 		std::cout << "Connecting water body " << i << std::endl;
 
 		std::vector<std::pair<int, int>> candidates;
 		WaterBody* source = waterBodies[i];
 
-		for (int j = 0; j < sz; j++) {
+		for (size_t j = 0; j < sz; j++) {
 			if (i == j) {
 				continue;
 			}
@@ -3345,7 +3345,6 @@ std::vector<graphs::Location2D> getPointsFromList(
 
 	while (!processing.empty()) {
 		int i = getrandom(processing.size());
-		auto next = processing.at(i);
 		processing.erase(processing.begin() + i);
 
 		int count = 0;
@@ -3865,8 +3864,8 @@ void ARegionList::AddHistoricalBuildings(ARegionArray* arr, const int w, const i
 
 	size_t sz = cities.size();
 	int distances[sz][sz];
-	for (int i = 0; i < sz; i++) {
-		for (int j = i + 1; j < sz; j++) {
+	for (size_t i = 0; i < sz; i++) {
+		for (size_t j = i + 1; j < sz; j++) {
 			if (i == j) {
 				distances[i][j] = 0;
 				continue;
@@ -3900,14 +3899,14 @@ void ARegionList::AddHistoricalBuildings(ARegionArray* arr, const int w, const i
 	}
 
 	std::unordered_set<ARegion*> connected;
-	for (int i = 0; i < sz; i++) {
+	for (size_t i = 0; i < sz; i++) {
 		auto start = cities[i];
 
 		if (connected.find(start) != connected.end()) {
 			continue;
 		}
 
-		for (int j = 0; j < sz; j++) {
+		for (size_t j = 0; j < sz; j++) {
 			auto dist = distances[i][j];
 			if (!dist || dist > 8) {
 				continue;

--- a/astring.cpp
+++ b/astring.cpp
@@ -118,22 +118,22 @@ AString & AString::operator=(const char *c)
 	return *this;
 }
 
-int AString::operator==(char *s)
+int AString::operator==(char *s) const
 {
 	return isEqual(s);
 }
 
-int AString::operator==(const char *s)
+int AString::operator==(const char *s) const
 {
 	return isEqual(s);
 }
 
-int AString::operator==(const AString &s)
+int AString::operator==(const AString &s) const
 {
 	return isEqual(s.str);
 }
 
-int AString::isEqual(const char *temp2)
+int AString::isEqual(const char *temp2) const
 {
 	char *temp1 = str;
 
@@ -306,7 +306,7 @@ AString *AString::getlegal()
 	}
 
 	if (!j) {
-		delete temp;
+		delete[] temp;
 		return 0;
 	}
 

--- a/astring.cpp
+++ b/astring.cpp
@@ -389,12 +389,11 @@ ostream & operator <<(ostream & os,const AString & s)
 
 istream & operator >>(istream & is,AString & s)
 {
-	char * buf = new char[256];
+	string buf;
 	is >> buf;
-	s.len = strlen(buf);
+	s.len = strlen(buf.c_str());
 	s.str = new char[s.len + 1];
-	strcpy(s.str,buf);
-	delete[] buf;
+	strcpy(s.str,buf.c_str());
 	return is;
 }
 

--- a/astring.h
+++ b/astring.h
@@ -47,9 +47,9 @@ public:
 	AString(const std::string &);
 	~AString();
 
-	int operator==(const AString &);
-	int operator==(char *);
-	int operator==(const char *);
+	int operator==(const AString &) const;
+	int operator==(char *) const;
+	int operator==(const char *) const;
 	int CheckPrefix(const AString &);
 	AString operator+(const AString &);
 	AString & operator+=(const AString &);
@@ -72,7 +72,7 @@ private:
 
 	int len;
 	char *str;
-	int isEqual(const char *);
+	int isEqual(const char *) const;
 };
 
 const std::string plural(int count, const std::string &one, const std::string &many);

--- a/events-assassination.cpp
+++ b/events-assassination.cpp
@@ -104,8 +104,8 @@ void AssassinationFact::GetEvents(std::list<Event> &events) {
     }
 
     events.push_back({
-        category: EventCategory::EVENT_ASSASSINATION,
-        score: 1,
-        text: buffer.str()
+        .category = EventCategory::EVENT_ASSASSINATION,
+        .score = 1,
+        .text = buffer.str()
     });
 }

--- a/events-battle.cpp
+++ b/events-battle.cpp
@@ -217,9 +217,9 @@ const Event cityCapture(BattleFact* fact) {
     }
 
     return {
-        category: EventCategory::EVENT_CITY_CAPTURE,
-        score: fact->location.settlementType + 2,
-        text: buffer.str()
+        .category = EventCategory::EVENT_CITY_CAPTURE,
+        .score = fact->location.settlementType + 2,
+        .text = buffer.str()
     };
 }
 
@@ -277,9 +277,9 @@ const Event monsterHunt(BattleFact* fact) {
     }
 
     return {
-        category: EventCategory::EVENT_MONSTER_HUNT,
-        score: 1,
-        text: buffer.str()
+        .category = EventCategory::EVENT_MONSTER_HUNT,
+        .score = 1,
+        .text = buffer.str()
     };
 }
 
@@ -322,9 +322,9 @@ const Event monsterAggresion(BattleFact* fact) {
     }
 
     return {
-        category: EventCategory::EVENT_MONSTER_AGGRESSION,
-        score: 1,
-        text: buffer.str()
+        .category = EventCategory::EVENT_MONSTER_AGGRESSION,
+        .score = 1,
+        .text = buffer.str()
     };
 }
 
@@ -569,9 +569,9 @@ const Event pvpBattle(BattleFact* fact) {
     if (totalFMI > 0) score += 1;
 
     return {
-        category: EventCategory::EVENT_BATTLE,
-        score: score,
-        text: buffer.str()
+        .category = EventCategory::EVENT_BATTLE,
+        .score = score,
+        .text = buffer.str()
     };
 }
 

--- a/events.cpp
+++ b/events.cpp
@@ -119,11 +119,11 @@ void populateSettlementLandmark(std::vector<Landmark> &landmarks, ARegion *reg, 
     std::string title = townType(reg->town->TownType()) + " of " + name;
 
     landmarks.push_back({
-        type: events::LandmarkType::SETTLEMENT,
-        name: name,
-        title: title,
-        distance: distance,
-        weight: 10
+        .type = events::LandmarkType::SETTLEMENT,
+        .name = name,
+        .title = title,
+        .distance = distance,
+        .weight = 10
     });
 }
 
@@ -164,11 +164,11 @@ void populateRegionLandmark(std::vector<Landmark> &landmarks, ARegion *source, A
     }
     
     landmarks.push_back({
-        type: type,
-        name: name,
-        title: title,
-        distance: distance,
-        weight: weight
+        .type = type,
+        .name = name,
+        .title = title,
+        .distance = distance,
+        .weight = weight
     });
 }
 
@@ -204,11 +204,11 @@ void populateForitifcationLandmark(std::vector<Landmark> &landmarks, ARegion *re
     std::string title = std::string(ObjectDefs[building->type].name) + " " + name;
 
     landmarks.push_back({
-        type: events::LandmarkType::FORTIFICATION,
-        name: name,
-        title: title,
-        distance: distance,
-        weight: 5
+        .type = events::LandmarkType::FORTIFICATION,
+        .name = name,
+        .title = title,
+        .distance = distance,
+        .weight = 5
     });
 }
 

--- a/game.h
+++ b/game.h
@@ -205,7 +205,7 @@ private:
 	void ModifyItemSpeed(int it, int speed);
 	void ModifyItemProductionBooster(int it, int item, int bonus);
 	void ModifyItemHitch(int it, int item, int bonus);
-	void ModifyItemProductionSkill(int it, char *sk, int lev);
+	void ModifyItemProductionSkill(int it, char const *sk, int lev);
 	void ModifyItemProductionOutput(int it, int months, int count);
 	void ModifyItemProductionInput(int it, int i, int input, int amount);
 	void ModifyItemMagicSkill(int it, char *sk, int lev);

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -143,7 +143,7 @@ void Game::WriteFactionTypeDescription(std::ostringstream& buffer, Faction &fac)
 		}
 
 		if (key == F_WAR) {
-			buffer << "tax " + nw << " " << plural(nw, "region", "regions");
+			buffer << "tax " << nw << " " << plural(nw, "region", "regions");
 		}
 
 		if (key == F_TRADE) {

--- a/i_rand.cpp
+++ b/i_rand.cpp
@@ -44,99 +44,146 @@ MODIFIED:
 #include "i_rand.h"
 #endif
 
-
-#define ind(mm,x)	(*(ub4 *)((ub1 *)(mm) + ((x) & ((RANDSIZ-1)<<2))))
-#define rngstep(mix,a,b,mm,m,m2,r,x) \
-{ \
-	x = *m; \
-	a = (a^(mix)) + *(m2++); \
-	*(m++) = y = ind(mm,x) + a + b; \
-	*(r++) = b = ind(mm,y>>RANDSIZL) + x; \
-}
+#define ind(mm, x) (*(ub4 *)((ub1 *)(mm) + ((x) & ((RANDSIZ - 1) << 2))))
+#define rngstep(mix, a, b, mm, m, m2, r, x)      \
+	{                                            \
+		x = *m;                                  \
+		a = (a ^ (mix)) + *(m2++);               \
+		*(m++) = y = ind(mm, x) + a + b;         \
+		*(r++) = b = ind(mm, y >> RANDSIZL) + x; \
+	}
 
 void isaac(randctx *ctx)
 {
-	register ub4 a,b,x,y,*m,*mm,*m2,*r,*mend;
-	mm=ctx->randmem; r=ctx->randrsl;
-	a = ctx->randa; b = ctx->randb + (++ctx->randc);
-	for (m = mm, mend = m2 = m+(RANDSIZ/2); m<mend; )
+	ub4 a, b, x, y, *m, *mm, *m2, *r, *mend;
+	mm = ctx->randmem;
+	r = ctx->randrsl;
+	a = ctx->randa;
+	b = ctx->randb + (++ctx->randc);
+	for (m = mm, mend = m2 = m + (RANDSIZ / 2); m < mend;)
 	{
-		rngstep( a<<13, a, b, mm, m, m2, r, x);
-		rngstep( a>>6 , a, b, mm, m, m2, r, x);
-		rngstep( a<<2 , a, b, mm, m, m2, r, x);
-		rngstep( a>>16, a, b, mm, m, m2, r, x);
+		rngstep(a << 13, a, b, mm, m, m2, r, x);
+		rngstep(a >> 6, a, b, mm, m, m2, r, x);
+		rngstep(a << 2, a, b, mm, m, m2, r, x);
+		rngstep(a >> 16, a, b, mm, m, m2, r, x);
 	}
-	for (m2 = mm; m2<mend; )
+	for (m2 = mm; m2 < mend;)
 	{
-		rngstep( a<<13, a, b, mm, m, m2, r, x);
-		rngstep( a>>6 , a, b, mm, m, m2, r, x);
-		rngstep( a<<2 , a, b, mm, m, m2, r, x);
-		rngstep( a>>16, a, b, mm, m, m2, r, x);
+		rngstep(a << 13, a, b, mm, m, m2, r, x);
+		rngstep(a >> 6, a, b, mm, m, m2, r, x);
+		rngstep(a << 2, a, b, mm, m, m2, r, x);
+		rngstep(a >> 16, a, b, mm, m, m2, r, x);
 	}
-	ctx->randb = b; ctx->randa = a;
+	ctx->randb = b;
+	ctx->randa = a;
 }
 
-
-#define mix(a,b,c,d,e,f,g,h) \
-{ \
-	a^=b<<11; d+=a; b+=c; \
-	b^=c>>2;  e+=b; c+=d; \
-	c^=d<<8;  f+=c; d+=e; \
-	d^=e>>16; g+=d; e+=f; \
-	e^=f<<10; h+=e; f+=g; \
-	f^=g>>4;  a+=f; g+=h; \
-	g^=h<<8;  b+=g; h+=a; \
-	h^=a>>9;  c+=h; a+=b; \
-}
+#define mix(a, b, c, d, e, f, g, h) \
+	{                               \
+		a ^= b << 11;               \
+		d += a;                     \
+		b += c;                     \
+		b ^= c >> 2;                \
+		e += b;                     \
+		c += d;                     \
+		c ^= d << 8;                \
+		f += c;                     \
+		d += e;                     \
+		d ^= e >> 16;               \
+		g += d;                     \
+		e += f;                     \
+		e ^= f << 10;               \
+		h += e;                     \
+		f += g;                     \
+		f ^= g >> 4;                \
+		a += f;                     \
+		g += h;                     \
+		g ^= h << 8;                \
+		b += g;                     \
+		h += a;                     \
+		h ^= a >> 9;                \
+		c += h;                     \
+		a += b;                     \
+	}
 
 /* if (flag==TRUE), then use the contents of randrsl[] to initialize mm[]. */
 void randinit(randctx *ctx, word flag)
 {
 	word i;
-	ub4 a,b,c,d,e,f,g,h;
-	ub4 *m,*r;
+	ub4 a, b, c, d, e, f, g, h;
+	ub4 *m, *r;
 	ctx->randa = ctx->randb = ctx->randc = 0;
-	m=ctx->randmem;
-	r=ctx->randrsl;
-	a=b=c=d=e=f=g=h=0x9e3779b9;	/* the golden ratio */
+	m = ctx->randmem;
+	r = ctx->randrsl;
+	a = b = c = d = e = f = g = h = 0x9e3779b9; /* the golden ratio */
 
-	for (i=0; i<4; ++i)		/* scramble it */
+	for (i = 0; i < 4; ++i) /* scramble it */
 	{
-		mix(a,b,c,d,e,f,g,h);
+		mix(a, b, c, d, e, f, g, h);
 	}
 
-	if (flag) 
+	if (flag)
 	{
 		/* initialize using the contents of r[] as the seed */
-		for (i=0; i<RANDSIZ; i+=8)
+		for (i = 0; i < RANDSIZ; i += 8)
 		{
-			a+=r[i  ]; b+=r[i+1]; c+=r[i+2]; d+=r[i+3];
-			e+=r[i+4]; f+=r[i+5]; g+=r[i+6]; h+=r[i+7];
-			mix(a,b,c,d,e,f,g,h);
-			m[i  ]=a; m[i+1]=b; m[i+2]=c; m[i+3]=d;
-			m[i+4]=e; m[i+5]=f; m[i+6]=g; m[i+7]=h;
+			a += r[i];
+			b += r[i + 1];
+			c += r[i + 2];
+			d += r[i + 3];
+			e += r[i + 4];
+			f += r[i + 5];
+			g += r[i + 6];
+			h += r[i + 7];
+			mix(a, b, c, d, e, f, g, h);
+			m[i] = a;
+			m[i + 1] = b;
+			m[i + 2] = c;
+			m[i + 3] = d;
+			m[i + 4] = e;
+			m[i + 5] = f;
+			m[i + 6] = g;
+			m[i + 7] = h;
 		}
 		/* do a second pass to make all of the seed affect all of m */
-		for (i=0; i<RANDSIZ; i+=8)
+		for (i = 0; i < RANDSIZ; i += 8)
 		{
-			a+=m[i  ]; b+=m[i+1]; c+=m[i+2]; d+=m[i+3];
-			e+=m[i+4]; f+=m[i+5]; g+=m[i+6]; h+=m[i+7];
-			mix(a,b,c,d,e,f,g,h);
-			m[i  ]=a; m[i+1]=b; m[i+2]=c; m[i+3]=d;
-			m[i+4]=e; m[i+5]=f; m[i+6]=g; m[i+7]=h;
+			a += m[i];
+			b += m[i + 1];
+			c += m[i + 2];
+			d += m[i + 3];
+			e += m[i + 4];
+			f += m[i + 5];
+			g += m[i + 6];
+			h += m[i + 7];
+			mix(a, b, c, d, e, f, g, h);
+			m[i] = a;
+			m[i + 1] = b;
+			m[i + 2] = c;
+			m[i + 3] = d;
+			m[i + 4] = e;
+			m[i + 5] = f;
+			m[i + 6] = g;
+			m[i + 7] = h;
 		}
 	}
 	else
 	{
 		/* fill in mm[] with messy stuff */
-		for (i=0; i<RANDSIZ; i+=8)
+		for (i = 0; i < RANDSIZ; i += 8)
 		{
-			mix(a,b,c,d,e,f,g,h);
-			m[i  ]=a; m[i+1]=b; m[i+2]=c; m[i+3]=d;
-			m[i+4]=e; m[i+5]=f; m[i+6]=g; m[i+7]=h;
+			mix(a, b, c, d, e, f, g, h);
+			m[i] = a;
+			m[i + 1] = b;
+			m[i + 2] = c;
+			m[i + 3] = d;
+			m[i + 4] = e;
+			m[i + 5] = f;
+			m[i + 6] = g;
+			m[i + 7] = h;
 		}
 	}
 
-	isaac(ctx);		/* fill in the first set of results */
-	ctx->randcnt=RANDSIZ;	/* prepare to use the first set of results */
+	isaac(ctx);				/* fill in the first set of results */
+	ctx->randcnt = RANDSIZ; /* prepare to use the first set of results */
 }

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -101,9 +101,10 @@ int ARegion::TerrainFactor(int value, int average)
 {
 	int retval = 0;
 	int df = abs(value-average);
-	if (df > 9)
-		if (df < 15) retval = 1;
-			else retval = df - 14;
+	if (df > 9) {
+		if (df < 15) retval = 1; 
+		else retval = df - 14;
+	}
 	return retval;
 }
 
@@ -1702,7 +1703,6 @@ void GeoMap::Generate(int spread, int smoothness)
 	while (step > 1) {
 		count++;
 		int nextstep = step/2 + step%2;
-		int showfirst = 1;
 		for (int x = 0; x <= size; x += step) {
 			for (int y = 0; y <= size; y += step) {
 				int av_ele = 0;
@@ -1773,7 +1773,6 @@ void GeoMap::Generate(int spread, int smoothness)
 			}
 		}
 		Adot();
-		showfirst = 1;
 		for (int x = 0; x <= size; x += step) {
 			for (int y = 0; y <= size; y += step) {
 				for (int i = 0; i < 2; i++) {

--- a/mapgen.cpp
+++ b/mapgen.cpp
@@ -54,52 +54,52 @@ const int MAX_RAINFALL = 1000;
 
 const std::vector<Biome> BIOMES = {
     // -10
-    { name: B_TUNDRA,                     feritality: 0.6, temp: { -1000,    0 }, rainfall: {   0,  200 } },
-    { name: B_DESERT,                     feritality: 1.2, temp: { -1000,    0 }, rainfall: { 201,  300 } },
-    { name: B_PLAINS,                     feritality: 0.6, temp: { -1000,    0 }, rainfall: { 301,  500 } },
-    { name: B_FOREST,                     feritality: 0.6, temp: { -1000,    0 }, rainfall: { 501, 1000 } },
+    { .name = B_TUNDRA, .feritality = 0.6, .temp = { -1000,    0 }, .rainfall = {   0,  200 } },
+    { .name = B_DESERT, .feritality = 1.2, .temp = { -1000,    0 }, .rainfall = { 201,  300 } },
+    { .name = B_PLAINS, .feritality = 0.6, .temp = { -1000,    0 }, .rainfall = { 301,  500 } },
+    { .name = B_FOREST, .feritality = 0.6, .temp = { -1000,    0 }, .rainfall = { 501, 1000 } },
 
     // 0
-    { name: B_TUNDRA,                     feritality: 0.8, temp: {     1,   10 }, rainfall: {   0,  100 } },
-    { name: B_DESERT,                     feritality: 1.2, temp: {     1,   30 }, rainfall: { 101,  200 } },
-    { name: B_PLAINS,                     feritality: 1.0, temp: {     1,   10 }, rainfall: { 201,  400 } },
-    { name: B_FOREST,                     feritality: 1.2, temp: {     1,   10 }, rainfall: { 401, 1000 } },
+    { .name = B_TUNDRA, .feritality = 0.8, .temp = {     1,   10 }, .rainfall = {   0,  100 } },
+    { .name = B_DESERT, .feritality = 1.2, .temp = {     1,   30 }, .rainfall = { 101,  200 } },
+    { .name = B_PLAINS, .feritality = 1.0, .temp = {     1,   10 }, .rainfall = { 201,  400 } },
+    { .name = B_FOREST, .feritality = 1.2, .temp = {     1,   10 }, .rainfall = { 401, 1000 } },
 
     // 10
-    { name: B_DESERT,                     feritality: 1.2, temp: {    11,   30 }, rainfall: {   0,  200 } },
-    { name: B_PLAINS,                     feritality: 1.0, temp: {    11,   20 }, rainfall: { 201,  300 } },
-    { name: B_FOREST,                     feritality: 1.0, temp: {    11,   20 }, rainfall: { 301,  500 } },
-    { name: B_SWAMP,                      feritality: 1.0, temp: {    11,   20 }, rainfall: { 501, 1000 } },
+    { .name = B_DESERT, .feritality = 1.2, .temp = {    11,   30 }, .rainfall = {   0,  200 } },
+    { .name = B_PLAINS, .feritality = 1.0, .temp = {    11,   20 }, .rainfall = { 201,  300 } },
+    { .name = B_FOREST, .feritality = 1.0, .temp = {    11,   20 }, .rainfall = { 301,  500 } },
+    { .name = B_SWAMP,  .feritality = 1.0, .temp = {    11,   20 }, .rainfall = { 501, 1000 } },
 
     // 20
-    { name: B_DESERT,                     feritality: 1.2, temp: {    21,   30 }, rainfall: {   0,  100 } },
-    { name: B_PLAINS,                     feritality: 1.0, temp: {    21,   30 }, rainfall: { 101,  200 } },
-    { name: B_FOREST,                     feritality: 1.2, temp: {    21,   30 }, rainfall: { 201,  400 } },
-    { name: B_JUNGLE,                     feritality: 0.8, temp: {    21,   30 }, rainfall: { 401,  500 } },
-    { name: B_SWAMP,                      feritality: 0.8, temp: {    21,   30 }, rainfall: { 501, 1000 } },
+    { .name = B_DESERT, .feritality = 1.2, .temp = {    21,   30 }, .rainfall = {   0,  100 } },
+    { .name = B_PLAINS, .feritality = 1.0, .temp = {    21,   30 }, .rainfall = { 101,  200 } },
+    { .name = B_FOREST, .feritality = 1.2, .temp = {    21,   30 }, .rainfall = { 201,  400 } },
+    { .name = B_JUNGLE, .feritality = 0.8, .temp = {    21,   30 }, .rainfall = { 401,  500 } },
+    { .name = B_SWAMP,  .feritality = 0.8, .temp = {    21,   30 }, .rainfall = { 501, 1000 } },
 
     // 30
-    { name: B_DESERT,                     feritality: 1.0, temp: {    31,   40 }, rainfall: {   0,  100 } },
-    { name: B_PLAINS,                     feritality: 1.2, temp: {    31,   40 }, rainfall: { 101,  300 } },
-    { name: B_FOREST,                     feritality: 1.2, temp: {    31,   40 }, rainfall: { 301,  400 } },
-    { name: B_JUNGLE,                     feritality: 1.0, temp: {    31,   40 }, rainfall: { 401,  600 } },
-    { name: B_SWAMP,                      feritality: 0.8, temp: {    31,   40 }, rainfall: { 601, 1000 } },
+    { .name = B_DESERT, .feritality = 1.0, .temp = {    31,   40 }, .rainfall = {   0,  100 } },
+    { .name = B_PLAINS, .feritality = 1.2, .temp = {    31,   40 }, .rainfall = { 101,  300 } },
+    { .name = B_FOREST, .feritality = 1.2, .temp = {    31,   40 }, .rainfall = { 301,  400 } },
+    { .name = B_JUNGLE, .feritality = 1.0, .temp = {    31,   40 }, .rainfall = { 401,  600 } },
+    { .name = B_SWAMP,  .feritality = 0.8, .temp = {    31,   40 }, .rainfall = { 601, 1000 } },
 
     // 40
-    { name: B_DESERT,                     feritality: 1.0, temp: {    41,   50 }, rainfall: {   0,  200 } },
-    { name: B_PLAINS,                     feritality: 1.2, temp: {    41,   50 }, rainfall: { 201,  300 } },
-    { name: B_FOREST,                     feritality: 1.2, temp: {    41,   50 }, rainfall: { 301,  400 } },
-    { name: B_JUNGLE,                     feritality: 1.0, temp: {    41,   50 }, rainfall: { 401, 1000 } },
+    { .name = B_DESERT, .feritality = 1.0, .temp = {    41,   50 }, .rainfall = {   0,  200 } },
+    { .name = B_PLAINS, .feritality = 1.2, .temp = {    41,   50 }, .rainfall = { 201,  300 } },
+    { .name = B_FOREST, .feritality = 1.2, .temp = {    41,   50 }, .rainfall = { 301,  400 } },
+    { .name = B_JUNGLE, .feritality = 1.0, .temp = {    41,   50 }, .rainfall = { 401, 1000 } },
 
     // 50
-    { name: B_DESERT,                     feritality: 1.0, temp: {    51,   60 }, rainfall: {   0,  300 } },
-    { name: B_PLAINS,                     feritality: 1.2, temp: {    51,   60 }, rainfall: { 301,  400 } },
-    { name: B_JUNGLE,                     feritality: 1.0, temp: {    51,   60 }, rainfall: { 401, 1000 } },
+    { .name = B_DESERT, .feritality = 1.0, .temp = {    51,   60 }, .rainfall = {   0,  300 } },
+    { .name = B_PLAINS, .feritality = 1.2, .temp = {    51,   60 }, .rainfall = { 301,  400 } },
+    { .name = B_JUNGLE, .feritality = 1.0, .temp = {    51,   60 }, .rainfall = { 401, 1000 } },
 
     // 60
-    { name: B_DESERT,                     feritality: 1.0, temp: {    61, 1000 }, rainfall: {   0,  400 } },
-    { name: B_PLAINS,                     feritality: 1.2, temp: {    61, 1000 }, rainfall: { 401,  500 } },
-    { name: B_JUNGLE,                     feritality: 1.0, temp: {    61, 1000 }, rainfall: { 501, 1000 } },
+    { .name = B_DESERT, .feritality = 1.0, .temp = {    61, 1000 }, .rainfall = {   0,  400 } },
+    { .name = B_PLAINS, .feritality = 1.2, .temp = {    61, 1000 }, .rainfall = { 401,  500 } },
+    { .name = B_JUNGLE, .feritality = 1.0, .temp = {    61, 1000 }, .rainfall = { 501, 1000 } },
 };
 
 bool Range::in(const int value) const {
@@ -167,15 +167,15 @@ CellMap::CellMap(int width, int height) {
         coords(i, x, y);
 
         items.push_back(new Cell({
-            index: i,
-            x: x,
-            y: y,
-            biome: B_UNKNOWN,
-            elevation: 0,
-            temperature: 0,
-            saturation: 0,
-            evoparation: 0,
-            rainfall: 0,
+            .index = i,
+            .x = x,
+            .y = y,
+            .biome = B_UNKNOWN,
+            .elevation = 0,
+            .temperature = 0,
+            .saturation = 0,
+            .evoparation = 0,
+            .rainfall = 0,
         }));
     }
 }
@@ -305,7 +305,6 @@ const Edge WIND[MOISTURE_SOURCES] = {
     {  1,  1, 0.05 }
 };
 
-const double SEA_EVOPARATION = 0.8;
 const double RAINFALL = 0.1;
 
 //                  | rainfall

--- a/mapgen.cpp
+++ b/mapgen.cpp
@@ -316,7 +316,6 @@ const double RAINFALL = 0.1;
 // altitude down    | decrease
 
 void simulateRain(CellMap& map, Cell* target, double windAngle, const Edge* windMatrix) {
-    bool isWater = target->biome == B_WATER;
     int x = target->x;
     int y = target->y;
 

--- a/modify.cpp
+++ b/modify.cpp
@@ -162,7 +162,7 @@ void Game::ModifyItemHitch(int it, int item, int capacity)
 	ItemDefs[it].hitchwalk = capacity;
 }
 
-void Game::ModifyItemProductionSkill(int it, char *sk, int lev)
+void Game::ModifyItemProductionSkill(int it, char const *sk, int lev)
 {
 	if (it < 0 || it > (NITEMS-1)) return;
 	if (sk && (FindSkill(sk) == NULL)) return;

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -406,14 +406,13 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 Faction *Game::CheckVictory()
 {
 	int visited, unvisited;
-	int d, i, count, reliccount;
+	int d, i, count;
 	int dir;
 	unsigned ucount;
 	Quest *q;
 	ARegion *r, *start;
 	Object *o;
 	Unit *u;
-	Faction *f;
 	Location *l;
 	AString message, times, temp, filename;
 	Arules wf;

--- a/neworigins/map.cpp
+++ b/neworigins/map.cpp
@@ -32,6 +32,7 @@
 #include <list>
 #include <unordered_set>
 #include <stack>
+#include <random>
 
 enum ZoneType {
 	UNDECIDED,	// zone type not yet determined
@@ -260,8 +261,8 @@ Coords Province::GetLocation() {
 	}
 
 	return {
-		x: xMin + (xMax - xMin + 1) / 2,
-		y: yMin + (yMax - yMin + 1) / 2
+		.x = xMin + (xMax - xMin + 1) / 2,
+		.y = yMin + (yMax - yMin + 1) / 2
 	};
 }
 
@@ -698,8 +699,8 @@ void MapBuilder::CreateZones(int minDistance, int maxAtempts) {
 	int attempts = 0;
 	while (this->zones.size() < this->maxZones && attempts++ < maxAtempts) {
 		Coords location = {
-			x: getrandom(this->w),
-			y: getrandom(this->h)
+			.x = getrandom(this->w),
+			.y = getrandom(this->h)
 		};
 
 		if ((location.x + location.y) % 2) continue;
@@ -1058,7 +1059,12 @@ void MapBuilder::SpecializeZones(size_t continents, int continentAreaFraction) {
 
 	Awrite("Grow oceans");
 	int oceanCores = std::max(1, (int) oceans.size() / 4);
-	std::random_shuffle(oceans.begin(), oceans.end());
+
+	// C++17 and up require different handling for shuffle
+	std::random_device rd;
+	std::mt19937 g(rd());
+	std::shuffle(oceans.begin(), oceans.end(), g);
+
 	oceans.resize(oceanCores);
 	for (auto &zone : oceans) {
 		zone->type = ZoneType::OCEAN;

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -368,8 +368,8 @@ void Game::ParseOrders(int faction, Aorders *f, OrdersCheck *pCheck)
 
 						if (unit->inTurnBlock)
 							ParseError(pCheck, unit, fac, "TURN: without ENDTURN");
-							if (!pCheck && unit->former && unit->former->format)
-								unit->former->oldorders.Add(new AString(saveorder));
+						if (!pCheck && unit->former && unit->former->format)
+							unit->former->oldorders.Add(new AString(saveorder));
 						if (pCheck && former) delete unit;
 						unit = former;
 					} else {
@@ -1202,7 +1202,6 @@ void Game::ProcessFactionOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	std::unordered_map<std::string, int> oldfactype;
 	std::unordered_map<std::string, int> factype;
 
-	int i;
 	if (!pCheck) {
 		// copy current values into temp variable
 		oldfactype = u->faction->type;

--- a/spells.cpp
+++ b/spells.cpp
@@ -2014,11 +2014,10 @@ int Game::RunTransmutation(ARegion *r, Unit *u)
 
 int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 {
-	int level, num, sactype, sacrifices, i, sac, max, dir, relics;
+	int level, num, sactype, sacrifices, i, sac, relics;
 	Object *o, *tower;
 	Unit *u, *victim;
 	Item *item;
-	ARegion *start;
 	AString message;
 
 	level = mage->GetSkill(S_BLASPHEMOUS_RITUAL);

--- a/unit.cpp
+++ b/unit.cpp
@@ -713,7 +713,7 @@ void Unit::ClearCastOrders()
 
 void Unit::DefaultOrders(Object *obj)
 {
-	int count, weight, i;
+	int weight, i;
 	ARegion *r, *n;
 
 	ClearOrders();
@@ -2253,13 +2253,15 @@ int Unit::Taxers(int numtaxers)
 	if (taxers > totalMen) taxers = totalMen;
 
 	// And finally for creatures
-	if (Globals->WHO_CAN_TAX & GameDefs::TAX_CREATURES)
+	if (Globals->WHO_CAN_TAX & GameDefs::TAX_CREATURES) {
 		basetax += creatures;
 		taxers += creatures;
+	}
 
-	if (Globals->WHO_CAN_TAX & GameDefs::TAX_ILLUSIONS)
+	if (Globals->WHO_CAN_TAX & GameDefs::TAX_ILLUSIONS) {
 		basetax += illusions;
 		taxers += illusions;
+	}
 	
 	if (numtaxers) return(taxers);
 


### PR DESCRIPTION
Also, removed all warnings to make compile clean.

Primarily this consisted of fixing type comparisons between int and size_t types. There were a couple of cases where missing braces led to warnings for ifs, including at least one that I suspect was a latent bug should the options have ever been enabled.

Lastly there was a change in the std istream that required a simple change in Astring.cpp to avoid an issue when moving from C++17 to C++20.

CLang on macOS was even pickier and complained about some things that g++ didn't.  Fixed those warnings too.
This included an error where the std::shuffle_random() was removed (as of C++17) and replaced with a more deterministic
and higher quality rng alternative but explicit rather than implicit.