### PR TITLE
Write all files (except rules)  using ostream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ ENGINE_OBJECTS = alist.o aregion.o army.o astring.o battle.o economy.o \
   genrules.o i_rand.o items.o main.o market.o modify.o monthorders.o \
   npc.o object.o orders.o parseorders.o production.o quests.o runorders.o \
   shields.o skills.o skillshows.o specials.o spells.o template.o unit.o \
-  events.o events-battle.o events-assassination.o mapgen.o simplex.o namegen.o
+  events.o events-battle.o events-assassination.o mapgen.o simplex.o namegen.o \
+  indenter.o
 
 UNITTEST_SRC = unittest/main.cpp $(wildcard unittest/*_test.cpp)
 UNITTEST_OBJECTS = $(patsubst unittest/%.cpp,unittest/obj/%.o,$(UNITTEST_SRC))

--- a/aregion.h
+++ b/aregion.h
@@ -151,8 +151,8 @@ class TownInfo
 		TownInfo();
 		~TownInfo();
 
-		void Readin(istream &f);
-		void Writeout(Aoutfile *);
+		void Readin(istream& f);
+		void Writeout(ostream& f);
 		int TownType();
 
 		AString *name;
@@ -190,20 +190,19 @@ class ARegion : public AListElem
 		void ZeroNeighbors();
 		void SetName(char const *);
 
-		void Writeout(Aoutfile *);
-		void Readin(istream &f, AList *);
+		void Writeout(ostream& f);
+		void Readin(istream& f, AList *);
 
 		int CanMakeAdv(Faction *, int);
 		int HasItem(Faction *, int);
-		void WriteProducts(Areport *, Faction *, int);
-		void WriteMarkets(Areport *, Faction *, int);
-		void WriteEconomy(Areport *, Faction *, int);
-		void WriteExits(Areport *, ARegionList *pRegs, int *exits_seen);
-		void WriteReport(Areport *f, Faction *fac, int month,
-				ARegionList *pRegions);
+		void WriteProducts(ostream& f, Faction *, int);
+		void WriteMarkets(ostream& f, Faction *, int);
+		void WriteEconomy(ostream& f, Faction *, int);
+		void WriteExits(ostream& f, ARegionList *pRegs, int *exits_seen);
+		void WriteReport(ostream& f, Faction *fac, int month, ARegionList *pRegions);
 		// DK
-		void WriteTemplate(Areport *, Faction *, ARegionList *, int);
-		void WriteTemplateHeader(Areport *, Faction *, ARegionList *, int);
+		void WriteTemplate(ostream&  f, Faction *, ARegionList *, int);
+		void WriteTemplateHeader(ostream& f, Faction *, ARegionList *, int);
 		void GetMapLine(char *, int, ARegionList *);
 
 		AString ShortPrint(ARegionList *pRegs);
@@ -454,7 +453,7 @@ class ARegionList : public AList
 		ARegion *GetRegion(int);
 		ARegion *GetRegion(int, int, int);
 		int ReadRegions(istream &f, AList *);
-		void WriteRegions(Aoutfile *f);
+		void WriteRegions(ostream&  f);
 		Location *FindUnit(int);
 		Location *GetUnitId(UnitId *id, int faction, ARegion *cur);
 

--- a/battle.cpp
+++ b/battle.cpp
@@ -742,15 +742,13 @@ void Battle::WriteSides(ARegion * r,
 	AddLine("");
 }
 
-void Battle::Report(Areport * f,Faction * fac) {
+void Battle::Report(ostream& f,Faction * fac) {
 	if (assassination == ASS_SUCC && fac != attacker) {
-		f->PutStr(*asstext);
-		f->PutStr("");
+		f << asstext->const_str() << "\n";
 		return;
 	}
 	forlist(&text) {
-		AString * s = (AString *) elem;
-		f->PutStr(*s);
+		f << ((AString *)elem)->const_str() << '\n';
 	}
 }
 

--- a/battle.h
+++ b/battle.h
@@ -61,7 +61,7 @@ class Battle : public AListElem
 		Battle();
 		~Battle();
 
-		void Report(Areport *,Faction *);
+		void Report(ostream& f,Faction *fac);
 		void AddLine(const AString &);
 
 		int Run(Events* events, ARegion *, Unit *, AList *, Unit *, AList *, int ass,

--- a/faction.h
+++ b/faction.h
@@ -108,8 +108,8 @@ class Attitude : public AListElem {
 public:
 	Attitude();
 	~Attitude();
-	void Writeout(Aoutfile * );
-	void Readin(istream &f);
+	void Writeout(ostream& f);
+	void Readin(istream& f);
 	
 	int factionnum;
 	int attitude;
@@ -132,8 +132,8 @@ public:
 	Faction(int);
 	~Faction();
 	
-	void Readin(istream &f);
-	void Writeout( Aoutfile * );
+	void Readin(istream& f);
+	void Writeout(ostream& f);
 	void View();
 	
 	void SetName(AString *);
@@ -145,10 +145,10 @@ public:
 	void Event(const AString &);
 	
 	AString FactionTypeStr();
-	void WriteReport( Areport *f, Game *pGame, int ** citems);
+	void WriteReport(ostream& f, Game *pGame, int ** citems);
 	// LLS - write order template
-	void WriteTemplate(Areport *f, Game *pGame);
-	void WriteFacInfo(Aoutfile *);
+	void WriteTemplate(ostream& f, Game *pGame);
+	void WriteFacInfo(ostream& f);
 	
 	void SetAttitude(int,int); /* faction num, attitude */
 	/* if attitude == -1, clear it */
@@ -229,7 +229,7 @@ public:
 	int noStartLeader;
 	int startturn;
 
-	void WriteFactionStats(Areport *f, Game *pGame, int ** citems);
+	void WriteFactionStats(ostream& f, Game *pGame, int ** citems);
 };
 
 Faction * GetFaction(AList *,int);

--- a/fileio.cpp
+++ b/fileio.cpp
@@ -33,26 +33,6 @@ using namespace std;
 
 extern long _ftype,_fcreator;
 
-Aoutfile::Aoutfile()
-{
-	file = new ofstream;
-}
-
-Aoutfile::~Aoutfile()
-{
-	delete file;
-}
-
-Areport::Areport()
-{
-	file = new ofstream;
-}
-
-Areport::~Areport()
-{
-	delete file;
-}
-
 Arules::Arules()
 {
 	file = new ofstream;
@@ -61,42 +41,6 @@ Arules::Arules()
 Arules::~Arules()
 {
 	delete file;
-}
-
-void Aoutfile::Open(const AString &s)
-{
-	while(!(file->rdbuf()->is_open())) {
-		AString *name = getfilename(s);
-		file->open(name->Str(), ios::out|ios::ate);
-		delete name;
-		// Handle a broke ios::ate implementation on some boxes
-		file->seekp(0, ios::end);
-		if ((int)file->tellp()!= 0) file->close();
-	}
-}
-
-int Aoutfile::OpenByName(const AString &s)
-{
-	AString temp = s;
-	file->open(temp.Str(), ios::out|ios::ate);
-	if (!file->rdbuf()->is_open()) return -1;
-	// Handle a broke ios::ate implementation on some boxes
-	file->seekp(0, ios::end);
-	if ((int)file->tellp() != 0) {
-		file->close();
-		return -1;
-	}
-	return 0;
-}
-
-void Aoutfile::Close()
-{
-	file->close();
-}
-
-void Areport::Close()
-{
-	file->close();
 }
 
 void Arules::Close()
@@ -114,94 +58,6 @@ void skipwhite(istream *f)
 		if (f->eof()) return;
 		ch = f->peek();
 	}
-}
-
-void Aoutfile::PutInt(int x)
-{
-	*file << x;
-	*file << F_ENDLINE;
-}
-
-void Aoutfile::PutStr(char const *s)
-{
-	*file << s << F_ENDLINE;
-}
-
-void Aoutfile::PutStr(const AString &s)
-{
-	*file << s << F_ENDLINE;
-}
-
-void Areport::Open(const AString &s)
-{
-	while(!(file->rdbuf()->is_open())) {
-		AString *name = getfilename(s);
-		file->open(name->Str(),ios::out|ios::ate);
-		delete name;
-		// Handle a broke ios::ate implementation on some boxes
-		file->seekp(0, ios::end);
-		if ((int)file->tellp()!=0) file->close();
-	}
-	tabs = 0;
-}
-
-int Areport::OpenByName(const AString &s)
-{
-	AString temp = s;
-	file->open(temp.Str(), ios::out|ios::ate);
-	if (!file->rdbuf()->is_open()) return -1;
-	// Handle a broke ios::ate implementation on some boxes
-	file->seekp(0, ios::end);
-	if ((int)file->tellp() != 0) {
-		file->close();
-		return -1;
-	}
-	tabs = 0;
-	return 0;
-}
-
-void Areport::AddTab()
-{
-	tabs++;
-}
-
-void Areport::DropTab()
-{
-	if (tabs > 0) tabs--;
-}
-
-void Areport::ClearTab()
-{
-	tabs = 0;
-}
-
-void Areport::PutStr(const AString &s,int comment)
-{
-	AString temp;
-	for (int i=0; i<tabs; i++) temp += "  ";
-	temp += s;
-	AString *temp2 = temp.Trunc(70);
-	if (comment) *file << ";";
-	*file << temp << F_ENDLINE;
-	while (temp2) {
-		temp = "  ";
-		for (int i=0; i<tabs; i++) temp += "  ";
-		temp += *temp2;
-		delete temp2;
-		temp2 = temp.Trunc(70);
-		if (comment) *file << ";";
-		*file << temp << F_ENDLINE;
-	}
-}
-
-void Areport::PutNoFormat(const AString &s)
-{
-	*file << s << F_ENDLINE;
-}
-
-void Areport::EndLine()
-{
-	*file << F_ENDLINE;
 }
 
 void Arules::Open(const AString &s)

