### PR TITLE
Allow @endturn on input orders

### DIFF
--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -2042,6 +2042,8 @@ AString *Game::ProcessTurnOrder(Unit *unit, Aorders *f, OrdersCheck *pCheck,
 			order = new AString("#end");
 		}
 		AString	saveorder = *order;
+		// In order to allow @endturn to work the same as endturn we need to check for and eat the possible @
+		int getatsign = order->getat();
 		token = order->gettoken();
 
 		if (token) {


### PR DESCRIPTION
This allows the following structure
@turn
    <some orders>
@endturn

to not end up screwing up and thinking you failed to end your orders.   The checker and ALH already thought this was
fine.  This just brings the game-processing in-line.