### PR TITLE
Checks orders checks password, too.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -136,7 +136,16 @@ int main(int argc, char *argv[])
 				break;
 			}
 
-			game.DummyGame();
+			if ( !game.OpenGame() ) {
+				Awrite( "Couldn't open the game file!" );
+				break;
+			}
+
+			if ( !game.ReadPlayers() ) {
+				Awrite( "Couldn't read the players file!" );
+				break;
+			}
+
 			if ( !game.DoOrdersCheck( argv[ 2 ], argv[ 3 ] )) {
 				Awrite( "Couldn't check the orders!" );
 				break;

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -155,30 +155,36 @@ UnitId *Game::ParseUnit(AString *s)
 	}
 }
 
-int ParseFactionType(AString *o, int *type)
+int ParseFactionType(AString *o, std::unordered_map<std::string, int> &type)
 {
-	int i;
-	for (i=0; i<NFACTYPES; i++) type[i] = 0;
+	for (auto &ft : *FactionTypes) {
+		type[ft] = 0;
+	}
 
 	AString *token = o->gettoken();
 	if (!token) return -1;
 
 	if (*token == "generic") {
 		delete token;
-		for (i=0; i<NFACTYPES; i++) type[i] = 1;
+
+		for (auto &ft : *FactionTypes) {
+			type[ft] = 1;
+		}
+
 		return 0;
 	}
 
 	while(token) {
-		int foundone = 0;
-		for (i=0; i<NFACTYPES; i++) {
-			if (*token == FactionStrs[i]) {
+		bool foundone = false;
+		
+		for (auto &ft : *FactionTypes) {
+			if (*token == ft.c_str()) {
 				delete token;
 				token = o->gettoken();
 				if (!token) return -1;
-				type[i] = token->value();
+				type[ft] = token->value();
 				delete token;
-				foundone = 1;
+				foundone = true;
 				break;
 			}
 		}
@@ -190,8 +196,8 @@ int ParseFactionType(AString *o, int *type)
 	}
 
 	int tot = 0;
-	for (i=0; i<NFACTYPES; i++) {
-		tot += type[i];
+	for (auto &kv : type) {
+		tot += kv.second;
 	}
 	if (tot > Globals->FACTION_POINTS) return -1;
 
@@ -236,6 +242,8 @@ void Game::ParseOrders(int faction, Aorders *f, OrdersCheck *pCheck)
 					fac = 0;
 					break;
 				}
+                                Faction *truefac; // used only to check password
+                                truefac = GetFaction(&factions, token->value());
 				if (pCheck) {
 					fac = &(pCheck->dummyFaction);
 					pCheck->numshows = 0;
@@ -256,6 +264,9 @@ void Game::ParseOrders(int faction, Aorders *f, OrdersCheck *pCheck)
 								"If this is your first turn, ignore this "
 								"error.");
 					}
+                                        if (!(*(truefac->password) == "none") && (!token || !(*(truefac->password) == *token))) {
+                                            ParseError(pCheck, 0, fac, "Incorrect password on #atlantis line.");
+                                        } // truefac is never again used
 				} else {
 					if (!(*(fac->password) == "none")) {
 						if (!token || !(*(fac->password) == *token)) {
@@ -1193,14 +1204,13 @@ void Game::ProcessFactionOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 		return;
 	}
 
-	int oldfactype[NFACTYPES];
-	int factype[NFACTYPES];
+	std::unordered_map<std::string, int> oldfactype;
+	std::unordered_map<std::string, int> factype;
 
 	int i;
 	if (!pCheck) {
-		for (i = 0; i < NFACTYPES; i++) {
-			oldfactype[i] = u->faction->type[i];
-		}
+		// copy current values into temp variable
+		oldfactype = u->faction->type;
 	}
 
 	int retval = ParseFactionType(o, factype);
@@ -1213,14 +1223,13 @@ void Game::ProcessFactionOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 		int m = CountMages(u->faction);
 		int a = CountApprentices(u->faction);
 
-		for (i = 0; i < NFACTYPES; i++) u->faction->type[i] = factype[i];
+		u->faction->type = factype;
 
 		if (m > AllowedMages(u->faction)) {
 			u->Error(AString("FACTION: Too many mages to change to that "
 							 "faction type."));
 
-			for (i = 0; i < NFACTYPES; i++)
-				u->faction->type[i] = oldfactype[i];
+			u->faction->type = oldfactype;
 
 			return;
 		}
@@ -1231,8 +1240,7 @@ void Game::ProcessFactionOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 				"s to change to that "
 				 "faction type.");
 
-			for (i = 0; i < NFACTYPES; i++)
-				u->faction->type[i] = oldfactype[i];
+			u->faction->type = oldfactype;
 
 			return;
 		}
@@ -1244,8 +1252,7 @@ void Game::ProcessFactionOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 				u->Error(AString("FACTION: Too many quartermasters to "
 							"change to that faction type."));
 
-				for (i = 0; i < NFACTYPES; i++)
-					u->faction->type[i] = oldfactype[i];
+				u->faction->type = oldfactype;
 
 				return;
 			}