--- a/fileio.h
+++ b/fileio.h
@@ -31,43 +31,6 @@
 #include <fstream>
 using namespace std;
 
-class Aoutfile {
-	public:
-		Aoutfile();
-		~Aoutfile();
-
-		void Open(const AString &);
-		int OpenByName(const AString &);
-		void Close();
-
-		void PutStr(char const *);
-		void PutStr(const AString &);
-		void PutInt(int);
-
-		ofstream *file;
-};
-
-class Areport {
-	public:
-		Areport();
-		~Areport();
-
-		void Open(const AString &);
-		int OpenByName(const AString &);
-		void Close();
-
-		void AddTab();
-		void DropTab();
-		void ClearTab();
-
-		void PutStr(const AString &,int = 0);
-		void PutNoFormat(const AString &);
-		void EndLine();
-
-		ofstream *file;
-		int tabs;
-};
-
 class Arules {
 	public:
 		Arules();

--- a/game.cpp
+++ b/game.cpp
@@ -131,13 +131,13 @@ AString Game::GetXtraMap(ARegion *reg,int type)
 	return(" ");
 }
 
-void Game::WriteSurfaceMap(Aoutfile *f, ARegionArray *pArr, int type)
+void Game::WriteSurfaceMap(ostream& f, ARegionArray *pArr, int type)
 {
 	ARegion *reg;
 	int yy = 0;
 	int xx = 0;
 
-	f->PutStr(AString("Map (") + xx*32 + "," + yy*16 + ")");
+	f << "Map (" << xx*32 << "," << yy*16 << ")\n";
 	for (int y=0; y < pArr->y; y+=2) {
 		AString temp;
 		int x;
@@ -147,7 +147,7 @@ void Game::WriteSurfaceMap(Aoutfile *f, ARegionArray *pArr, int type)
 			temp += GetXtraMap(reg,type);
 			temp += "  ";
 		}
-		f->PutStr(temp);
+		f << temp << "\n";
 		temp = "  ";
 		for (x=1; x< pArr->x; x+=2) {
 			reg = pArr->GetRegion(x+xx*32,y+yy*16+1);
@@ -155,17 +155,17 @@ void Game::WriteSurfaceMap(Aoutfile *f, ARegionArray *pArr, int type)
 			temp += GetXtraMap(reg,type);
 			temp += "  ";
 		}
-		f->PutStr(temp);
+		f << temp << "\n";
 	}
-	f->PutStr("");
+	f << "\n";
 }
 
-void Game::WriteUnderworldMap(Aoutfile *f, ARegionArray *pArr, int type)
+void Game::WriteUnderworldMap(ostream& f, ARegionArray *pArr, int type)
 {
 	ARegion *reg, *reg2;
 	int xx = 0;
 	int yy = 0;
-	f->PutStr(AString("Map (") + xx*32 + "," + yy*16 + ")");
+	f << "Map (" << xx*32 << "," << yy*16 << ")\n";
 	for (int y=0; y< pArr->y; y+=2) {
 		AString temp = " ";
 		AString temp2;
@@ -188,8 +188,7 @@ void Game::WriteUnderworldMap(Aoutfile *f, ARegionArray *pArr, int type)
 
 			temp2 += " ";
 		}
-		f->PutStr(temp);
-		f->PutStr(temp2);
+		f << temp << "\n" << temp2 << "\n";
 
 		temp = " ";
 		temp2 = "  ";
@@ -213,10 +212,9 @@ void Game::WriteUnderworldMap(Aoutfile *f, ARegionArray *pArr, int type)
 
 			temp2 += " ";
 		}
-		f->PutStr(temp);
-		f->PutStr(temp2);
+		f << temp << "\n" << temp2 << "\n";
 	}
-	f->PutStr("");
+	f << "\n";
 }
 
 int Game::ViewMap(const AString & typestr,const AString & mapfile)
@@ -226,49 +224,46 @@ int Game::ViewMap(const AString & typestr,const AString & mapfile)
 	if (AString(typestr) == "lair") type = 2;
 	if (AString(typestr) == "gate") type = 3;
 
-	Aoutfile f;
-	if (f.OpenByName(mapfile) == -1) return(0);
+	ofstream f(mapfile.const_str(), ios::out|ios::ate);
+	if (!f.is_open()) return(0);
 
 	switch (type) {
 		case 0:
-			f.PutStr("Geographical Map");
+			f << "Geographical Map\n";
 			break;
 		case 1:
-			f.PutStr("Wandering Monster Map");
+			f << "Wandering Monster Map\n";
 			break;
 		case 2:
-			f.PutStr("Lair Map");
+			f << "Lair Map\n";
 			break;
 		case 3:
-			f.PutStr("Gate Map");
+			f << "Gate Map\n";
 			break;
 	}
 
 	int i;
 	for (i = 0; i < regions.numLevels; i++) {
-		f.PutStr("");
+		f << '\n';
 		ARegionArray *pArr = regions.pRegionArrays[i];
 		switch(pArr->levelType) {
 			case ARegionArray::LEVEL_NEXUS:
-				f.PutStr(AString("Level ") + i + ": Nexus");
+				f << "Level " << i << ": Nexus\n";
 				break;
 			case ARegionArray::LEVEL_SURFACE:
-				f.PutStr(AString("Level ") + i + ": Surface");
-				WriteSurfaceMap(&f, pArr, type);
+				f << "Level " << i << ": Surface\n";
+				WriteSurfaceMap(f, pArr, type);
 				break;
 			case ARegionArray::LEVEL_UNDERWORLD:
-				f.PutStr(AString("Level ") + i + ": Underworld");
-				WriteUnderworldMap(&f, pArr, type);
+				f << "Level " << i << ": Underworld\n";
+				WriteUnderworldMap(f, pArr, type);
 				break;
 			case ARegionArray::LEVEL_UNDERDEEP:
-				f.PutStr(AString("Level ") + i + ": Underdeep");
-				WriteUnderworldMap(&f, pArr, type);
+				f << "Level " << i << ": Underdeep\n";
+				WriteUnderworldMap(f, pArr, type);
 				break;
 		}
 	}
-
-	f.Close();
-
 	return(1);
 }
 
@@ -318,8 +313,7 @@ int Game::OpenGame()
 	//
 	// The order here must match the order in SaveGame
 	//
-	ifstream f;
-	f.open("game.in", ios::in);
+	ifstream f("game.in", ios::in);
 	if (!f.is_open()) return(0);
 	//
 	// Read in Globals
@@ -438,44 +432,41 @@ int Game::OpenGame()
 
 int Game::SaveGame()
 {
-	Aoutfile f;
-	if (f.OpenByName("game.out") == -1) return(0);
+	ofstream f("game.out", ios::out|ios::ate);
+	if (!f.is_open()) return(0);
 
 	//
 	// Write out Globals
 	//
-	f.PutStr("atlantis_game");
-	f.PutInt(CURRENT_ATL_VER);
-	f.PutStr(Globals->RULESET_NAME);
-	f.PutInt(Globals->RULESET_VERSION);
+	f << "atlantis_game\n";
+	f << CURRENT_ATL_VER << "\n";
+	f << Globals->RULESET_NAME << "\n";
+	f << Globals->RULESET_VERSION << "\n";
 
-	f.PutInt(year);
-	f.PutInt(month);
-	f.PutInt(getrandom(10000));
-	f.PutInt(factionseq);
-	f.PutInt(unitseq);
-	f.PutInt(shipseq);
-	f.PutInt(guardfaction);
-	f.PutInt(monfaction);
-
+	f << year << "\n";
+	f << month << "\n";
+	f << getrandom(10000) << "\n";
+	f << factionseq << "\n";
+	f << unitseq << "\n";
+	f << shipseq << "\n";
+	f << guardfaction << "\n";
+	f << monfaction << "\n";
 	//
 	// Write out the Factions
 	//
-	f.PutInt(factions.Num());
-
+	f << factions.Num() << "\n";
 	forlist(&factions) {
-		((Faction *) elem)->Writeout(&f);
+		((Faction *) elem)->Writeout(f);
 	}
 
 	//
 	// Write out the ARegions
 	//
-	regions.WriteRegions(&f);
+	regions.WriteRegions(f);
 
 	// Write out quests
-	quests.WriteQuests(&f);
+	quests.WriteQuests(f);
 
-	f.Close();
 	return(1);
 }
 
