### PR TITLE
Sanitize existing names/descriptions and prevent new issues

### DIFF
--- a/astring.cpp
+++ b/astring.cpp
@@ -283,10 +283,10 @@ int AString::getat()
 char islegal(char c)
 {
 	if ((c>='a' && c<='z') || (c>='A' && c<='Z') || (c>='0' && c<='9') ||
-			c=='!' || c=='[' || c==']' || c==',' || c=='.' || c==' ' ||
+			c=='!' || c==',' || c=='.' || c==' ' ||
 			c=='{' || c=='}' || c=='@' || c=='#' || c=='$' || c=='%' ||
 			c=='^' || c=='&' || c=='*' || c=='-' || c=='_' || c=='+' ||
-			c=='=' || c==';' || c==':' || c=='<' || c=='>' || c=='?' ||
+			c=='=' || c==':' || c=='<' || c=='>' || c=='?' ||
 			c=='/' || c=='~' || c=='\'' || c== '\\' || c=='`')
 		return 1;
 	return 0;
@@ -311,6 +311,25 @@ AString *AString::getlegal()
 	}
 
 	*temp2 = '\0';
+	AString * retval = new AString(temp);
+	delete[] temp;
+	return retval;
+}
+
+AString *AString::stripnumber()
+{
+	char *temp = new char[len+1];
+	int i = len  - 1;
+
+	// walk back until we find either a [ or a a ( which will be the unit/faction or object identifier
+	while (i > 0 && (str[i] != '[' && str[i] != '(')) {
+		i--;
+	}
+	// walk back one more step to get rid of the space;
+	if (i > 0) i--;
+	// copy the string up to that point
+	strncpy(temp, str, i);
+	temp[i] = '\0';
 	AString * retval = new AString(temp);
 	delete[] temp;
 	return retval;

--- a/astring.h
+++ b/astring.h
@@ -63,6 +63,7 @@ public:
 	AString *gettoken();
 	int getat();
 	AString *getlegal();
+	AString *stripnumber();
 	AString *Trunc(int, int back=30);
 	int value();
 	int strict_value();

--- a/faction.cpp
+++ b/faction.cpp
@@ -215,6 +215,10 @@ void Faction::Readin(Ainfile *f, ATL_VER v)
 	unclaimed = f->GetInt();
 
 	name = f->GetStr();
+	// sanitize the name
+	AString *temp = name->stripnumber();
+	SetName(temp);
+
 	address = f->GetStr();
 	password = f->GetStr();
 	times = f->GetInt();

--- a/object.cpp
+++ b/object.cpp
@@ -137,8 +137,14 @@ void Object::Readin(Ainfile *f, AList *facs, ATL_VER v)
 	incomplete = f->GetInt();
 
 	if (name) delete name;
+	// sanitize the name if needed [ ] and re-add it;
 	name = f->GetStr();
-	describe = f->GetStr();
+	temp = name->stripnumber();
+	SetName(temp);
+	// sanitize the description as well
+	temp = f->GetStr();
+	describe = temp->getlegal();
+	delete temp;
 	if (*describe == "none") {
 		delete describe;
 		describe = 0;

--- a/unit.cpp
+++ b/unit.cpp
@@ -212,12 +212,19 @@ void Unit::Writeout(Aoutfile *s)
 void Unit::Readin(Ainfile *s, AList *facs, ATL_VER v)
 {
 	name = s->GetStr();
-	describe = s->GetStr();
+	AString *tmp = s->GetStr();
+	describe = tmp->getlegal();
+	delete tmp;
+	// sanitize the description too
 	if (*describe == "none") {
 		delete describe;
 		describe = 0;
 	}
 	num = s->GetInt();
+	// Now we have the number so we can rebuild the name
+	tmp = name->stripnumber();
+	SetName(tmp);
+
 	type = s->GetInt();
 	int i = s->GetInt();
 	faction = GetFaction(facs, i);


### PR DESCRIPTION
Since this is a diff against the old (pre-unit test) code, I cannot prove that this works, but I will be applying an analogous patch +
unit tests against main here shortly.   This feels correct in that
it will

a) strip out the 'real' unit/faction/object number from the name. b) rebuild the name with the new set of legal characters (and reattach the unit/faction/object number)
c) sanitize the descriptions to only the new set of legal characters on readin.
d) prevent (via the change to islegal()) any new names or descriptions from containing the bogus characters.

The non-allowed characters are now the set ()[]; instead of just () as before.

Please do not merge this until you verify that a) the changes in the patch vs master are identical (modulo the changes to the file io routines) and b) look at the unit test output there.