### PR TITLE
Update workflow runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - neworigins
+      - neworigins-v6
+      - jt-*
   workflow_dispatch:
   pull_request:
 


### PR DESCRIPTION
Update the workflow runner to run on the current neworigins-v6 branch. Also have it run on any jt-* branches which I use for local feature testing (I don't necessarily like pushing that last bit into master but I figure I am likely the only one who cares)