@@ -490,37 +481,33 @@ void Game::DummyGame()
 
 int Game::WritePlayers()
 {
-	Aoutfile f;
-	if (f.OpenByName("players.out") == -1) return(0);
+	ofstream f("players.out", ios::out|ios::ate);
+	if (!f.is_open()) return(0);
 
-	f.PutStr(PLAYERS_FIRST_LINE);
-	f.PutStr(AString("Version: ") + CURRENT_ATL_VER);
-	f.PutStr(AString("TurnNumber: ") + TurnNumber());
-
+	f << PLAYERS_FIRST_LINE << "\n";
+	f << "Version: " << CURRENT_ATL_VER << "\n";
+	f << "TurnNumber: " << TurnNumber() << "\n";
 	if (gameStatus == GAME_STATUS_UNINIT)
 		return(0);
-	else if (gameStatus == GAME_STATUS_NEW)
-		f.PutStr(AString("GameStatus: New"));
+	
+	if (gameStatus == GAME_STATUS_NEW)
+		f << "GameStatus: New\n\n";
 	else if (gameStatus == GAME_STATUS_RUNNING)
-		f.PutStr(AString("GameStatus: Running"));
+		f << "GameStatus: Running\n\n";
 	else if (gameStatus == GAME_STATUS_FINISHED)
-		f.PutStr(AString("GameStatus: Finished"));
-
-	f.PutStr("");
+		f << "GameStatus: Finished\n\n";
 
 	forlist(&factions) {
 		Faction *fac = (Faction *) elem;
-		fac->WriteFacInfo(&f);
+		fac->WriteFacInfo(f);
 	}
 
-	f.Close();
 	return(1);
 }
 
 int Game::ReadPlayers()
 {
-	ifstream f;
-	f.open("players.in", ios::in);
+	ifstream f("players.in", ios::in);
 	if (!f.is_open()) return(0);
 
 	AString pLine;
@@ -1018,26 +1005,20 @@ void Game::WriteNewFac(Faction *pFac)
 
 int Game::DoOrdersCheck(const AString &strOrders, const AString &strCheck)
 {
-	ifstream ordersFile;
-	ordersFile.open(strOrders.const_str(), ios::in);
+	ifstream ordersFile(strOrders.const_str(), ios::in);
 	if (!ordersFile.is_open()) {
 		Awrite("No such orders file!");
 		return(0);
 	}
 
-	Aoutfile checkFile;
-	if (checkFile.OpenByName(strCheck) == -1) {
+	ofstream checkFile(strCheck.const_str(), ios::out|ios::ate);
+	if (!checkFile.is_open()) {
 		Awrite("Couldn't open the orders check file!");
 		return(0);
 	}
 
-	OrdersCheck check;
-	check.pCheckFile = &checkFile;
-
+	OrdersCheck check(checkFile);
 	ParseOrders(0, ordersFile, &check);
-
-	ordersFile.close();
-	checkFile.Close();
 
 	return(1);
 }
@@ -1150,8 +1131,7 @@ void Game::ReadOrders()
 			AString str = "orders.";
 			str += fac->num;
 
-			ifstream file;
-			file.open(str.const_str(), ios::in);
+			ifstream file(str.const_str(), ios::in);
 			if(file.is_open()) {
 				ParseOrders(fac->num, file, 0);
 				file.close();
@@ -1202,8 +1182,6 @@ void Game::MakeFactionReportLists()
 
 void Game::WriteReport()
 {
-	Areport f;
-
 	MakeFactionReportLists();
 	CountAllSpecialists();
 
@@ -1229,10 +1207,9 @@ void Game::WriteReport()
 		if (!fac->IsNPC() ||
 				((((month == 0) && (year == 1)) || Globals->GM_REPORT) &&
 			(fac->num == 1))) {
-			int i = f.OpenByName(str);
-			if (i != -1) {
-				fac->WriteReport(&f, this, citems);
-				f.Close();
+			ofstream f(str.const_str(), ios::out|ios::ate);
+			if (f.is_open()) {
+				fac->WriteReport(f, this, citems);
 			}
 		}
 		Adot();
@@ -1242,18 +1219,13 @@ void Game::WriteReport()
 // LLS - write order templates for factions
 void Game::WriteTemplates()
 {
-	Areport f;
-
 	forlist(&factions) {
 		Faction *fac = (Faction *) elem;
-		AString str = "template.";
-		str = str + fac->num;
-
 		if (!fac->IsNPC()) {
-			int i = f.OpenByName(str);
-			if (i != -1) {
-				fac->WriteTemplate(&f, this);
-				f.Close();
+			string str = "template." + to_string(fac->num);
+			ofstream f(str.c_str(), ios::out|ios::ate);
+			if (f.is_open()) {
+				fac->WriteTemplate(f, this);
 			}
 			fac->present_regions.DeleteAll();
 		}
@@ -1428,28 +1400,26 @@ void Game::CountAllSpecialists()
 // LLS
 void Game::UnitFactionMap()
 {
-	Aoutfile f;
 	unsigned int i;
 	Unit *u;
 
 	Awrite("Opening units.txt");
-	if (f.OpenByName("units.txt") == -1) {
+	ofstream f("units.txt", ios::out|ios::ate);
+	if (!f.is_open()) {
 		Awrite("Couldn't open file!");
-	} else {
-		Awrite(AString("Writing ") + unitseq + " units");
-		for (i = 1; i < unitseq; i++) {
-			u = GetUnit(i);
-			if (!u) {
-				Awrite("doesn't exist");
-			} else {
-				Awrite(AString(i) + ":" + u->faction->num);
-				f.PutStr(AString(i) + ":" + u->faction->num);
-			}
+		return;
+	}
+	Awrite(AString("Writing ") + unitseq + " units");
+	for (i = 1; i < unitseq; i++) {
+		u = GetUnit(i);
+		if (!u) {
+			Awrite("doesn't exist");
+		} else {
+			Awrite(AString(i) + ":" + u->faction->num);
+			f << i << ":" << u->faction->num << endl;
 		}
 	}
-	f.Close();
 }
-
 
 //The following function added by Creative PBM February 2000
 void Game::RemoveInactiveFactions()

--- a/game.h
+++ b/game.h
@@ -40,9 +40,9 @@ class Game;
 class OrdersCheck
 {
 public:
-	OrdersCheck();
+	OrdersCheck(ostream& f) : pCheckFile(f), numshows(0), numerrors(0) { }
 
-	Aoutfile *pCheckFile;
+	ostream& pCheckFile;
 	Unit dummyUnit;
 	Faction dummyFaction;
 	Order dummyOrder;
@@ -175,8 +175,8 @@ private:
 	int MakeWMon(ARegion *pReg);
 	void MakeLMon(Object *pObj);
 
-	void WriteSurfaceMap(Aoutfile *f, ARegionArray *pArr, int type);
-	void WriteUnderworldMap(Aoutfile *f, ARegionArray *pArr, int type);
+	void WriteSurfaceMap(ostream& f, ARegionArray *pArr, int type);
+	void WriteUnderworldMap(ostream& f, ARegionArray *pArr, int type);
 	char GetRChar(ARegion *r);
 	AString GetXtraMap(ARegion *, int);
 

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -234,7 +234,6 @@ void Game::WriteFactionTypeDescription(std::ostringstream& buffer, Faction &fac)
 int Game::GenRules(const AString &rules, const AString &css,
 		const AString &intro)
 {
-	ifstream introf;
 	Arules f;
 	AString temp, temp2;
 	int cap;
@@ -247,10 +246,8 @@ int Game::GenRules(const AString &rules, const AString &css,
 		return 0;
 	}
 
-	introf.open(intro.const_str(), ios::in);
-	if (!introf.is_open()) {
-		return 0;
-	}
+	ifstream introf(intro.const_str(), ios::in);
+	if (!introf.is_open()) return 0;
 
 	int qm_exist = (Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT);
 	if (qm_exist) {
@@ -600,10 +597,11 @@ int Game::GenRules(const AString &rules, const AString &css,
 	f.LinkRef("intro");
 	f.ClassTagText("div", "rule", "");
 	f.TagText("h2", "Introduction");
-	AString in;
 	while (!introf.eof()) {
-		introf >> ws >> in;
-		f.PutStr(in);
+		string in;
+		getline(introf >> ws, in);
+		AString temp(in);
+		f.PutStr(temp);
 	}
 
 	f.LinkRef("playing");

--- a/havilah/world.cpp
+++ b/havilah/world.cpp
@@ -223,20 +223,15 @@ void SetupNames()
 
 void CountNames()
 {
-	Aoutfile names;
-	AString *name;
-
 	Awrite(AString("Regions ") + nregions);
 
 	// Dump all the names we created to a file so the GM can scan
 	// them easily (to check for randomly generated rude words,
 	// for example)
-	names.OpenByName("names.out");
+	ofstream names("names.out", ios::out|ios::ate);
 	forlist(&regionnames) {
-		name = (AString *) elem;
-		names.PutStr(*name);
+		names << ((AString *) elem)->const_str() << '\n';
 	}
-	names.Close();
 }
 
 int AGetName(int town, ARegion *reg)

--- a/indenter.cpp
+++ b/indenter.cpp
@@ -1,0 +1,51 @@
+#include "indenter.hpp"
+
+namespace indent {
+  const int indentbuf::idx = ios_base::xalloc();
+
+  ostream &wrap(ostream &os) {
+    os << wrap(70);
+    return os;
+  }
+
+  ostream &comment(ostream &os) {
+    if(os.pword(indentbuf::idx) != nullptr) {
+      indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
+      buf->comment();
+    } else {
+      indentbuf *newbuf = new indentbuf(os, 0);
+      newbuf->comment();
+      os.pword(indentbuf::idx) = newbuf;
+    }
+    return os;
+  }
+
+  ostream& incr(ostream& os) {
+    if(os.pword(indentbuf::idx) != nullptr) {
+      indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
+      buf->adjust_indent(2);
+    } else {
+      indentbuf *newbuf = new indentbuf(os, 2);
+      os.pword(indentbuf::idx) = newbuf;
+    }
+    return os;
+  }
+
+  ostream& decr(ostream& os) {
+    if(os.pword(indentbuf::idx) != nullptr) {
+      indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
+      buf->adjust_indent(-2);
+    }
+    return os;
+  }
+
+  // This removes all indenting, wrapping and commenting from the output stream.
+  ostream& clear(ostream& os) {
+    if(os.pword(indentbuf::idx) != nullptr) {
+      indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
+      delete buf;
+      os.pword(indentbuf::idx) = nullptr;
+    }
+    return os;
+  }    
+}

--- a/indenter.hpp
+++ b/indenter.hpp
@@ -1,0 +1,149 @@
+#include <iostream>
+#include <sstream>
+using namespace std;
+
+namespace indent {
+  class indentbuf: public streambuf {
+  public:
+    static const int idx;
+
+    indentbuf(ostream& orig, size_t indent)
+    : orig(orig),
+      orig_buf(orig.rdbuf()),
+      comment_on(false),
+      indent(indent),
+      wrap(70),
+      lookback(30)
+    {
+      orig.rdbuf(this);
+      update_prefix();
+    }
+
+    virtual ~indentbuf() {
+      pubsync();
+      orig.rdbuf(orig_buf);
+    }
+
+    void adjust_indent(size_t adj) {
+      indent += adj;
+      update_prefix();
+    }
+
+    void set_indent(size_t val) {
+      indent = val;
+      update_prefix();
+    }
+
+    void set_wrap(size_t wrap_val, size_t lookback_val) {
+      wrap = wrap_val;
+      lookback = lookback_val;
+    }
+
+    // Comment will only last until the next natural newline.
+    void comment() {
+      comment_on = true;
+    }
+
+  protected:
+    int_type overflow(int_type ch) {
+      // If we get an eof just return the right stuff.
+      if (traits_type::eq_int_type(ch, traits_type::eof())) {
+        return traits_type::not_eof(ch);
+      }
+
+      buffer += ch;
+      if (ch == '\n' || ch == '\r') {
+        buffer = prefix + buffer;
+        // Ok.. we just got a new line, so output the buffer in wrapped chunks.
+        while (buffer.size() > wrap) {
+          // find the last space before the wrap point.
+          size_t wrap_pos = buffer.find_last_of("\n ", wrap);
+          size_t extra = 1;
+          // If we didn't find a space, just wrap at the wrap point.
+          if (wrap_pos == string::npos || (wrap - wrap_pos > lookback)) { wrap_pos = wrap; extra = 0; }
+          if (comment_on) orig_buf->sputc(';');
+          orig_buf->sputn(buffer.c_str(), wrap_pos);
+          orig_buf->sputc('\n');
+          buffer = buffer.substr(wrap_pos + extra);
+          if (buffer.size() > 0) {
+            buffer = prefix + string(2, ' ') + buffer;
+          }
+        }
+        if (buffer.size() > 0) {
+          if (comment_on) orig_buf->sputc(';');
+          orig_buf->sputn(buffer.c_str(), buffer.size());
+        }
+        buffer.clear();
+        // all output, turn off comment now.
+        comment_on = false;
+      }
+      return ch;
+    }
+
+    int_type sync(void) {
+      if (buffer.size() > 0) {
+        if (comment_on) orig_buf->sputc(';');
+        buffer = prefix + buffer;
+        orig_buf->sputn(buffer.c_str(), buffer.size());
+        buffer.clear();
+      }
+      return orig_buf->pubsync();
+    }
+  private:
+    void update_prefix() {
+      if (indent < 0) indent = 0;
+      if (indent) prefix = string(indent, ' ');
+      else prefix.clear();
+    }
+
+    ostream& orig;
+    streambuf *orig_buf;
+    bool comment_on;
+    size_t indent;
+    size_t wrap;
+    size_t lookback;
+    string buffer;
+    string prefix;
+  };
+
+  ostream &wrap(ostream &os);
+  ostream &comment(ostream &os);
+  ostream &incr(ostream &os);
+  ostream &decr(ostream &os);
+  ostream &clear(ostream &os);
+
+  struct wrap_data { size_t wrap; size_t lookback; };
+  inline wrap_data wrap(size_t wrap=70, size_t lookback=30) {
+    return { wrap, lookback };
+  }
+  template<typename _CharT, typename _Traits>
+    inline basic_ostream<_CharT, _Traits>&
+    operator<<(basic_ostream<_CharT, _Traits>& os, wrap_data data) {
+    if(os.pword(indentbuf::idx) == nullptr) {
+      indentbuf *newbuf = new indentbuf(os, 0);
+      newbuf->set_wrap(data.wrap, data.lookback);
+      os.pword(indentbuf::idx) = newbuf;
+    } else {
+      indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
+      buf->set_wrap(data.wrap, data.lookback);
+    }
+    return os;
+  }
+
+  struct indent_data { size_t indent; };
+  inline indent_data set_indent(size_t indent=2) {
+    return { indent };
+  }
+  template<typename _CharT, typename _Traits>
+    inline basic_ostream<_CharT, _Traits>&
+    operator<<(basic_ostream<_CharT, _Traits>& os, indent_data data) {
+    if(os.pword(indentbuf::idx) == nullptr) {
+      indentbuf *newbuf = new indentbuf(os, data.indent);
+      os.pword(indentbuf::idx) = newbuf;
+    } else {
+      indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
+      buf->set_indent(data.indent);
+    }
+    return os;
+  }
+}

--- a/items.cpp
+++ b/items.cpp
@@ -1541,16 +1541,15 @@ AString Item::Report(int seeillusions)
 	return ret;
 }
 
-void Item::Writeout(Aoutfile *f)
+void Item::Writeout(ostream& f)
 {
 	AString temp;
 	if (type != -1) {
-		temp = AString(num) + " ";
-		if (ItemDefs[type].type & IT_ILLUSION) temp += "i";
-		temp += ItemDefs[type].abr;
-	}
-	else temp = "-1 NO_ITEM";
-	f->PutStr(temp);
+		f << num << " ";
+		if (ItemDefs[type].type & IT_ILLUSION) f << "i";
+		f << ItemDefs[type].abr << '\n';
+	} else
+		f << "-1 NO_ITEM\n";
 }
 
 void Item::Readin(istream &f)
@@ -1565,9 +1564,9 @@ void Item::Readin(istream &f)
 	delete token;
 }
 
-void ItemList::Writeout(Aoutfile *f)
+void ItemList::Writeout(ostream& f)
 {
-	f->PutInt(Num());
+	f << Num() << "\n";
 	forlist (this) ((Item *) elem)->Writeout(f);
 }
 

--- a/items.h
+++ b/items.h
@@ -445,8 +445,8 @@ class Item : public AListElem
 		Item();
 		~Item();
 
-		void Readin(istream &f);
-		void Writeout(Aoutfile *);
+		void Readin(istream& f);
+		void Writeout(ostream& f);
 		
 		AString Report(int);
 
@@ -459,8 +459,8 @@ class Item : public AListElem
 class ItemList : public AList
 {
 	public:
-		void Readin(istream &f);
-		void Writeout(Aoutfile *);
+		void Readin(istream& f);
+		void Writeout(ostream& f);
 
 		AString Report(int, int, int);
 		AString BattleReport();

--- a/market.cpp
+++ b/market.cpp
@@ -92,18 +92,17 @@ void Market::PostTurn(int population, int wages)
 	}
 }
 
-void Market::Writeout(Aoutfile *f)
+void Market::Writeout(ostream& f)
 {
-	f->PutInt(type);
-	if (item != -1) f->PutStr(ItemDefs[item].abr);
-	else f->PutStr("NO_ITEM");
-	f->PutInt(price);
-	f->PutInt(amount);
-	f->PutInt(minpop);
-	f->PutInt(maxpop);
-	f->PutInt(minamt);
-	f->PutInt(maxamt);
-	f->PutInt(baseprice);
+	f << type << '\n';
+	f << (item == -1 ? "NO_ITEM" : ItemDefs[item].abr) << '\n';
+	f << price << '\n';
+	f << amount << '\n';
+	f << minpop << '\n';
+	f << maxpop << '\n';
+	f << minamt << '\n';
+	f << maxamt << '\n';
+	f << baseprice << '\n';
 }
 
 void Market::Readin(istream& f)
@@ -137,9 +136,9 @@ void MarketList::PostTurn(int population, int wages)
 	}
 }
 
-void MarketList::Writeout(Aoutfile *f)
+void MarketList::Writeout(ostream& f)
 {
-	f->PutInt(Num());
+	f << Num() << '\n';
 	forlist (this) ((Market *) elem)->Writeout(f);
 }
 

--- a/market.h
+++ b/market.h
@@ -53,16 +53,16 @@ public:
 	int baseprice;
 	int activity;
 
-	void PostTurn(int,int);
-	void Writeout(Aoutfile * f);
+	void PostTurn(int, int);
+	void Writeout(ostream& f);
 	void Readin(istream& f);
 	AString Report();
 };
 
 class MarketList : public AList {
 public:
-	void PostTurn(int,int);
-	void Writeout(Aoutfile * f);
+	void PostTurn(int, int);
+	void Writeout(ostream&  f);
 	void Readin(istream& f);
 };
 

--- a/neworigins/world.cpp
+++ b/neworigins/world.cpp
@@ -223,20 +223,15 @@ void SetupNames()
 
 void CountNames()
 {
-	Aoutfile names;
-	AString *name;
-
 	Awrite(AString("Regions ") + nregions);
 
 	// Dump all the names we created to a file so the GM can scan
 	// them easily (to check for randomly generated rude words,
 	// for example)
-	names.OpenByName("names.out");
+	ofstream names("names.out", ios::out|ios::ate);
 	forlist(&regionnames) {
-		name = (AString *) elem;
-		names.PutStr(*name);
+		names << ((AString *) elem)->const_str() << '\n';
 	}
-	names.Close();
 }
 
 int AGetName(int town, ARegion *reg)

--- a/object.h
+++ b/object.h
@@ -88,8 +88,8 @@ class Object : public AListElem
 		~Object();
 
 		void Readin(istream& f, AList *);
-		void Writeout(Aoutfile *f);
-		void Report(Areport *, Faction *, int, int, int, int, int, int, int);
+		void Writeout(ostream& f);
+		void Report(ostream& f, Faction *, int, int, int, int, int, int, int);
 
 		void SetName(AString *);
 		void SetDescribe(AString *);
@@ -113,7 +113,7 @@ class Object : public AListElem
 		
 		// Fleets
 		void ReadinFleet(istream &f);
-		void WriteoutFleet(Aoutfile *f);
+		void WriteoutFleet(ostream &f);
 		int CheckShip(int);
 		int GetNumShips(int);
 		void SetNumShips(int, int);

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -31,21 +31,9 @@
 #include "skills.h"
 #include "gamedata.h"
 
-OrdersCheck::OrdersCheck()
-{
-	pCheckFile = 0;
-	numshows = 0;
-	numerrors = 0;
-	dummyUnit.monthorders = 0;
-}
-
 void OrdersCheck::Error(const AString &strError)
 {
-	if (pCheckFile) {
-		pCheckFile->PutStr("");
-		pCheckFile->PutStr("");
-		pCheckFile->PutStr(AString("*** Error: ") + strError + " ***");
-	}
+	pCheckFile << "\n\n*** Error: " << strError << " ***\n";
 	numerrors++;
 }
 
@@ -446,7 +434,7 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 				indent--;
 			for (i = 0, prefix = ""; i < indent; i++)
 				prefix += "  ";
-			pCheck->pCheckFile->PutStr(prefix + saveorder);
+			pCheck->pCheckFile << prefix << saveorder << "\n";
 			if (code == O_TURN || code == O_FORM)
 				indent++;
 		}
@@ -470,16 +458,11 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 	}
 
 	if (pCheck) {
-		pCheck->pCheckFile->PutStr("");
+		pCheck->pCheckFile << "\n";
 		if (!pCheck->numerrors) {
-			pCheck->pCheckFile->PutStr("No errors found.");
+			pCheck->pCheckFile << "No errors found.\n";
 		} else {
-			AString str = pCheck->numerrors;
-			str += " error";
-			if (pCheck->numerrors != 1)
-				str += "s";
-			str += " found!";
-			pCheck->pCheckFile->PutStr(str);
+			pCheck->pCheckFile << pCheck->numerrors << " error" << (pCheck->numerrors == 1 ? "" : "s") << " found!\n";
 		}
 	}
 }

--- a/production.cpp
+++ b/production.cpp
@@ -50,17 +50,15 @@ Production::Production(int it, int maxamt)
 	skill = LookupSkill(&skname);
 }
 
-void Production::Writeout(Aoutfile *f)
+void Production::Writeout(ostream& f)
 {
-	if (itemtype != -1) f->PutStr(ItemDefs[itemtype].abr);
-	else f->PutStr("NO_ITEM");
-	f->PutInt(amount);
-	f->PutInt(baseamount);
+	f << (itemtype == -1 ? "NO_ITEM" : ItemDefs[itemtype].abr) << '\n';	
+	f << amount << '\n';
+	f << baseamount << '\n';
 	if (itemtype == I_SILVER) {
-		if (skill != -1) f->PutStr(SkillDefs[skill].abbr);
-		else f->PutStr("NO_SKILL");
+		f << (skill == -1 ? "NO_SKILL" : SkillDefs[skill].abbr) << '\n';
 	}
-	f->PutInt(productivity);
+	f << productivity << '\n';
 }
 
 void Production::Readin(istream& f)
@@ -89,9 +87,9 @@ AString Production::WriteReport()
 	return temp;
 }
 
-void ProductionList::Writeout(Aoutfile *f)
+void ProductionList::Writeout(ostream& f)
 {
-	f->PutInt(Num());
+	f << Num() << '\n';
 	forlist(this) ((Production *) elem)->Writeout(f);
 }
 

--- a/production.h
+++ b/production.h
@@ -35,9 +35,9 @@
 class Production : public AListElem {
 public:
 	Production(int,int); /* item type, amt max */
-	Production();
-	
-	void Writeout(Aoutfile *);
+    Production();
+
+    void Writeout(ostream& f);
 	void Readin(istream& f);
 	AString WriteReport();
 	
@@ -54,7 +54,7 @@ public:
 	Production * GetProd(int,int); /* item type, skill */
 	void AddProd(Production *);
 	
-	void Writeout(Aoutfile *);
+	void Writeout(ostream& f);
 	void Readin(istream& f);
 };
 

--- a/quests.cpp
+++ b/quests.cpp
@@ -146,74 +146,58 @@ int QuestList::ReadQuests(istream& f)
     return 1;
 }
 
-void QuestList::WriteQuests(Aoutfile *f)
+void QuestList::WriteQuests(ostream& f)
 {
 	Quest *q;
 	Item *i;
 	set<string>::iterator it;
 
-	f->PutInt(quests.Num());
+	f << quests.Num() << '\n';
 	forlist(this) {
 		q = (Quest *) elem;
-		f->PutInt(q->type);
+		f << q->type << '\n';
 		switch(q->type) {
 			case Quest::SLAY:
-				f->PutInt(q->target);
+				f << q->target << '\n';
 				break;
 			case Quest::HARVEST:
 				q->objective.Writeout(f);
-				f->PutInt(q->regionnum);
+				f << q->regionnum << '\n';
 				break;
 			case Quest::BUILD:
-				if (q->building != -1)
-					f->PutStr(ObjectDefs[q->building].name);
-				else
-					f->PutStr("NO_OBJECT");
-				f->PutStr(q->regionname);
+				f << (q->building == -1 ? "NO_OBJECT" : ObjectDefs[q->building].name) << '\n';
+				f << q->regionname << '\n';
 				break;
 			case Quest::VISIT:
-				if (q->building != -1)
-					f->PutStr(ObjectDefs[q->building].name);
-				else
-					f->PutStr("NO_OBJECT");
-				f->PutInt(q->destinations.size());
-				for (it = q->destinations.begin();
-						it != q->destinations.end();
-						it++) {
-					f->PutStr(it->c_str());
+				f << (q->building == -1 ? "NO_OBJECT" : ObjectDefs[q->building].name) << '\n';
+				f << q->destinations.size() << '\n';
+				for (it = q->destinations.begin(); it != q->destinations.end();	it++) {
+					f << *it << '\n';
 				}
 				break;
 			case Quest::DEMOLISH:
-				f->PutInt(q->target);
-				f->PutInt(q->regionnum);
+				f << q->target << '\n';
+				f << q->regionnum << '\n';
 				break;
 			default:
-				f->PutInt(q->target);
+				f << q->target << '\n';
 				q->objective.Writeout(f);
-				if (q->building != -1)
-					f->PutStr(ObjectDefs[q->building].name);
-				else
-					f->PutStr("NO_OBJECT");
-				f->PutInt(q->regionnum);
-				f->PutStr(q->regionname);
-				f->PutInt(q->destinations.size());
-				for (it = q->destinations.begin();
-						it != q->destinations.end();
-						it++) {
-					f->PutStr(it->c_str());
+				f << (q->building == -1 ? "NO_OBJECT" : ObjectDefs[q->building].name) << '\n';
+				f << q->regionnum << '\n';
+				f << q->regionname << '\n';
+				f << q->destinations.size() << '\n';
+				for (it = q->destinations.begin(); it != q->destinations.end();	it++) {
+					f << *it << '\n';
 				}
 				break;
 		}
-		f->PutInt(q->rewards.Num());
+		f << q->rewards.Num() << '\n';
 		forlist(&q->rewards) {
 			i = (Item *) elem;
 			i->Writeout(f);
 		}
 	}
-
-	f->PutInt(0);
-
-        return;
+	f << 0 << '\n';
 }
 
 int QuestList::CheckQuestKillTarget(Unit *u, ItemList *reward, AString *quest_rewards)

--- a/quests.h
+++ b/quests.h
@@ -64,7 +64,7 @@ class QuestList : public AList
 {
 	public:
 		int ReadQuests(istream& f);
-		void WriteQuests(Aoutfile *f);
+		void WriteQuests(ostream& f);
 
 		int CheckQuestKillTarget(Unit *u, ItemList *reward, AString *quest_rewards);
 		int CheckQuestHarvestTarget(ARegion *r,

--- a/skills.cpp
+++ b/skills.cpp
@@ -248,24 +248,20 @@ void Skill::Readin(istream &f)
 	}
 }
 
-void Skill::Writeout(Aoutfile *f)
+void Skill::Writeout(ostream& f)
 {
-	AString temp;
-
 	if (type != -1) {
+		f << SkillDefs[type].abbr << " " << days;
 		if (Globals->REQUIRED_EXPERIENCE) {
-			temp = AString(SkillDefs[type].abbr) + " " + days + " " + exp;
-		} else {
-			temp = AString(SkillDefs[type].abbr) + " " + days;
+			f << " " << exp;
 		}
 	} else {
+		f << "NO_SKILL 0";
 		if (Globals->REQUIRED_EXPERIENCE) {
-			temp = AString("NO_SKILL 0 0");
-		} else {
-			temp = AString("NO_SKILL 0");
+			f << " 0";
 		}
 	}
-	f->PutStr(temp);
+	f << '\n';
 }
 
 Skill *Skill::Split(int total, int leave)
@@ -439,8 +435,8 @@ void SkillList::Readin(istream& f)
 	}
 }
 
-void SkillList::Writeout(Aoutfile *f)
+void SkillList::Writeout(ostream& f)
 {
-	f->PutInt(Num());
+	f << Num() << '\n';
 	forlist(this) ((Skill *) elem)->Writeout(f);
 }

--- a/skills.h
+++ b/skills.h
@@ -134,7 +134,7 @@ class ShowSkill : public AListElem {
 class Skill : public AListElem {
 	public:
 		void Readin(istream& f);
-		void Writeout(Aoutfile *);
+		void Writeout(ostream &f);
 
 		Skill * Split(int,int); /* total num, num leaving */
 
@@ -154,7 +154,7 @@ class SkillList : public AList {
 		SkillList * Split(int,int); /* total men, num to split */
 		AString Report(int); /* Number of men */
 		void Readin(istream& f);
-		void Writeout(Aoutfile *);
+		void Writeout(ostream& f);
 };
 
 class HealType {

--- a/snapshot-tests/turns/turn_5/game.out
+++ b/snapshot-tests/turns/turn_5/game.out
@@ -139,7 +139,7 @@ NoAddress
 none
 1
 0
-2
+3
 7
 PATT 1
 SPIR 1

--- a/snapshot-tests/turns/turn_5/orders.3
+++ b/snapshot-tests/turns/turn_5/orders.3
@@ -9,6 +9,7 @@ unit 152
 ;Workers (152), revealing faction, won't cross water, 10 nomads [NOMA],
 ;  186 silver [SILV]. Weight: 100. Capacity: 0/0/150/0. Skills: none.
 @work
+option template map
 
 ;*** plain (29,11) in Koheda ***
 

--- a/snapshot-tests/turns/turn_5/players.out
+++ b/snapshot-tests/turns/turn_5/players.out
@@ -28,5 +28,5 @@ Password: none
 LastOrders: 6
 FirstTurn: 0
 SendTimes: 1
-Template: long
+Template: map
 Battle: na

--- a/snapshot-tests/turns/turn_5/template.3
+++ b/snapshot-tests/turns/turn_5/template.3
@@ -1,16 +1,68 @@
 
-Orders Template (Long Format):
+Orders Template (Map Format):
 
 #atlantis 3
 
-;*** plain (28,10) in Koheda, contains Thandianost [city] ***
+;-----------------------------------------------------------
+;plain (28,10) in Koheda, contains Thandianost [city]
+;         ____
+; nw     /    \     ne  Next monsoon
+;   ____/      \____    Tax  34403
+;  /    \      /    \   Ente  1997
+; /  ~ ~ \____/      \  Wage    16.2 (max 11467)
+; \ ~ ~  /    \      /
+;  \____/Thandi\____/   Sell unlim IRON @  75
+;  /    \      /    \        unlim WOOD @  75
+; /  ~ ~ \____/      \       unlim STON @  75
+; \ ~ ~  /    \      /       unlim  FUR @  75
+;  \____/Hynoda\____/        unlim HERB @  75
+;       \      /             unlim HORS @  75
+; sw     \____/     se       unlim SWOR @ 150
+;                            unlim XBOW @ 150
+;                            unlim LBOW @ 150
+;                            unlim CARM @ 150
+;                            unlim PARM @ 625
+;                            unlim WAGO @ 250
+;                            unlim PICK @ 150
+;                            unlim SPEA @ 150
+;                            unlim  AXE @ 150
+;                            unlim HAMM @ 150
+;                            unlim  NET @ 200
+;                            unlim LASS @ 150
+;                            unlim  BAG @ 150
+;                            unlim SPIN @ 150
+;                            unlim LARM @ 112
+;                            unlim CLAR @ 100
+;                            unlim LANC @ 250
+;                            unlim BAXE @ 225
+;                            unlim JAVE @ 150
+;                            unlim PIKE @ 250
+;                            unlim NOMA @  64
+;                            unlim LEAD @ 129
+;
+;                       Prod    56 GRAI
+;                               21 HORS
 
 unit 152
 ;Workers (152), revealing faction, won't cross water, 10 nomads [NOMA],
 ;  248 silver [SILV]. Weight: 100. Capacity: 0/0/150/0. Skills: none.
 @work
 
-;*** plain (29,11) in Koheda ***
+;-----------------------------------------------------------
+;plain (29,11) in Koheda
+;         ____
+; nw     /    \     ne  Next monsoon
+;   ____/      \____    Tax   2285
+;  /    \      /    \   Ente   126
+; /Thandi\____/  ~ ~ \  Wage    14.6 (max 1537)
+; \      /    \ ~ ~  /
+;  \____/      \____/   Sell    99 HELF @  58
+;  /    \      /    \           19 LEAD @ 116
+; /Hynoda\____/Eindor\
+; \      /    \      /  Prod    67 GRAI
+;  \____/  ~ ~ \____/           39 HORS
+;       \ ~ ~  /
+; sw     \____/     se
 
 unit 164
 ;Scout (164), revealing faction, won't cross water, plainsman [PLAI], 4
@@ -24,7 +76,25 @@ unit 167
 @guard 1
 @tax
 
-;*** plain (28,12) in Koheda, contains Hynodale [town] ***
+;-----------------------------------------------------------
+;plain (28,12) in Koheda, contains Hynodale [town]
+;         ____
+; nw     /    \     ne  Next monsoon
+;   ____/Thandi\____    Tax   9455
+;  /    \      /    \   Ente   569
+; /  ~ ~ \____/      \  Wage    14.9 (max 3151)
+; \ ~ ~  /    \      /
+;  \____/Hynoda\____/   Want   105 GRAI @  21
+;  /    \      /    \          110 LIVE @  23
+; /  ~ ~ \____/  ~ ~ \         150 FISH @  49
+; \ ~ ~  /    \ ~ ~  /           3 LANC @ 163
+;  \____/  ~ ~ \____/
+;       \ ~ ~  /        Sell     1 HORS @  51
+; sw     \____/     se         385 PLAI @  59
+;                               77 LEAD @ 119
+;
+;                       Prod    71 LIVE
+;                               31 HORS
 
 unit 140
 ;King (140), revealing faction, won't cross water, leader [LEAD].

--- a/snapshot-tests/turns/turn_6/orders.3
+++ b/snapshot-tests/turns/turn_6/orders.3
@@ -9,6 +9,7 @@ unit 152
 ;Workers (152), revealing faction, won't cross water, 10 nomads [NOMA],
 ;  248 silver [SILV]. Weight: 100. Capacity: 0/0/150/0. Skills: none.
 @work
+option template long
 
 ;*** plain (29,11) in Koheda ***
 

--- a/template.cpp
+++ b/template.cpp
@@ -25,6 +25,7 @@
 
 #include "game.h"
 #include "gamedata.h"
+#include "indenter.hpp"
 #include <stdio.h>
 #ifdef WIN32
 #include <memory.h>
@@ -37,8 +38,6 @@
 #define TMPL_MAP_OFS 1
 #define FILL_SIZE 6
 #define TEMPLATE_MAX_LINES 13
-
-static void TrimWrite(Areport *f, char *buffer);
 
 static char const *TemplateMap[] = {
  //12345678901234567890
@@ -296,19 +295,17 @@ static char const *ter_fill[] = {
 // NEW FUNCTION DK 2000.03.07,
 // converted WriteReport
 //
-void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
+void ARegion::WriteTemplateHeader(ostream& f, Faction *fac,
 		ARegionList *pRegs, int month)
 {
 
-	f->PutStr("");
-
-	f->PutStr("-------------------------------------------------"
-			"----------", 1);
+	f << '\n' << indent::comment << "-----------------------------------------------------------\n";
 
 	// plain (X,Y) in Blah, contains Blah
-	f->PutStr(Print(pRegs), 1);
+	f << indent::comment << Print(pRegs) << '\n';
 
 	char buffer[LINE_WIDTH+1];
+	string temp;
 	char *data = buffer + MAP_WIDTH;
 	int line = 0;
 
@@ -317,7 +314,9 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 
 	// ----------------------------------------------------------------
 	GetMapLine(buffer, line, pRegs);
-	TrimWrite(f, buffer);
+	temp = buffer;
+	temp.erase(temp.find_last_not_of(' ') + 1);
+	f << indent::comment << temp << '\n';
 	line++;
 
 	// ----------------------------------------------------------------
@@ -325,7 +324,7 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 	if (Globals->WEATHER_EXISTS) {
 		GetMapLine(buffer, line, pRegs);
 
-		char const * nextWeather = "";
+		char const *nextWeather = "";
 		int nxtweather = pRegs->GetWeather(this, (month + 1) % 12);
 		if (nxtweather == W_WINTER)
 			nextWeather = "winter";
@@ -334,15 +333,18 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 		if (nxtweather == W_NORMAL)
 			nextWeather = "clear";
 		snprintf(data, LINE_WIDTH - MAP_WIDTH, "Next %s", nextWeather);
-
-		TrimWrite(f, buffer);
+		temp = buffer;
+		temp.erase(temp.find_last_not_of(' ') + 1);
+		f << indent::comment << temp << '\n';
 		line++;
 	}
 
 	// ----------------------------------------------------------------
 	GetMapLine(buffer, line, pRegs);
 	snprintf(data, LINE_WIDTH - MAP_WIDTH, "Tax  %5i", wealth);
-	TrimWrite(f, buffer);
+	temp = buffer;
+	temp.erase(temp.find_last_not_of(' ') + 1);
+	f << indent::comment << temp << '\n';
 	line++;
 
 	// ----------------------------------------------------------------
@@ -350,7 +352,9 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 	if (prod) {
 		GetMapLine(buffer, line, pRegs);
 		snprintf(data, LINE_WIDTH - MAP_WIDTH, "Ente %5i", prod->amount);
-		TrimWrite(f, buffer);
+		temp = buffer;
+		temp.erase(temp.find_last_not_of(' ') + 1);
+		f << indent::comment << temp << '\n';
 		line++;
 	}
 
@@ -359,7 +363,9 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 	if (prod) {
 		GetMapLine(buffer, line, pRegs);
 		snprintf(data, LINE_WIDTH - MAP_WIDTH, "Wage %5i.%1i (max %i)", (prod->productivity/10), (prod->productivity%10), prod->amount);
-		TrimWrite(f, buffer);
+		temp = buffer;
+		temp.erase(temp.find_last_not_of(' ') + 1);
+		f << indent::comment << temp << '\n';
 		line++;
 	}
 
@@ -379,7 +385,9 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 
 				if (!any) {
 					GetMapLine(buffer, line, pRegs);
-					TrimWrite(f, buffer);
+					temp = buffer;
+					temp.erase(temp.find_last_not_of(' ') + 1);
+					f << indent::comment << temp << '\n';
 					line++;
 				}
 
@@ -397,9 +405,10 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 						ItemDefs[m->item].abr,
 						m->price);
 				}
-				TrimWrite(f, buffer);
+				temp = buffer;
+				temp.erase(temp.find_last_not_of(' ') + 1);
+				f << indent::comment << temp << '\n';
 				line++;
-
 				any = 1;
 			}
 		}
@@ -415,7 +424,9 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 
 				if (!any) {
 					GetMapLine(buffer, line, pRegs);
-					TrimWrite(f, buffer);
+					temp = buffer;
+					temp.erase(temp.find_last_not_of(' ') + 1);
+					f << indent::comment << temp << '\n';
 					line++;
 				}
 
@@ -433,8 +444,9 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 						ItemDefs[m->item].abr,
 						m->price);
 				}
-
-				TrimWrite(f, buffer);
+				temp = buffer;
+				temp.erase(temp.find_last_not_of(' ') + 1);
+				f << indent::comment << temp << '\n';
 				line++;
 				any = 1;
 			}
