### PR TITLE
Part 2 of the json reports

### DIFF
--- a/aregion.h
+++ b/aregion.h
@@ -201,7 +201,7 @@ class ARegion : public AListElem
 		void WriteMarkets(ostream& f, Faction *, int);
 		void WriteEconomy(ostream& f, Faction *, int);
 		void WriteExits(ostream& f, ARegionList *pRegs, int *exits_seen);
-		void WriteReport(ostream& f, Faction *fac, int month, ARegionList *pRegions);
+		void write_text_report(ostream& f, Faction *fac, int month, ARegionList *pRegions);
 		void write_json_report(json& j, Faction *fac, int month, ARegionList *pRegions);
 		// DK
 		void WriteTemplate(ostream&  f, Faction *, ARegionList *, int);

--- a/battle.h
+++ b/battle.h
@@ -35,6 +35,9 @@ class Battle;
 #include "events.h"
 #include <vector>
 
+#include "external/nlohmann/json.hpp"
+using json = nlohmann::json;
+
 enum {
 	ASS_NONE,
 	ASS_SUCC,
@@ -48,19 +51,14 @@ enum {
 	BATTLE_DRAW
 };
 
-class BattlePtr : public AListElem
-{
-	public:
-		Battle * ptr;
-};
-
 class Battle : public AListElem
 {
 	public:
 		Battle();
 		~Battle();
 
-		void Report(ostream& f,Faction *fac);
+		void write_text_report(ostream& f, Faction *fac);
+		void write_json_report(json &j, Faction *fac);
 		void AddLine(const AString &);
 
 		int Run(Events* events, ARegion *, Unit *, AList *, Unit *, AList *, int ass,
@@ -86,8 +84,8 @@ class Battle : public AListElem
 
 		int assassination;
 		Faction * attacker; /* Only matters in the case of an assassination */
-		AString * asstext;
-		AList text;
+		std::string asstext;
+		std::vector<std::string> text;
 };
 
 #endif

--- a/faction.h
+++ b/faction.h
@@ -168,8 +168,8 @@ public:
 	void SetAddress( AString &strNewAddress );
 	
 	void CheckExist(ARegionList *);
-	void Error(const AString &);
-	void Event(const AString &);
+	void error(const string& s);
+	void event(const string& s);
 	
 	AString FactionTypeStr();
 	void write_text_report(ostream& f, Game *pGame, size_t **citems);
@@ -191,8 +191,7 @@ public:
 	void DefaultOrders();
 	void TimesReward();
 	
-	void SetNPC();
-	int IsNPC();
+	bool is_npc = false; // by default factions are not NPCs
 
 	void DiscoverItem(int item, int force, int full);
 
@@ -238,6 +237,7 @@ public:
 	AList present_regions;
 	
 	int defaultattitude;
+	// TODO: Convert this to a hashmap of <attitude, vector<factionid>>
 	AList attitudes;
 	SkillList skills;
 	ItemList items;
@@ -246,10 +246,10 @@ public:
 	// Both are lists of AStrings
 	//
 	AList extraPlayers;
-	AList errors;
-	AList events;
-	AList battles;
+	vector<string> errors;
+	vector<string> events;
 
+	vector<Battle *> battles;
 	vector<ShowSkill> shows;
 	vector<string> itemshows;
 	vector<string> objectshows;

--- a/game.cpp
+++ b/game.cpp
@@ -92,7 +92,7 @@ void Game::DefaultWorkOrder()
 			Object *o = (Object *) elem;
 			forlist(&o->units) {
 				Unit *u = (Unit *) elem;
-				if (u->monthorders || u->faction->IsNPC() ||
+				if (u->monthorders || u->faction->is_npc ||
 						(Globals->TAX_PILLAGE_MONTH_LONG &&
 						 u->taxing != TAX_NONE))
 					continue;
@@ -759,7 +759,7 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 	} else if (*pToken == "Reward:") {
 		pTemp = pLine->gettoken();
 		int nAmt = pTemp->value();
-		pFac->Event(AString("Reward of ") + nAmt + " silver.");
+		pFac->event("Reward of " + to_string(nAmt) + " silver.");
 		pFac->unclaimed += nAmt;
 	} else if (*pToken == "SendTimes:") {
 		// get the token, but otherwise ignore it
@@ -1069,7 +1069,7 @@ int Game::RunGame()
 	Awrite("Writing order templates...");
 	WriteTemplates();
 	Awrite("");
-	battles.DeleteAll();
+	battles.clear();
 
 	EmptyHell();
 
@@ -1136,7 +1136,7 @@ void Game::ReadOrders()
 {
 	forlist(&factions) {
 		Faction *fac = (Faction *) elem;
-		if (!fac->IsNPC()) {
+		if (!fac->is_npc) {
 			AString str = "orders.";
 			str += fac->num;
 
@@ -1213,7 +1213,7 @@ void Game::WriteReport()
 		Faction *fac = (Faction *) elem;
 		string str = "report." + to_string(fac->num);
 
-		if (!fac->IsNPC() || fac->gets_gm_report(this)) {
+		if (!fac->is_npc || fac->gets_gm_report(this)) {
 			if (Globals->REPORT_FORMAT & GameDefs::REPORT_FORMAT_TEXT) {
 				ofstream f(str, ios::out|ios::ate);
 				if (f.is_open()) {
@@ -1244,7 +1244,7 @@ void Game::WriteTemplates()
 {
 	forlist(&factions) {
 		Faction *fac = (Faction *) elem;
-		if (!fac->IsNPC()) {
+		if (!fac->is_npc) {
 			string str = "template." + to_string(fac->num);
 			ofstream f(str.c_str(), ios::out|ios::ate);
 			if (f.is_open()) {
@@ -1261,7 +1261,7 @@ void Game::DeleteDeadFactions()
 {
 	forlist(&factions) {
 		Faction *fac = (Faction *) elem;
-		if (!fac->IsNPC() && !fac->exists) {
+		if (!fac->is_npc && !fac->exists) {
 			factions.Remove(fac);
 			forlist((&factions))
 				((Faction *) elem)->RemoveAttitude(fac->num);
@@ -1453,8 +1453,7 @@ void Game::RemoveInactiveFactions()
 	cturn = TurnNumber();
 	forlist(&factions) {
 		Faction *fac = (Faction *) elem;
-		if ((cturn - fac->lastorders) >= Globals->MAX_INACTIVE_TURNS &&
-				!fac->IsNPC()) {
+		if ((cturn - fac->lastorders) >= Globals->MAX_INACTIVE_TURNS &&	!fac->is_npc) {
 			fac->quit = QUIT_BY_GM;
 		}
 	}
@@ -1863,7 +1862,7 @@ void Game::CreateNPCFactions()
 		guardfaction = f->num;
 		temp = new AString("The Guardsmen");
 		f->SetName(temp);
-		f->SetNPC();
+		f->is_npc = true;
 		f->lastorders = 0;
 		factions.Add(f);
 	} else
@@ -1875,7 +1874,7 @@ void Game::CreateNPCFactions()
 		monfaction = f->num;
 		temp = new AString("Creatures");
 		f->SetName(temp);
-		f->SetNPC();
+		f->is_npc = true;
 		f->lastorders = 0;
 		factions.Add(f);
 	} else
@@ -2139,7 +2138,7 @@ void Game::CountItems(size_t ** citems)
 	forlist (&factions)
 	{
 		Faction * fac = (Faction *) elem;
-		if (!fac->IsNPC())
+		if (!fac->is_npc)
 		{
 			for (int j = 0; j < NITEMS; j++)
 			{

--- a/game.h
+++ b/game.h
@@ -295,7 +295,7 @@ private:
 
 	AList factions;
 	AList newfactions; /* List of strings */
-	AList battles;
+	vector<Battle *> battles;
 	ARegionList regions;
 	int factionseq;
 	unsigned int unitseq;

--- a/gamedefs.cpp
+++ b/gamedefs.cpp
@@ -23,6 +23,7 @@
 //
 // END A3HEADER
 #include "gamedefs.h"
+#include <string>
 
 char const *dr[] = {
 	"North",
@@ -63,11 +64,9 @@ char const *mn[] = {
 
 char const ** MonthNames = mn;
 
-char const *weath[] = {
+std::string SeasonNames[] = {
 	"clear",
 	"winter",
 	"monsoon season",
 	"blizzard"
 };
-
-char const ** SeasonNames = weath;

--- a/gamedefs.h
+++ b/gamedefs.h
@@ -26,6 +26,7 @@
 #ifndef GAME_DEFS
 #define GAME_DEFS
 
+#include <string>
 #include "helper.h"
 
 /* Directions */
@@ -44,7 +45,7 @@ extern char const **DirectionAbrs;
 
 extern char const **MonthNames;
 
-extern char const **SeasonNames;
+extern std::string SeasonNames[];
 
 extern int *allowedMages;
 extern int allowedMagesSize;

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -594,7 +594,7 @@ Faction *Game::CheckVictory()
 		f = (Faction *) elem;
 		// No accidentally sending all the Guardsmen
 		// or Creatures to the Eternal City!
-		if (f->IsNPC())
+		if (f->is_npc)
 			continue;
 		reliccount = 0;
 		forlist(&regions) {
@@ -674,7 +674,7 @@ Faction *Game::CheckVictory()
 			temp += " and returned to the Eternal City.";
 			message = AString("You") + temp;
 			times = *f->name + temp;
-			f->Event(message);
+			f->event(message.const_str());
 			message = "You";
 			times += "\n\nThey";
 			temp = " returned after ";
@@ -750,7 +750,7 @@ Faction *Game::CheckVictory()
 				times += "  They";
 				times += temp;
 			}
-			f->Event(message);
+			f->event(message.const_str());
 			WriteTimesArticle(times);
 
 			string filename = "winner." + to_string(f->num);

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -330,23 +330,18 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 
 			forlist_reuse(&facs) {
 				Faction * f = ((FactionPtr *) elem)->ptr;
-				if (x->dir == MOVE_PAUSE) {
-					f->Event(*fleet->name +
-						AString(" performs maneuvers in ") +
-						reg->ShortPrint(&regions) +
-						AString("."));
-				} else {
-					f->Event(*fleet->name +
-						AString(" sails from ") +
-						reg->ShortPrint(&regions) +
-						AString(" to ") +
-						newreg->ShortPrint(&regions) +
-						AString("."));
+				stringstream tmp;
+				tmp << fleet->name << (x->dir == MOVE_PAUSE ? " performs maneuvers in " : " sails from ")
+				    << reg->ShortPrint(&regions);
+				if(x->dir != MOVE_PAUSE) {
+					tmp << " to " << newreg->ShortPrint(&regions);
 				}
+				tmp << ".";
+				f->event(tmp.str());
 			}
 			if (Globals->TRANSIT_REPORT != GameDefs::REPORT_NOTHING &&
 					x->dir != MOVE_PAUSE) {
-				if (!(cap->faction->IsNPC())) newreg->visited = 1;
+				if (!(cap->faction->is_npc)) newreg->visited = 1;
 				forlist(&fleet->units) {
 					// Everyone onboard gets to see the sights
 					unit = (Unit *) elem;
@@ -371,10 +366,9 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 			}
 			reg = newreg;
 			if (newreg->ForbiddenShip(fleet)) {
-				cap->faction->Event(*fleet->name +
-					AString(" is stopped by guards in ") +
-					newreg->ShortPrint(&regions) + 
-					AString("."));
+				stringstream tmp;
+				tmp << fleet->name << " is stopped by guards in " << newreg->ShortPrint(&regions) << ".";
+				cap->faction->event(tmp.str());
 				stop = 1;
 			}
 			o->dirs.Remove(x);
@@ -2000,7 +1994,7 @@ Location *Game::DoAMoveOrder(Unit *unit, ARegion *region, Object *obj)
 
 	// TODO: Should we get a transit report on the starting region?
 	if (Globals->TRANSIT_REPORT != GameDefs::REPORT_NOTHING) {
-		if (!(unit->faction->IsNPC())) newreg->visited = 1;
+		if (!(unit->faction->is_npc)) newreg->visited = 1;
 		// Update our visit record in the region we are leaving.
 		Farsight *f;
 		forlist(&region->passers) {

--- a/object.cpp
+++ b/object.cpp
@@ -156,7 +156,7 @@ void Object::Readin(istream& f, AList *facs)
 		if (!temp->faction)
 			continue;
 		temp->MoveUnit(this);
-		if (!(temp->faction->IsNPC())) region->visited = 1;
+		if (!(temp->faction->is_npc)) region->visited = 1;
 	}
 	mages = ObjectDefs[type].maxMages;
 	ReadinFleet(f);

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -296,11 +296,12 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 		}
 	}
 	if (!succ) {
-		AString temp = *(u->name) + " is caught attempting to assassinate " +
-			*(tar->name) + " in " + *(r->name) + ".";
+		stringstream temp;
+		temp << u->name << " is caught attempting to assassinate " << tar->name << " in " << r->name << ".";
+		string temp2 = temp.str();
 		forlist(seers) {
 			Faction *f = ((FactionPtr *) elem)->ptr;
-			f->Event(temp);
+			f->event(temp2);
 		}
 		// One learns from one's mistakes.  Surviving them is another matter!
 		u->PracticeAttribute("stealth");
@@ -370,11 +371,12 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 	}
 
 	if (!succ) {
-		AString temp = *(u->name) + " is caught attempting to steal from " +
-			*(tar->name) + " in " + *(r->name) + ".";
+		stringstream temp;
+		temp << u->name << " is caught attempting to steal from " << tar->name << " in " << r->name << ".";
+		string temp2 = temp.str();
 		forlist(seers) {
 			Faction *f = ((FactionPtr *) elem)->ptr;
-			f->Event(temp);
+			f->event(temp2);
 		}
 		// One learns from one's mistakes.  Surviving them is another matter!
 		u->PracticeAttribute("stealth");
@@ -408,11 +410,12 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 	tar->items.SetNum(so->item, tar->items.GetNum(so->item) - amt);
 
 	{
-		AString temp = *(u->name) + " steals " +
-			ItemString(so->item, amt) + " from " + *(tar->name) + ".";
+		stringstream temp;
+		temp << u->name << " steals " << ItemString(so->item, amt) << " from " << tar->name << ".";
+		string temp2 = temp.str();
 		forlist(seers) {
 			Faction *f = ((FactionPtr *) elem)->ptr;
-			f->Event(temp);
+			f->event(temp2);
 		}
 	}
 
@@ -639,8 +642,9 @@ void Game::RunFindUnit(Unit *u)
 		if (!all) {
 			fac = GetFaction(&factions, f->find);
 			if (fac) {
-				u->faction->Event(AString("The address of ") + *(fac->name) +
-						" is " + *(fac->address) + ".");
+				stringstream temp;
+				temp << "The address of " << fac->name << " is " << fac->address << ".";
+				u->faction->event(temp.str());
 			} else {
 				u->Error(AString("FIND: ") + f->find + " is not a valid "
 						"faction number.");
@@ -649,8 +653,9 @@ void Game::RunFindUnit(Unit *u)
 			forlist(&factions) {
 				fac = (Faction *)elem;
 				if (fac) {
-					u->faction->Event(AString("The address of ") +
-							*(fac->name) + " is " + *(fac->address) + ".");
+					stringstream temp;
+					temp << "The address of " << fac->name << " is " << fac->address << ".";
+					u->faction->event(temp.str());
 				}
 			}
 		}
@@ -844,8 +849,9 @@ void Game::RunPillageRegion(ARegion *reg)
 				forlist(facs) {
 					Faction *fp = ((FactionPtr *) elem)->ptr;
 					if (fp != u->faction) {
-						fp->Event(*(u->name) + " pillages " +
-								*(reg->name) + ".");
+						stringstream temp;
+						temp << u->name << " pillages " << reg->name << ".";
+						fp->event(temp.str());
 					}
 				}
 			}
@@ -1168,10 +1174,11 @@ void Game::EndGame(Faction *pVictor)
 		else
 			pFac->quit = QUIT_GAME_OVER;
 
-		if (pVictor)
-			pFac->Event(*(pVictor->name) + " has won the game!");
-		else
-			pFac->Event("The game has ended with no winner.");
+		if (pVictor) {
+			string temp(pVictor->name->const_str());
+			pFac->event(temp + " has won the game!");
+		} else
+			pFac->event("The game has ended with no winner.");
 	}
 
 	gameStatus = GAME_STATUS_FINISHED;
@@ -2023,7 +2030,7 @@ void Game::AssessMaintenance()
 			Object *obj = (Object *) elem;
 			forlist((&obj->units)) {
 				Unit *u = (Unit *) elem;
-				if (!(u->faction->IsNPC())) {
+				if (!(u->faction->is_npc)) {
 					r->visited = 1;
 					if (quests.CheckQuestVisitTarget(r, u, &quest_rewards)) {
 						u->Event(AString("You have completed a pilgrimage!") + quest_rewards);
@@ -2576,7 +2583,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 			u->Error(ord + ": " + o->target->Print() +
 					" is not a member of your faction.");
 			return 0;
-		} else if (u->faction != t->faction && t->faction->IsNPC()) {
+		} else if (u->faction != t->faction && t->faction->is_npc) {
 			u->Error(ord + ": Can't give to non-player unit (" +
 				o->target->Print() + ").");
 			return 0;
@@ -2822,7 +2829,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		u->Error(ord + ": " + o->target->Print() +
 				" is not a member of your faction.");
 		return 0;
-	} else if (u->faction != t->faction && t->faction->IsNPC()) {
+	} else if (u->faction != t->faction && t->faction->is_npc) {
 		u->Error(ord + ": Can't give to non-player unit (" +
 				o->target->Print() + ").");
 		return 0;

--- a/unit.cpp
+++ b/unit.cpp
@@ -1588,7 +1588,7 @@ void Unit::Short(int needed, int hunger)
 {
 	int i, n = 0, levels;
 
-	if (faction->IsNPC())
+	if (faction->is_npc)
 		return; // Don't starve monsters and the city guard!
 
 	if (needed < 1 && hunger < 1) return;
@@ -2462,14 +2462,14 @@ void Unit::DiscardUnfinishedShips() {
 
 void Unit::Event(const AString & s)
 {
-	AString temp = *name + ": " + s;
-	faction->Event(temp);
+	string temp(name->const_str());
+	faction->event(temp + ": " + s.const_str());
 }
 
 void Unit::Error(const AString & s)
 {
-	AString temp = *name + ": " + s;
-	faction->Error(temp);
+	string temp(name->const_str());
+	faction->error(temp + ": " + s.const_str());
 }
 
 int Unit::GetAttribute(char const *attrib)

--- a/unittest/json_report_test.cpp
+++ b/unittest/json_report_test.cpp
@@ -19,7 +19,7 @@ ut::suite<"JSON Report"> json_report_suite = []
 {
   using namespace ut;
 
-  "Report contains basic faction information for a new faction"_test = []
+  "Faction json contains basic faction information"_test = []
   {
     UnitTestHelper helper;
     helper.initialize_game();
@@ -38,18 +38,135 @@ ut::suite<"JSON Report"> json_report_suite = []
     // pick some of the data out of the report for checking
     string data_name = json_report["name"];
     int data_num = json_report["number"];
-    string data_month = json_report["date"]["month"];
-    int new_items = json_report["item_reports"].size();
-    int new_skills = json_report["skill_reports"].size();
-    int regions = json_report["regions"].size();
+    auto new_items = json_report["item_reports"].size();
+    auto new_skills = json_report["skill_reports"].size();
+    auto regions = json_report["regions"].size();
 
-    expect(data_name == name);
-    expect(data_num == 3_i);
-    expect(new_items == 1_i); // should just be the new leader
-    expect(new_skills == 3_i); // should be combat 1, 2, and 3
-    expect(regions == 1_i); // and we should only have 1 region we know about (our start region)
+    expect(data_name == name); // faction name should match our name.
+    expect(data_num == 3_i); // faction num should be 3 since we have guards and wandering monsters.
+    expect(new_items == 1_ul); // should just be the new leader
+    expect(new_skills == 3_ul); // should be combat 1, 2, and 3 based on the test game setup.
 
+    // Verify that the game date is correct.
     string expected_month("January");
+    string data_month = json_report["date"]["month"];
     expect(data_month == expected_month);
+
+    // Verify the basic region info is correct.
+    expect(regions == 1_ul); // and we should only have 1 region we know about (our start region)
   };
+
+  "Errors are reported"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    Faction *faction = helper.create_faction("Test Faction");
+    faction->error("This is an error");
+
+    json json_report;
+    faction->write_json_report(json_report, &helper.game_object(), nullptr);
+
+    auto count = json_report["errors"].size();
+    expect(count == 1_ul);
+    string error = json_report["errors"][0];
+    string expected = "This is an error";
+    expect(error == expected);
+  };
+
+  "More than 1000 errors will log a too many errors and ignore the rest"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    Faction *faction = helper.create_faction("Test Faction");
+    for(auto i = 0; i < 1003; i++) faction->error("This is error #" + to_string(i+1));
+
+    json json_report;
+    faction->write_json_report(json_report, &helper.game_object(), nullptr);
+
+    auto count = json_report["errors"].size();
+    expect(count == 1001_ul);
+    string error = json_report["errors"][1000];
+    string expected = "Too many errors!";
+    expect(error == expected);
+
+    error = json_report["errors"][999];
+    expected = "This is error #1000";
+    expect(error == expected);
+  };
+
+  "Events are reported"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    Faction *faction = helper.create_faction("Test Faction");
+    faction->event("This is event 1");
+    faction->event("This is event 2");
+
+    json json_report;
+    faction->write_json_report(json_report, &helper.game_object(), nullptr);
+
+    auto count = json_report["events"].size();
+    expect(count == 2_ul);
+
+    // make sure they are in the right order
+    string event = json_report["events"][0];
+    string expected = "This is event 1";
+    expect(event == expected);
+
+    event = json_report["events"][1];
+    expected = "This is event 2";
+    expect(event == expected);
+  };
+
+
+  "Region json contains basic region information"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    helper.setup_reports();
+
+    // Generate just this single regions json object.
+    Faction *faction = helper.create_faction("Test Faction");
+    ARegion *region = helper.get_region(0, 0, 0);
+    ARegionList *regions = helper.get_regions();
+
+    json json_report;
+    region->write_json_report(json_report, faction, helper.get_month(), regions);
+
+    string expected_provice("Testing Wilds"); // name given in the unit test setup
+    string province = json_report["province"];
+    expect(province == expected_provice);
+
+    string expected_terrain("plain"); // should be the terrain set up in the unit test
+    string terrain = json_report["terrain"];
+    expect(terrain == expected_terrain);
+
+    auto x = json_report["coordinates"]["x"];
+    auto y = json_report["coordinates"]["y"];
+    auto z = json_report["coordinates"]["z"];
+    expect(x == 0_i);
+    expect(y == 0_i);
+    expect(z == 0_i);
+
+    string expected_label("surface");
+    string label = json_report["coordinates"]["label"];
+    expect(label == expected_label);
+
+    string settlement_name = json_report["settlement"]["name"];
+    string expected_settlement_name("Basictown"); // name given in the unit test setup
+    expect(settlement_name == expected_settlement_name);
+
+    string settlement_size = json_report["settlement"]["size"];
+    string expected_settlement_size("city");
+    expect(settlement_size == expected_settlement_size);
+  };
+
 };

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -39,6 +39,11 @@ Faction *UnitTestHelper::create_faction(string name) {
     return fac;
 }
 
+ARegion *UnitTestHelper::get_region(int x, int y, int z) {
+    ARegionArray *level = game.regions.pRegionArrays[z];
+    return level->GetRegion(x, y);
+}
+
 string UnitTestHelper::cout_data() {
     return cout_buffer.str();
 }

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -33,6 +33,12 @@ public:
     int get_region_count();
     // Create a faction that we can use for testing.
     Faction *create_faction(string name);
+    // Get a region by coordinates
+    ARegion *get_region(int x, int y, int level);
+    // Get all regions
+    ARegionList *get_regions() { return &game.regions; }
+    // get the game month 
+    int get_month() { return game.month; }
 
     // Get the contents of cout as a string.
     string cout_data();

--- a/unittest/world.cpp
+++ b/unittest/world.cpp
@@ -37,7 +37,7 @@ void Game::CreateWorld() {
     Awrite("Creating world");
     regions.CreateLevels(1);    
     // because of the way regions are numbered, if you want 4 hexes you need a height of 4 and a width of 2.
-    regions.CreateSurfaceLevel(0, 2, 4, "Surface");
+    regions.CreateSurfaceLevel(0, 2, 4, nullptr);
  }
 
 int ARegionList::GetRegType( ARegion *pReg ) { return 0; }


### PR DESCRIPTION
Intent of this part is to get basic region data and the rest of  the faction data bits into the json report.

- errors, and events converted to (for now) a string vector. Will eventually make this a more interesting structure including things like unit/location when appropriate.
- Replaced the SetNPC()/IsNPC() functions with a boolean variable. There is a bit of oddity around save/load in game.in since that state was previously determined by the type values.  So added a bit of a hack to preserve data file integrity. Will likely need to live with that hack until we move to a json input/output file format for game data since converting/updating data format in current style is harder than it should be.
- Wrote out basic regions information to json output, but not yet going into buildings/units.
- Still not going into battles, but they were just text string blobs anyway in the battle 'text' member.. they should eventually become json-y objects.