### PR TITLE
Update README and genrules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: cpp
-compiler:
-  - clang
-  - gcc
-script: make all

--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
 # Atlantis PBEM Source Code
-[![Build Status](https://travis-ci.org/Atlantis-PBEM/Atlantis.svg?branch=master)](https://travis-ci.org/Atlantis-PBEM)
+[![Build Status](https://github.com/Atlantis-PBEM/Atlantis/actions/workflows/build.yml/badge.svg)](https://github.com/Atlantis-PBEM/Atlantis)
+[![License: GPL v2](https://img.shields.io/badge/License-GPL_v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
-Copyright 1998-2001 Geoff Dunbar
+Copyright 1998-2023 orginally by Geoff Dunbar & Russell Wallace
+Additional copyright to various changes by Larry Stanberry, JT Traub, Stephen Baillie, Artem Trytiak, and many,
+many others throughout the history of the project.
 
-This distribution of the Atlantis source code purposefully comes with
-only this file as documentation. Please visit the Atlantis Project Gamemaster
-Guide (https://github.com/Atlantis-PBEM/Atlantis/blob/master/GAMEMASTER.md) for full documentation.
+Please see [the Credits file](https://github.com/Atlantis-PBEM/Atlantis/blob/master/CREDITS) for a more
+complete, but still inadequate, list of additional contributors.
 
+This distribution of the Atlantis source code purposefully comes with only this file as documentation. Please
+visit the [Atlantis Project Gamemaster Guide](https://github.com/Atlantis-PBEM/Atlantis/blob/master/GAMEMASTER.md)
+for more documentation.
 
-The Atlantis source code is released under the terms of the file
-LICENSE, which should be in the same directory as this file. If the
-license file is not present, please delete the source code, and retrieve the
-official release from the Atlantis Development Egroup at
-http://groups.yahoo.com/group/atlantisdev/
+Additional support can be found via the [Atlantis New Origins Discord](https://discord.gg/HusGETf) which exists
+primarily to support [Atlantis New Origins](https://atlantis-pbem.com) games, but also serves as a development
+community to improve the game.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
+License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program, in the file
+[LICENSE](https://github.com/Atlantis-PBEM/Atlantis/blob/master/LICENSE) which should exist in the same directory
+as this file.   If the license file is not present, please delete the source code, and retrieve the official
+source code from the [Github](https://github.com/Atlants-PBEM/Atlantis) repository.

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -5187,17 +5187,23 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << enclose("p", false);
 	f << enclose("p", true) << "Larry Stanbery created the Atlantis 4.0.4+ derivative.\n"
 	  << enclose("p", false);
-	f << enclose("p", true) << url("mailto:jtraub@dragoncat.net", "JT Traub") << " took over the source code "
-	  << "and merged the then forking versions of 4.0.4c and 4.0.4+ back into 4.0.5 along with modifications of his "
-	  << "own and has been maintaining the code.\n"
+	f << enclose("p", true) << "JT Traub took over the source code and merged the then forking versions of 4.0.4c "
+	  << "and 4.0.4+ back into 4.0.5 along with modifications of his own and maintained the code until v5.0\n"
 	  << enclose("p", false);
-	f << enclose("p", true) << "Development of the code is open and there is a egroup devoted to it located at "
-	  << url("http://groups.yahoo.com/group/atlantisdev", "The YahooGroups AtlantisDev egroup")
-	  << ". Please join this egroup if you work on the code and share your changes back into the codebase as a "
-	  << "whole\n"
+	f << enclose("p", true) << "After that, Stephen Baillie took over the code and maintained it until "
+	  << "the v5.2.3-v5.2.5 time frame.\n"
 	  << enclose("p", false);
-	f << enclose("p", true) << "Please see the CREDITS file in the source distribution for a complete (hopefully) "
-	  << "list of all contributors.\n"
+	f << enclose("p", true) << "Artem Trytiak took over the code maintainence at that point and has maintained it "
+	  << "since along with a number of other contrubutors to the github project.\n"
+	  << enclose("p", false);
+	f << enclose("p", true) << "The Atlantis source code is now hosted on github at the "
+	  << url("https://github.com/Atlantis-PBEM/Atlantis", "Atlantis") << " github project. "
+	  << "Additionally, Artem runs the " << url("https://atlantis-pbem.com", "New Origins")
+	  << " website which hosts the New Origins games and the related " << url("https://discord.gg/HusGETf", "Discord")
+	  << "server, which serves as a de-facto development community.\n"
+	  << enclose("p", false);
+	f << enclose("p", true) << "Please see the CREDITS file in the source distribution for a more complete, "
+	  << "but still inadequate, list of contributors.\n"
 	  << enclose("p", false);
 
 	f << enclose("body", false);

--- a/snapshot-tests/rules/basic.html
+++ b/snapshot-tests/rules/basic.html
@@ -7100,20 +7100,31 @@ foo@some.email
       Larry Stanbery created the Atlantis 4.0.4+ derivative.
     </p>
     <p>
-      <a href="mailto:jtraub@dragoncat.net">JT Traub</a> took over the source
-      code and merged the then forking versions of 4.0.4c and 4.0.4+ back into
-      4.0.5 along with modifications of his own and has been maintaining the
-      code.
+      JT Traub took over the source code and merged the then forking versions
+      of 4.0.4c and 4.0.4+ back into 4.0.5 along with modifications of his own
+      and maintained the code until v5.0
     </p>
     <p>
-      Development of the code is open and there is a egroup devoted to it
-      located at <a href="http://groups.yahoo.com/group/atlantisdev">The
-      YahooGroups AtlantisDev egroup</a>. Please join this egroup if you work
-      on the code and share your changes back into the codebase as a whole
+      After that, Stephen Baillie took over the code and maintained it until
+      the v5.2.3-v5.2.5 time frame.
     </p>
     <p>
-      Please see the CREDITS file in the source distribution for a complete
-      (hopefully) list of all contributors.
+      Artem Trytiak took over the code maintainence at that point and has
+      maintained it since along with a number of other contrubutors to the
+      github project.
+    </p>
+    <p>
+      The Atlantis source code is now hosted on github at the <a
+      href="https://github.com/Atlantis-PBEM/Atlantis">Atlantis</a> github
+      project. Additionally, Artem runs the <a
+      href="https://atlantis-pbem.com">New Origins</a> website which hosts the
+      New Origins games and the related <a
+      href="https://discord.gg/HusGETf">Discord</a>server, which serves as a
+      de-facto development community.
+    </p>
+    <p>
+      Please see the CREDITS file in the source distribution for a more
+      complete, but still inadequate, list of contributors.
     </p>
   </body>
 </html>

--- a/snapshot-tests/rules/fracas.html
+++ b/snapshot-tests/rules/fracas.html
@@ -7380,20 +7380,31 @@ WORK
       Larry Stanbery created the Atlantis 4.0.4+ derivative.
     </p>
     <p>
-      <a href="mailto:jtraub@dragoncat.net">JT Traub</a> took over the source
-      code and merged the then forking versions of 4.0.4c and 4.0.4+ back into
-      4.0.5 along with modifications of his own and has been maintaining the
-      code.
+      JT Traub took over the source code and merged the then forking versions
+      of 4.0.4c and 4.0.4+ back into 4.0.5 along with modifications of his own
+      and maintained the code until v5.0
     </p>
     <p>
-      Development of the code is open and there is a egroup devoted to it
-      located at <a href="http://groups.yahoo.com/group/atlantisdev">The
-      YahooGroups AtlantisDev egroup</a>. Please join this egroup if you work
-      on the code and share your changes back into the codebase as a whole
+      After that, Stephen Baillie took over the code and maintained it until
+      the v5.2.3-v5.2.5 time frame.
     </p>
     <p>
-      Please see the CREDITS file in the source distribution for a complete
-      (hopefully) list of all contributors.
+      Artem Trytiak took over the code maintainence at that point and has
+      maintained it since along with a number of other contrubutors to the
+      github project.
+    </p>
+    <p>
+      The Atlantis source code is now hosted on github at the <a
+      href="https://github.com/Atlantis-PBEM/Atlantis">Atlantis</a> github
+      project. Additionally, Artem runs the <a
+      href="https://atlantis-pbem.com">New Origins</a> website which hosts the
+      New Origins games and the related <a
+      href="https://discord.gg/HusGETf">Discord</a>server, which serves as a
+      de-facto development community.
+    </p>
+    <p>
+      Please see the CREDITS file in the source distribution for a more
+      complete, but still inadequate, list of contributors.
     </p>
   </body>
 </html>

--- a/snapshot-tests/rules/havilah.html
+++ b/snapshot-tests/rules/havilah.html
@@ -7847,20 +7847,31 @@ foo@some.email
       Larry Stanbery created the Atlantis 4.0.4+ derivative.
     </p>
     <p>
-      <a href="mailto:jtraub@dragoncat.net">JT Traub</a> took over the source
-      code and merged the then forking versions of 4.0.4c and 4.0.4+ back into
-      4.0.5 along with modifications of his own and has been maintaining the
-      code.
+      JT Traub took over the source code and merged the then forking versions
+      of 4.0.4c and 4.0.4+ back into 4.0.5 along with modifications of his own
+      and maintained the code until v5.0
     </p>
     <p>
-      Development of the code is open and there is a egroup devoted to it
-      located at <a href="http://groups.yahoo.com/group/atlantisdev">The
-      YahooGroups AtlantisDev egroup</a>. Please join this egroup if you work
-      on the code and share your changes back into the codebase as a whole
+      After that, Stephen Baillie took over the code and maintained it until
+      the v5.2.3-v5.2.5 time frame.
     </p>
     <p>
-      Please see the CREDITS file in the source distribution for a complete
-      (hopefully) list of all contributors.
+      Artem Trytiak took over the code maintainence at that point and has
+      maintained it since along with a number of other contrubutors to the
+      github project.
+    </p>
+    <p>
+      The Atlantis source code is now hosted on github at the <a
+      href="https://github.com/Atlantis-PBEM/Atlantis">Atlantis</a> github
+      project. Additionally, Artem runs the <a
+      href="https://atlantis-pbem.com">New Origins</a> website which hosts the
+      New Origins games and the related <a
+      href="https://discord.gg/HusGETf">Discord</a>server, which serves as a
+      de-facto development community.
+    </p>
+    <p>
+      Please see the CREDITS file in the source distribution for a more
+      complete, but still inadequate, list of contributors.
     </p>
   </body>
 </html>

--- a/snapshot-tests/rules/kingdoms.html
+++ b/snapshot-tests/rules/kingdoms.html
@@ -7910,20 +7910,31 @@ foo@some.email
       Larry Stanbery created the Atlantis 4.0.4+ derivative.
     </p>
     <p>
-      <a href="mailto:jtraub@dragoncat.net">JT Traub</a> took over the source
-      code and merged the then forking versions of 4.0.4c and 4.0.4+ back into
-      4.0.5 along with modifications of his own and has been maintaining the
-      code.
+      JT Traub took over the source code and merged the then forking versions
+      of 4.0.4c and 4.0.4+ back into 4.0.5 along with modifications of his own
+      and maintained the code until v5.0
     </p>
     <p>
-      Development of the code is open and there is a egroup devoted to it
-      located at <a href="http://groups.yahoo.com/group/atlantisdev">The
-      YahooGroups AtlantisDev egroup</a>. Please join this egroup if you work
-      on the code and share your changes back into the codebase as a whole
+      After that, Stephen Baillie took over the code and maintained it until
+      the v5.2.3-v5.2.5 time frame.
     </p>
     <p>
-      Please see the CREDITS file in the source distribution for a complete
-      (hopefully) list of all contributors.
+      Artem Trytiak took over the code maintainence at that point and has
+      maintained it since along with a number of other contrubutors to the
+      github project.
+    </p>
+    <p>
+      The Atlantis source code is now hosted on github at the <a
+      href="https://github.com/Atlantis-PBEM/Atlantis">Atlantis</a> github
+      project. Additionally, Artem runs the <a
+      href="https://atlantis-pbem.com">New Origins</a> website which hosts the
+      New Origins games and the related <a
+      href="https://discord.gg/HusGETf">Discord</a>server, which serves as a
+      de-facto development community.
+    </p>
+    <p>
+      Please see the CREDITS file in the source distribution for a more
+      complete, but still inadequate, list of contributors.
     </p>
   </body>
 </html>

--- a/snapshot-tests/rules/neworigins.html
+++ b/snapshot-tests/rules/neworigins.html
@@ -7821,20 +7821,31 @@ WORK
       Larry Stanbery created the Atlantis 4.0.4+ derivative.
     </p>
     <p>
-      <a href="mailto:jtraub@dragoncat.net">JT Traub</a> took over the source
-      code and merged the then forking versions of 4.0.4c and 4.0.4+ back into
-      4.0.5 along with modifications of his own and has been maintaining the
-      code.
+      JT Traub took over the source code and merged the then forking versions
+      of 4.0.4c and 4.0.4+ back into 4.0.5 along with modifications of his own
+      and maintained the code until v5.0
     </p>
     <p>
-      Development of the code is open and there is a egroup devoted to it
-      located at <a href="http://groups.yahoo.com/group/atlantisdev">The
-      YahooGroups AtlantisDev egroup</a>. Please join this egroup if you work
-      on the code and share your changes back into the codebase as a whole
+      After that, Stephen Baillie took over the code and maintained it until
+      the v5.2.3-v5.2.5 time frame.
     </p>
     <p>
-      Please see the CREDITS file in the source distribution for a complete
-      (hopefully) list of all contributors.
+      Artem Trytiak took over the code maintainence at that point and has
+      maintained it since along with a number of other contrubutors to the
+      github project.
+    </p>
+    <p>
+      The Atlantis source code is now hosted on github at the <a
+      href="https://github.com/Atlantis-PBEM/Atlantis">Atlantis</a> github
+      project. Additionally, Artem runs the <a
+      href="https://atlantis-pbem.com">New Origins</a> website which hosts the
+      New Origins games and the related <a
+      href="https://discord.gg/HusGETf">Discord</a>server, which serves as a
+      de-facto development community.
+    </p>
+    <p>
+      Please see the CREDITS file in the source distribution for a more
+      complete, but still inadequate, list of contributors.
     </p>
   </body>
 </html>

--- a/snapshot-tests/rules/standard.html
+++ b/snapshot-tests/rules/standard.html
@@ -7853,20 +7853,31 @@ foo@some.email
       Larry Stanbery created the Atlantis 4.0.4+ derivative.
     </p>
     <p>
-      <a href="mailto:jtraub@dragoncat.net">JT Traub</a> took over the source
-      code and merged the then forking versions of 4.0.4c and 4.0.4+ back into
-      4.0.5 along with modifications of his own and has been maintaining the
-      code.
+      JT Traub took over the source code and merged the then forking versions
+      of 4.0.4c and 4.0.4+ back into 4.0.5 along with modifications of his own
+      and maintained the code until v5.0
     </p>
     <p>
-      Development of the code is open and there is a egroup devoted to it
-      located at <a href="http://groups.yahoo.com/group/atlantisdev">The
-      YahooGroups AtlantisDev egroup</a>. Please join this egroup if you work
-      on the code and share your changes back into the codebase as a whole
+      After that, Stephen Baillie took over the code and maintained it until
+      the v5.2.3-v5.2.5 time frame.
     </p>
     <p>
-      Please see the CREDITS file in the source distribution for a complete
-      (hopefully) list of all contributors.
+      Artem Trytiak took over the code maintainence at that point and has
+      maintained it since along with a number of other contrubutors to the
+      github project.
+    </p>
+    <p>
+      The Atlantis source code is now hosted on github at the <a
+      href="https://github.com/Atlantis-PBEM/Atlantis">Atlantis</a> github
+      project. Additionally, Artem runs the <a
+      href="https://atlantis-pbem.com">New Origins</a> website which hosts the
+      New Origins games and the related <a
+      href="https://discord.gg/HusGETf">Discord</a>server, which serves as a
+      de-facto development community.
+    </p>
+    <p>
+      Please see the CREDITS file in the source distribution for a more
+      complete, but still inadequate, list of contributors.
     </p>
   </body>
 </html>


### PR DESCRIPTION
This updates the readme to no longer point to travis-ci for the build. It also adds a badge for the license. The language has been cleaned up and the copyright brought current as well as updating the maintainers and some other cleanup.  It also removes the travis-ci config file .travis.yml which is no longer used.

Similar changes have been made to the generated rules to bring the credits section of them up to date.

Since this changes the output rules files, the snapshots have been updated with the new changes as well so that they will pass.