@@ -444,42 +456,44 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 	// ----------------------------------------------------------------
 	any = 0;
 	{
-		 forlist((&products)) {
-			 Production *p = ((Production *) elem);
-			 if (ItemDefs[p->itemtype].type & IT_ADVANCED) {
-				 if (!CanMakeAdv(fac, p->itemtype)) {
-					 continue;
-				 }
-			 } else {
-				 if (p->itemtype == I_SILVER) {
-					 continue;
-				 }
-			 }
+		forlist((&products)) {
+			Production *p = ((Production *) elem);
+			if (ItemDefs[p->itemtype].type & IT_ADVANCED) {
+				if (!CanMakeAdv(fac, p->itemtype)) {
+					continue;
+				}
+			} else {
+				if (p->itemtype == I_SILVER) {
+					continue;
+				}
+			}
 
-			 if (!any) {
-				 GetMapLine(buffer, line, pRegs);
-				 TrimWrite(f, buffer);
-				 line++;
-			 }
+			if (!any) {
+				GetMapLine(buffer, line, pRegs);
+				temp = buffer;
+				temp.erase(temp.find_last_not_of(' ') + 1);
+				f << indent::comment << temp << '\n';
+				line++;
+			}
 
-			 GetMapLine(buffer, line, pRegs);
+			GetMapLine(buffer, line, pRegs);
 
-			 if (p->amount == -1) {
-				 snprintf(data, LINE_WIDTH - MAP_WIDTH, "%s unlim %4s",
-					 (any ? "    " : "Prod"),
-					 ItemDefs[p->itemtype].abr);
-			 } else {
-				 snprintf(data, LINE_WIDTH - MAP_WIDTH, "%s %5i %4s",
-					 (any ? "    " : "Prod"),
-					 p->amount,
-					 ItemDefs[p->itemtype].abr);
-			 }
-
-			 TrimWrite(f, buffer);
-			 line++;
-			 any = 1;
-
-		 }
+			if (p->amount == -1) {
+				snprintf(data, LINE_WIDTH - MAP_WIDTH, "%s unlim %4s",
+					(any ? "    " : "Prod"),
+					ItemDefs[p->itemtype].abr);
+			} else {
+				snprintf(data, LINE_WIDTH - MAP_WIDTH, "%s %5i %4s",
+					(any ? "    " : "Prod"),
+					p->amount,
+					ItemDefs[p->itemtype].abr);
+			}
+			temp = buffer;
+			temp.erase(temp.find_last_not_of(' ') + 1);
+			f << indent::comment << temp << '\n';
+			line++;
+			any = 1;
+		}
 	}
 
 	// ----------------------------------------------------------------
