### PR TITLE
Sanitize existing names/descriptions and prevent new issues

### DIFF
--- a/astring.cpp
+++ b/astring.cpp
@@ -289,10 +289,10 @@ int AString::getat()
 char islegal(char c)
 {
 	if ((c>='a' && c<='z') || (c>='A' && c<='Z') || (c>='0' && c<='9') ||
-			c=='!' || c=='[' || c==']' || c==',' || c=='.' || c==' ' ||
+			c=='!' || c==',' || c=='.' || c==' ' ||
 			c=='{' || c=='}' || c=='@' || c=='#' || c=='$' || c=='%' ||
 			c=='^' || c=='&' || c=='*' || c=='-' || c=='_' || c=='+' ||
-			c=='=' || c==';' || c==':' || c=='<' || c=='>' || c=='?' ||
+			c=='=' || c==':' || c=='<' || c=='>' || c=='?' ||
 			c=='/' || c=='~' || c=='\'' || c== '\\' || c=='`')
 		return 1;
 	return 0;
@@ -317,6 +317,25 @@ AString *AString::getlegal()
 	}
 
 	*temp2 = '\0';
+	AString * retval = new AString(temp);
+	delete[] temp;
+	return retval;
+}
+
+AString *AString::stripnumber()
+{
+	char *temp = new char[len+1];
+	int i = len  - 1;
+
+	// walk back until we find either a [ or a a ( which will be the unit/faction or object identifier
+	while (i > 0 && (str[i] != '[' && str[i] != '(')) {
+		i--;
+	}
+	// walk back one more step to get rid of the space;
+	if (i > 0) i--;
+	// copy the string up to that point
+	strncpy(temp, str, i);
+	temp[i] = '\0';
 	AString * retval = new AString(temp);
 	delete[] temp;
 	return retval;

--- a/astring.h
+++ b/astring.h
@@ -65,6 +65,7 @@ public:
 	AString *gettoken();
 	int getat();
 	AString *getlegal();
+	AString *stripnumber();
 	AString *Trunc(int, int back=30);
 	int value();
 	int strict_value();

--- a/faction.cpp
+++ b/faction.cpp
@@ -192,6 +192,9 @@ void Faction::Readin(istream& f)
 	AString tmp;
 	f >> ws >> tmp;
 	name = new AString(tmp);
+	AString *temp = name->stripnumber();
+	SetName(temp);
+	
 	f >> ws >> tmp;
 	address = new AString(tmp);
 	f >> ws >> tmp;

--- a/object.cpp
+++ b/object.cpp
@@ -134,9 +134,11 @@ void Object::Readin(istream& f, AList *facs)
 	if (name) delete name;
 	f >> ws >> temp;
 	name = new AString(temp);
+	AString *tmp = name->stripnumber();
+	SetName(tmp);
 
 	f >> ws >> temp;
-	describe = new AString(temp);
+	describe = temp.getlegal();
 	if (*describe == "none") {
 		delete describe;
 		describe = 0;

--- a/unit.cpp
+++ b/unit.cpp
@@ -204,16 +204,17 @@ void Unit::Readin(istream& f, AList *facs)
 {
 	AString temp;
 	f >> ws >> temp;
-	name = new AString(temp);
+	name = temp.stripnumber();
 
 	f >> ws >> temp;
-	describe = new AString(temp);
+	describe = temp.getlegal();
 	if (*describe == "none") {
 		delete describe;
 		describe = 0;
 	}
 
 	f >> num;
+	SetName(new AString(*name));
 	f >> type;
 
 	int i;

--- a/unittest/name_sanitization_test.cpp
+++ b/unittest/name_sanitization_test.cpp
@@ -1,0 +1,71 @@
+#include "external/boost/ut.hpp"
+#include "external/nlohmann/json.hpp"
+
+using json = nlohmann::json;
+
+#include "game.h"
+#include "gamedata.h"
+#include "testhelper.hpp"
+
+// Because boost::ut has it's own concept of events, as does Game, we cannot just use do
+// using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
+// closure to make the user defined literals and all the other niceness available.
+namespace ut = boost::ut;
+
+using namespace std;
+
+// This suite will test various aspects of the Faction class in isolation.
+ut::suite<"Name Sanitization"> name_sanitization_suite = []
+{
+  using namespace ut;
+
+  "Name is correctly read in/out on load"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    string name("Test Faction");
+    Faction *faction = helper.create_faction(name);
+
+    string expected_name("Test Faction (3)");
+    string actual_name(faction->name->const_str());
+    expect(actual_name == expected_name);
+
+    stringstream ss;
+    faction->Writeout(ss);
+
+    Faction faction2;
+    faction2.Readin(ss);
+
+    string actual_name2(faction2.name->const_str());
+    expect(actual_name2 == expected_name);
+  };
+
+  "Name is correctly sanitized on load"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    string name("Test Faction (3)");
+    Faction *faction = helper.create_faction(name);
+    // Create an unsanitized name that we want to make sure gets sanitized.
+    delete faction->name;
+    faction->name = new AString("Test Faction [];boy (3)");
+
+    string expected_name("Test Faction [];boy (3)");
+    string actual_name(faction->name->const_str());
+    expect(actual_name == expected_name);
+
+    stringstream ss;
+    faction->Writeout(ss);
+
+    Faction faction2;
+    faction2.Readin(ss);
+
+    string sanitized_name("Test Faction boy (3)");
+    string actual_name2(faction2.name->const_str());
+    expect(actual_name2 == sanitized_name);
+  };
+};


### PR DESCRIPTION
Since this is a diff against the old (pre-unit test) code, I cannot prove that this works, but I will be applying an analogous patch +
unit tests against main here shortly.   This feels correct in that
it will

a) strip out the 'real' unit/faction/object number from the name. b) rebuild the name with the new set of legal characters (and reattach the unit/faction/object number)
c) sanitize the descriptions to only the new set of legal characters on readin.
d) prevent (via the change to islegal()) any new names or descriptions from containing the bogus characters.

The non-allowed characters are now the set ()[]; instead of just () as before.