@@ -1373,6 +1380,10 @@ void Game::ProcessDestroyOrder(Unit *u, OrdersCheck *pCheck)
 void Game::ProcessFindOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 {
 	AString *token = o->gettoken();
+	if (!Globals->HAVE_EMAIL_SPECIAL_COMMANDS) {
+		ParseError(pCheck, u, 0, "FIND: This command was disabled.");
+		return;
+	}
 	if (!token) {
 		ParseError(pCheck, u, 0, "FIND: No faction number given.");
 		return;
@@ -1540,7 +1551,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 {
 	AString * token = o->gettoken();
 	BuildOrder * order = new BuildOrder;
-	int maxbuild, i;
+	int maxbuild;
 
 	// 'incomplete' for ships:
 	maxbuild = 0;
@@ -1615,22 +1626,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 						ParseError(pCheck, unit, 0, "BUILD: Can't build that.");
 						return;
 					}
-					for (i = 1; i < 100; i++)
-						if (!reg->GetObject(i))
-							break;
-					if (i < 100) {
-						Object * obj = new Object(reg);
-						obj->type = ot;
-						obj->incomplete = ObjectDefs[obj->type].cost;
-						obj->num = i;
-						obj->SetName(new AString("Building"));
-						unit->build = obj->num;
-						unit->object->region->objects.Add(obj);
-						unit->MoveUnit(obj);
-					} else {
-						unit->Error("BUILD: The region is full.");
-						return;
-					}
+					order->new_building = ot;
 				}
 			}
 			order->target = NULL; // Not helping anyone...
@@ -1793,18 +1789,26 @@ void Game::ProcessProduceOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 		ParseError(pCheck, u, 0, "PRODUCE: No item given.");
 		return;
 	}
-	int it = ParseEnabledItem(token);
+	const int it = ParseEnabledItem(token);
 	delete token;
+
+	if (it == -1) {
+		ParseError(pCheck, u, 0, "PRODUCE: Invalid item.");
+		return;
+	}
+	const ItemType &item_def = ItemDefs[it];
+
+	if (item_def.type == IT_SHIP ) {
+		ParseError(pCheck, u, 0, "PRODUCE: Use BUILD for ships.");
+		return;
+	}
 
 	ProduceOrder *p = new ProduceOrder;
 	p->item = it;
-	if (it != -1) {
-		AString skname = ItemDefs[it].pSkill;
-		p->skill = LookupSkill(&skname);
-	} else {
-		p->skill = -1;
-	}
+	AString skname = item_def.pSkill;
+	p->skill = LookupSkill(&skname);
 	p->target = target;
+
 	if (u->monthorders ||
 		(Globals->TAX_PILLAGE_MONTH_LONG &&
 		 ((u->taxing == TAX_TAX) || (u->taxing == TAX_PILLAGE)))) {
@@ -1922,7 +1926,11 @@ void Game::ProcessDeclareOrder(Faction *f, AString *o, OrdersCheck *pCheck)
 	if (*token == "default") {
 		fac = -1;
 	} else {
-		fac = token->value();
+		fac = token->strict_value();
+		if (fac == -1) {
+			f->Error(AString("DECLARE: Non-existent faction."));
+			return;
+		}
 	}
 	delete token;
 
@@ -3055,12 +3063,14 @@ void Game::ProcessDistributeOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 		ParseError(pCheck, u, 0, "DISTRIBUTE: No item given.");
 		return;
 	}
+
 	int item = ParseTransportableItem(token);
-	delete token;
 	if (item == -1) {
-		ParseError(pCheck, u, 0, "DISTRIBUTE: Invalid item.");
+		ParseError(pCheck, u, 0, AString("DISTRIBUTE: Invalid item ") + AString(*token) + ".");
+		delete token;
 		return;
 	}
+	delete token;
 
 	int except = 0;
 	token = o->gettoken();


### PR DESCRIPTION
This reads game.in and players.in to get the passwords from players.in.

A test in a local game ran as shown below.  The local game contained game.in, players.in, and orders.3.  Players.in had a password for faction 3 of "mypassword".  Orders.3 specified a password of "notmypassword".  The orders checker detects the error.  When the password in orders.3 is changed to "mypassword", the orders checker reports no errors.

L$ ls
game.in  orders.3  players.in
L$ grep -A2 'Faction (3)' players.in 
Name: Faction (3)
Email: NoAddress
Password: mypassword
L$ cat orders.3
#atlantis 3 "notmypassword"
#end
L$ ../../Atlantis/neworigins/neworigins check orders.3 check.out && cat check.out
Atlantis Engine Version: 5.2.5 (beta)
NewOrigins, Version: 3.0.0 (beta)

Saved Game Engine Version: 5.2.5 (beta)
Saved Rule-Set Version: 3.0.0 (beta)
Reading the regions...
Setting up the neighbors...


*** Error: Incorrect password on #atlantis line. ***
#atlantis 3 "notmypassword"
#end

1 error found!
L$ sed -i s/notmypassword/mypassword/ orders.3
You have new mail in /var/mail/stan
L$ ../../Atlantis/neworigins/neworigins check orders.3 check.out && cat check.out
Atlantis Engine Version: 5.2.5 (beta)
NewOrigins, Version: 3.0.0 (beta)

Saved Game Engine Version: 5.2.5 (beta)
Saved Rule-Set Version: 3.0.0 (beta)
Reading the regions...
Setting up the neighbors...
#atlantis 3 "mypassword"
#end

No errors found.
L$ 