@@ -493,12 +507,16 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 				if (!sawgate && u->faction == fac &&
 					u->GetSkill(S_GATE_LORE)) {
 					GetMapLine(buffer, line, pRegs);
-					TrimWrite(f, buffer);
+					temp = buffer;
+					temp.erase(temp.find_last_not_of(' ') + 1);
+					f << indent::comment << temp << '\n';
 					line++;
 
 					GetMapLine(buffer, line, pRegs);
 					snprintf(data, LINE_WIDTH - MAP_WIDTH, "Gate %4i", gate);
-					TrimWrite(f, buffer);
+					temp = buffer;
+					temp.erase(temp.find_last_not_of(' ') + 1);
+					f << indent::comment << temp << '\n';
 					line++;
 
 					sawgate = 1;
@@ -510,7 +528,9 @@ void ARegion::WriteTemplateHeader(Areport *f, Faction *fac,
 	// ----------------------------------------------------------------
 	while (line < TEMPLATE_MAX_LINES) {
 		GetMapLine(buffer, line, pRegs);
-		TrimWrite(f, buffer);
+		temp = buffer;
+		temp.erase(temp.find_last_not_of(' ') + 1);
+		f << indent::comment << temp << '\n';
 		line++;
 	}
 }
@@ -573,19 +593,4 @@ void ARegion::GetMapLine(char *buffer, int line, ARegionList *pRegs)
 
 		i++;
 	}
