### PR TITLE
Fix Landmark ordering for events

### DIFF
--- a/events.cpp
+++ b/events.cpp
@@ -123,7 +123,10 @@ void populateSettlementLandmark(std::vector<Landmark> &landmarks, ARegion *reg, 
         .name = name,
         .title = title,
         .distance = distance,
-        .weight = 10
+        .weight = 10,
+        .x = reg->xloc,
+        .y = reg->yloc,
+        .z = reg->zloc
     });
 }
 
@@ -168,7 +171,10 @@ void populateRegionLandmark(std::vector<Landmark> &landmarks, ARegion *source, A
         .name = name,
         .title = title,
         .distance = distance,
-        .weight = weight
+        .weight = weight,
+        .x = reg->xloc,
+        .y = reg->yloc,
+        .z = reg->zloc
     });
 }
 
@@ -208,14 +214,33 @@ void populateForitifcationLandmark(std::vector<Landmark> &landmarks, ARegion *re
         .name = name,
         .title = title,
         .distance = distance,
-        .weight = 5
+        .weight = 5,
+        .x = reg->xloc,
+        .y = reg->yloc,
+        .z = reg->zloc
     });
 }
 
 bool compareLandmarks(const Landmark &first, const Landmark &second) {
-    return first.weight == second.weight
-        ? first.distance < second.distance
-        : first.weight < second.weight;
+    // Making this a bit more explicit since if you end up with 2 equidistant, equal weight landmarks, then
+    // it will be arbitary which landmark is chosen based on the initial ordering in the vector being sorted,
+    // which is based solely on an *unordered* map, which means the ordering is not guaranteed to be the same
+    // across runs even with identical input since it's based on memory layout on the executing machine.
+
+    // prefer shorter distances.
+    if (first.distance != second.distance) {
+        return first.distance < second.distance;
+    }
+    // prefer more weighty locales (citys > fortifications > volcano/river > other terrains)
+    if (first.weight != second.weight) {
+        return first.weight > second.weight;
+    }
+    // if everything else is equal, prefer one with the lower x coordinate
+    if (first.x != second.x) {
+        return first.x < second.x;
+    }
+    // If they are *still* equal, prefer the smaller y coordinate
+    return first.y < second.y;
 }
 
 const EventLocation EventLocation::Create(ARegion* region) {

--- a/events.h
+++ b/events.h
@@ -120,7 +120,12 @@ struct Landmark {
     std::string title;
     int distance;
     int weight;
+    int x;
+    int y;
+    int z;
 };
+
+bool compareLandmarks(const Landmark &a, const Landmark &b);
 
 struct EventLocation {
     int x;

--- a/snapshot-tests/neworigins_turns/turn_13/times.5664
+++ b/snapshot-tests/neworigins_turns/turn_13/times.5664
@@ -4,9 +4,9 @@
 (                             NewOrigins Events                             )
  )                            February, Year 2                             (
 (                                                                           )
- )      In the ocean of Great Nena River, near forests of Aoratalotos      (
-(         Forest, Pirates (41) who continue to cause fear to local          )
- )                              inhabitants.                               (
+ )     In the ocean of Great Nena River, near city of Epikataralotos,      (
+(       Pirates (41) who continue to cause fear to local inhabitants.       )
+ )                                                                         (
 (__       _       _       _       _       _       _       _       _       __)
     '-._.-' (___ _) '-._.-' '-._.-' )     ( '-._.-' '-._.-' (__ _ ) '-._.-'
             ( _ __)                (_     _)                (_ ___)

--- a/unittest/landmark_order_test.cpp
+++ b/unittest/landmark_order_test.cpp
@@ -1,0 +1,72 @@
+#include "external/boost/ut.hpp"
+
+#include "game.h"
+#include "gamedata.h"
+#include "events.h"
+
+// Because boost::ut has it's own concept of events, as does Game, we cannot just use do
+// using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
+// closure to make the user defined literals and all the other niceness available.
+namespace ut = boost::ut;
+namespace ev = events; // these are the events from events.h
+
+// This suite will test various aspects of the Faction class in isolation.
+ut::suite<"Landmark Order"> landmark_order_suite = []
+{
+  using namespace ut;
+
+  Landmark landmark1 = {
+    .type = ev::SETTLEMENT,
+    .name = "Settlement 1",
+    .title = "Settlement 1",
+    .distance = 1,
+    .weight = 1,
+    .x = 1,
+    .y = 1,
+    .z = 1
+  };
+
+  Landmark landmark2 = {
+    .type = ev::SETTLEMENT,
+    .name = "Settlement 2",
+    .title = "Settlement 2",
+    .distance = 2,
+    .weight = 1,
+    .x = 1,
+    .y = 1,
+    .z = 1
+  };
+
+  "Landmarks prefer shortest distance"_test = [landmark1, landmark2]
+  {
+    expect(eq(compareLandmarks(landmark1, landmark2), true));
+    expect(eq(compareLandmarks(landmark2, landmark1), false));
+  };
+
+  "When distance is equal, landmarks prefer higher weight"_test = [landmark1, landmark2]() mutable
+  {
+    landmark2.distance = 1;
+    landmark2.weight = 2;
+    expect(eq(compareLandmarks(landmark1, landmark2), false));
+    expect(eq(compareLandmarks(landmark2, landmark1), true));
+  };
+
+  "When distance and weight are equal, landmarks prefer lower x"_test = [landmark1, landmark2]() mutable
+  {
+    landmark2.distance = 1;
+    landmark2.weight = 1;
+    landmark2.x = 2;
+    expect(eq(compareLandmarks(landmark1, landmark2), true));
+    expect(eq(compareLandmarks(landmark2, landmark1), false));
+  };
+
+  "When distance, weight, and x are equal, landmarks prefer lower y"_test = [landmark1, landmark2]() mutable
+  {
+    landmark2.distance = 1;
+    landmark2.weight = 1;
+    landmark2.x = 1;
+    landmark2.y = 2;
+    expect(eq(compareLandmarks(landmark1, landmark2), true));
+    expect(eq(compareLandmarks(landmark2, landmark1), false));
+  };
+};


### PR DESCRIPTION
The intent of the code was that weighter landmarks (settlments) would
take preference over fortifications, etc.   This test was backwards.
However, it was also possible that if there were two equally close
and equally weighty landmarks, the order would fluctate based solely on
how the in-memory layout of the unordered_map being used to construct
the data got laid out.   This changes this to be a stable ordering based
on distance (shorter distance), weight (higher weight), x coordinate
(westernmost preferred) and finally y coordinate (northernmost
preferred).   Exposed the comparison function to allow unit tests and
added unit tests.