### PR TITLE
Finish object reports, write unit reports

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -1365,7 +1365,7 @@ void ARegion::write_json_report(json& j, Faction *fac, int month, ARegionList *r
 
 		ItemType itemdef = ItemDefs[m->item];
 		json item = {
-			{ "name", itemdef.name }, { "plural", itemdef.names }, { "abbr", itemdef.abr }, { "price", m->price }
+			{ "name", itemdef.name }, { "plural", itemdef.names }, { "tag", itemdef.abr }, { "price", m->price }
 		};
 		if (m->amount != -1) item["amount"] = m->amount;
 		else item["unlimited"] = true;
@@ -1396,7 +1396,7 @@ void ARegion::write_json_report(json& j, Faction *fac, int month, ARegionList *r
 		// If it's a normal resource, and we aren't here or not showing it, skip it.
 		if (!present && !(Globals->TRANSIT_REPORT & GameDefs::REPORT_SHOW_RESOURCES)) continue;
 		json item = {
-			{ "name", itemdef.name }, { "plural", itemdef.names }, { "abbr", itemdef.abr },
+			{ "name", itemdef.name }, { "plural", itemdef.names }, { "tag", itemdef.abr },
 	 	};
 		// I don't think resources can be unlimited, but just in case, we will handle it.
 		if (p->amount != -1) item["amount"] = p->amount;

--- a/object.cpp
+++ b/object.cpp
@@ -342,35 +342,29 @@ void Object::write_json_report(json& j, Faction *fac, int obs, int truesight,
 		}
 	}
 
-	//json& unit_container = (type == O_DUMMY) ? j["units"] : container["units"];
+	json& unit_container = (type == O_DUMMY) ? j["units"] : container["units"];
 
 	// Add units to container
-	/* 
 	forlist ((&units)) {
 		Unit *u = (Unit *) elem;
+		json unit = json::object();
 		int attitude = fac->get_attitude(u->faction->num);
 		if (u->faction == fac) {
-			u->WriteReport(f, -1, 1, 1, 1, attitude, fac->showunitattitudes);
+			u->write_json_report(unit, -1, 1, 1, 1, attitude, fac->showunitattitudes);
 		} else {
 			if (present) {
-				u->WriteReport(f, obs, truesight, detfac, type != O_DUMMY, attitude, fac->showunitattitudes);
+				u->write_json_report(unit, obs, truesight, detfac, type != O_DUMMY, attitude, fac->showunitattitudes);
 			} else {
-				if (((type == O_DUMMY) &&
-					(Globals->TRANSIT_REPORT &
-					 GameDefs::REPORT_SHOW_OUTDOOR_UNITS)) ||
-					((type != O_DUMMY) &&
-						(Globals->TRANSIT_REPORT &
-					 	GameDefs::REPORT_SHOW_INDOOR_UNITS)) ||
-					((u->guard == GUARD_GUARD) &&
-						(Globals->TRANSIT_REPORT &
-					 	GameDefs::REPORT_SHOW_GUARDS))) {
-					u->WriteReport(f, passobs, passtrue, passdetfac,
-							type != O_DUMMY, attitude, fac->showunitattitudes);
+				if (((type == O_DUMMY) && (Globals->TRANSIT_REPORT & GameDefs::REPORT_SHOW_OUTDOOR_UNITS)) ||
+					((type != O_DUMMY) && (Globals->TRANSIT_REPORT & GameDefs::REPORT_SHOW_INDOOR_UNITS)) ||
+					((u->guard == GUARD_GUARD) && (Globals->TRANSIT_REPORT & GameDefs::REPORT_SHOW_GUARDS))) {
+					u->write_json_report(unit, passobs, passtrue, passdetfac, type != O_DUMMY, attitude, fac->showunitattitudes);
 				}
 			}
 		}
+		if (unit.empty()) continue;
+		unit_container.push_back(unit);
 	}
-	*/
 
 	if (type != O_DUMMY) {
 		j["structures"].push_back(container);
@@ -480,10 +474,10 @@ void Object::write_text_report(ostream& f, Faction *fac, int obs, int truesight,
 		Unit *u = (Unit *) elem;
 		int attitude = fac->get_attitude(u->faction->num);
 		if (u->faction == fac) {
-			u->WriteReport(f, -1, 1, 1, 1, attitude, fac->showunitattitudes);
+			u->write_text_report(f, -1, 1, 1, 1, attitude, fac->showunitattitudes);
 		} else {
 			if (present) {
-				u->WriteReport(f, obs, truesight, detfac, type != O_DUMMY, attitude, fac->showunitattitudes);
+				u->write_text_report(f, obs, truesight, detfac, type != O_DUMMY, attitude, fac->showunitattitudes);
 			} else {
 				if (((type == O_DUMMY) &&
 					(Globals->TRANSIT_REPORT &
@@ -494,7 +488,7 @@ void Object::write_text_report(ostream& f, Faction *fac, int obs, int truesight,
 					((u->guard == GUARD_GUARD) &&
 						(Globals->TRANSIT_REPORT &
 					 	GameDefs::REPORT_SHOW_GUARDS))) {
-					u->WriteReport(f, passobs, passtrue, passdetfac,
+					u->write_text_report(f, passobs, passtrue, passdetfac,
 							type != O_DUMMY, attitude, fac->showunitattitudes);
 				}
 			}

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -2656,7 +2656,7 @@ void Game::ProcessNospoilsOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	int val = ParseTF(token);
 	delete token;
 	if (val==-1) {
-		ParseError(pCheck, u, 0, "NOSPILS: Invalid value.");
+		ParseError(pCheck, u, 0, "NOSPOILS: Invalid value.");
 		return;
 	}
 	if (!pCheck) {

--- a/unit.h
+++ b/unit.h
@@ -49,6 +49,9 @@ class UnitId;
 #include <set>
 #include <string>
 
+#include "external/nlohmann/json.hpp"
+using json = nlohmann::json;
+
 enum {
 	GUARD_NONE,
 	GUARD_GUARD,
@@ -130,7 +133,9 @@ class Unit : public AListElem
 
 		AString SpoilsReport(void);
 		int CanGetSpoil(Item *i);
-		void WriteReport(ostream& f,int,int,int,int, int, int);
+		void write_text_report(ostream& f, int obs, int truesight, int detfac, int autosee, int attitude, int showattitudes);
+		void write_json_report(json& j, int obs, int truesight, int detfac, int autosee, int attitude, int showattitudes);
+		json write_json_orders();
 		AString GetName(int);
 		AString MageReport();
 		AString ReadyItem();

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -67,3 +67,6 @@ string UnitTestHelper::cout_data() {
     return cout_buffer.str();
 }
 
+void UnitTestHelper::parse_orders(int faction_id, istream& orders) {
+    game.ParseOrders(faction_id, orders, nullptr);
+}

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -43,7 +43,8 @@ public:
     Unit *get_first_unit(Faction *faction);
     // Create a fleet in the given region.
     void create_fleet(ARegion *region, Unit *owner, int ship_type, int ship_count);
-
+    // Parse the orders contained in the input stream.
+    void parse_orders(int faction_id, istream& orders);
 
     // dummy
     int get_seed() { return getrandom(10000); };


### PR DESCRIPTION
* This finishes up the object reports and fully outputs the unit reports including their orders.
* It also replaces the 'abbr' json field with 'tag' which is better imho (thanks Valdis for the suggestion to rename it)

NOTE - the orders field on the unit in the json output retains the nested structure we parse things into.  So, where the text orders would look something like

```
study foo
turn
   study bar
   claim 100
endturn
```

the json would look something like
```
[
  { "order": "study foo" }
  { "order": "turn",
    "nested": [
      { "order": "study bar" }
      { "order": "claim 100" }
    ]
  }
  { "order": "endturn" }
]
```
under the units "orders" key.

While that final 'endturn' is redundant in the json, I chose to leave it so that someone just iterating the json array and nested orders, would have it there and wouldn't have to fake it when it reached the end of it's nested list.  If there is a strong objection, I can/will remove it.