-}
-
-static void TrimWrite(Areport *f, char *buffer) {
-
-	char *p = buffer + strlen(buffer) - 1;
-	while (p > buffer) {
-		if (*p == ' ') {
-			p--;
-		} else {
-			break;
-		}
-	}
-	p[1] = 0;
-
-	f->PutStr(buffer, 1);
 }

--- a/unit.cpp
+++ b/unit.cpp
@@ -168,44 +168,34 @@ void Unit::MakeWMon(char const *monname, int mon, int num)
 	SetMonFlags();
 }
 
-void Unit::Writeout(Aoutfile *s)
+void Unit::Writeout(ostream& f)
 {
 	set<string>::iterator it;
 
-	s->PutStr(*name);
-	if (describe) {
-		s->PutStr(*describe);
-	} else {
-		s->PutStr("none");
-	}
-	s->PutInt(num);
-	s->PutInt(type);
-	s->PutInt(faction->num);
-	s->PutInt(guard);
-	s->PutInt(reveal);
-	s->PutInt(free);
-	if (readyItem != -1) s->PutStr(ItemDefs[readyItem].abr);
-	else s->PutStr("NO_ITEM");
+	f << name->const_str() << '\n';
+	f << (describe ? describe->const_str() : "none") << '\n';
+	f << num << '\n';
+	f << type << '\n';
+	f << faction->num << '\n';
+	f << guard << '\n';
+	f << reveal << '\n';
+	f << free << '\n';
+	f << (readyItem != -1 ? ItemDefs[readyItem].abr : "NO_ITEM") << '\n';
+
 	for (int i = 0; i < MAX_READY; ++i) {
-		if (readyWeapon[i] != -1)
-			s->PutStr(ItemDefs[readyWeapon[i]].abr);
-		else s->PutStr("NO_ITEM");
-		if (readyArmor[i] != -1)
-			s->PutStr(ItemDefs[readyArmor[i]].abr);
-		else s->PutStr("NO_ITEM");
+		f << (readyWeapon[i] != -1 ? ItemDefs[readyWeapon[i]].abr : "NO_ITEM") << '\n';
+		f << (readyArmor[i] != -1 ? ItemDefs[readyArmor[i]].abr : "NO_ITEM") << '\n';
 	}
-	s->PutInt(flags);
-	items.Writeout(s);
-	skills.Writeout(s);
-	if (combat != -1) s->PutStr(SkillDefs[combat].abbr);
-	else s->PutStr("NO_SKILL");
-	s->PutInt(savedmovement);
-	s->PutInt(savedmovedir);
-	s->PutInt(visited.size());
-	for (it = visited.begin();
-			it != visited.end();
-			it++) {
-		s->PutStr(it->c_str());
+
+	f << flags << '\n';
+	items.Writeout(f);
+	skills.Writeout(f);
+	f << (combat != -1 ? SkillDefs[combat].abbr : "NO_SKILL") << '\n';
+	f << savedmovement << '\n';
+	f << savedmovedir << '\n';
+	f << visited.size() << '\n';
+	for (it = visited.begin(); it != visited.end();	it++) {
+		f << it->c_str() << '\n';
 	}
 }
 
@@ -267,8 +257,9 @@ void Unit::Readin(istream& f, AList *facs)
 
 	f >> i;
 	while (i-- > 0) {
-		f >> ws >> temp;
-		visited.insert(temp.Str());
+		string s;
+		getline(f >> ws, s);
+		visited.insert(s);
 	}
 }
 
@@ -434,7 +425,7 @@ AString Unit::SpoilsReport() {
 	return temp;
 }
 
-void Unit::WriteReport(Areport *f, int obs, int truesight, int detfac,
+void Unit::WriteReport(ostream& f, int obs, int truesight, int detfac,
 				int autosee, int attitude, int showattitudes)
 {
 	int stealth = GetAttribute("stealth");
@@ -579,7 +570,7 @@ void Unit::WriteReport(Areport *f, int obs, int truesight, int detfac,
 		temp += AString("; ") + *describe;
 	}
 	temp += ".";
-	f->PutStr(temp);
+	f << temp << '\n';
 }
 
 AString Unit::TemplateReport()

--- a/unit.h
+++ b/unit.h
@@ -126,12 +126,12 @@ class Unit : public AListElem
 		void SetMonFlags();
 		void MakeWMon(char const *,int,int);
 
-		void Writeout( Aoutfile *f );
+		void Writeout(ostream& f);
 		void Readin(istream& f, AList *);
 
 		AString SpoilsReport(void);
 		int CanGetSpoil(Item *i);
-		void WriteReport(Areport *,int,int,int,int, int, int);
+		void WriteReport(ostream& f,int,int,int,int, int, int);
 		AString GetName(int);
 		AString MageReport();
 		AString ReadyItem();

--- a/unittest/indent_formatter_test.cpp
+++ b/unittest/indent_formatter_test.cpp
@@ -1,0 +1,103 @@
+#include <sstream>
+#include "../external/boost/ut.hpp"
+
+#include "../game.h"
+#include "../gamedata.h"
+#include "../indenter.hpp"
+
+// Because boost::ut has it's own concept of events, as does Game, we cannot just use do
+// using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
+// closure to make the user defined literals and all the other niceness available.
+namespace ut = boost::ut;
+
+// This suite will test various aspects of the Faction class in isolation.
+ut::suite<"Indent Formatter"> indent_formatter_suite = []
+{
+  using namespace ut;
+
+  "increment indents"_test = []
+  {
+    stringstream ss;
+    ss << indent::incr << "test\n";
+    ss.flush();
+    expect(eq(ss.str(), string("  test\n")));
+  };
+
+  "incr and decr control indent level"_test = []
+  {
+    stringstream ss;
+    ss << indent::incr << "test\n";
+    ss << indent::incr << "test\n";
+    ss << indent::decr << "test\n";
+    ss.flush();
+    expect(eq(ss.str(), string("  test\n    test\n  test\n")));
+  };
+
+  "clear removes formatter"_test = []
+  {
+    stringstream ss;
+    ss << indent::incr << "test\n";
+    ss << indent::incr << "test\n";
+    ss << indent::clear << "test\n";
+    expect(eq(ss.str(), string("  test\n    test\ntest\n")));
+  };
+
+  "default wraps at first space before 70 characters then indents wrapped lines"_test = []
+  {
+    stringstream ss;
+    ss << indent::incr << "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 \n";
+    expect(eq(
+      ss.str(),
+      string("  123456789 123456789 123456789 123456789 123456789 123456789\n    123456789 123456789 \n")
+    ));
+  };
+
+  "wrap with no indent still wraps correctly"_test = []
+  {
+    stringstream ss;
+    ss << indent::wrap << "--123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 \n";
+    expect(eq(
+      ss.str(),
+      string("--123456789 123456789 123456789 123456789 123456789 123456789\n  123456789 123456789 \n")
+    ));
+  };
+
+
+  "wrap at shorter values works"_test = []
+  {
+    stringstream ss;
+    ss << indent::wrap(5) << "test bar\n";
+    expect(eq(ss.str(), string("test\n  bar\n")));
+  };
+
+  "wrap with different lookback works"_test = []
+  {
+    stringstream ss;
+    // since the lookback is only 2, this cannot break at the first space, so should just break at the wrap point.
+    // and then indent, then break the second wrapped line also at the wrap point and indent until done.
+    ss << indent::wrap(5, 2) << "t esttestbar\n";
+    expect(eq(ss.str(), string("t est\n  tes\n  tba\n  r\n")));
+  };
+
+  "comment prefixes line with semicolon"_test = []
+  {
+    stringstream ss;
+    ss << indent::comment << "test\n";
+    expect(eq(ss.str(), string(";test\n")));
+  };
+
+  "comment is not counted in wrapping and persists on wrapped lines"_test = []
+  {
+    stringstream ss;
+    ss << indent::wrap(5, 2) << indent::comment << "t esttestbar\n";
+    expect(eq(ss.str(), string(";t est\n;  tes\n;  tba\n;  r\n")));
+  };
+
+  "flushes correctly"_test = []
+  {
+    stringstream ss;
+    ss << indent::incr << "test";
+    ss.flush();
+    expect(eq(ss.str(), string("  test")));
+  };
+};


### PR DESCRIPTION
This changes the code to use generic ostreams to write reports as well as game output files. 
The wrap/indent/logic which used to be part of Areport is now written as a streambuf interceptor
which inserts itself into the streams that want it.   This will allow us to (as we go farther) to use
stringstreams for testing so that we can compare/check output in test suites.

This does not *yet* modify the rules generation, nor does it *yet* support json output for
reports (and templates) but that will be coming soon.

The snapshot tests were modified (before my code changes) to generate one turn with map
output to make sure my changes did not break those formats either.