### PR TITLE
Change event/error to be json rather than just string arrays in json reports.

### DIFF
--- a/aregion.h
+++ b/aregion.h
@@ -183,7 +183,7 @@ class ARegion : public AListElem
 
 	public:
 		ARegion();
-		ARegion(int, int);
+		//ARegion(int, int);
 		~ARegion();
 		
 		void Setup();
@@ -197,6 +197,7 @@ class ARegion : public AListElem
 
 		int CanMakeAdv(Faction *, int);
 		int HasItem(Faction *, int);
+		json basic_region_data();
 		void build_json_report(json& j, Faction *fac, int month, ARegionList *pRegions);
 
 		AString ShortPrint(ARegionList *pRegs);
@@ -221,7 +222,7 @@ class ARegion : public AListElem
 		Object *GetDummy();
 		void CheckFleets();
 
-		int MoveCost(int, ARegion *, int, AString *road);
+		int MoveCost(int, ARegion *, int, std::string *road);
 		Unit *Forbidden(Unit *); /* Returns unit that is forbidding */
 		Unit *ForbiddenByAlly(Unit *); /* Returns unit that is forbidding */
 		int CanTax(Unit *);
@@ -353,6 +354,9 @@ class ARegion : public AListElem
 		int distance;
 		ARegion *next;
 
+		// A link to the region's level to make some things easier.
+		ARegionArray *level;
+
 		// find a production for a certain skill.
 		Production *get_production_for_skill(int item, int skill);
 		// Editing functions
@@ -375,8 +379,6 @@ class ARegion : public AListElem
 		std::vector<int> GetPossibleLairs();
 		void SetupHabitat(TerrainType* terrain);
 		void SetupEconomy();
-
-		json basic_json_data(ARegionList *pRegions);
 };
 
 class ARegionArray

--- a/basic/map.cpp
+++ b/basic/map.cpp
@@ -273,7 +273,8 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				reg->type = -1;
 				reg->race = -1;  
 				reg->wages = -1; 
-				
+
+				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 			}

--- a/battle.cpp
+++ b/battle.cpp
@@ -363,7 +363,7 @@ void Battle::NormalRound(int round,Army * a,Army * b)
 void Battle::GetSpoils(AList *losers, ItemList *spoils, int ass)
 {
 	ItemList *ships = new ItemList;
-	AString quest_rewards;
+	string quest_rewards;
 
 	forlist(losers) {
 		Unit * u = ((Location *) elem)->unit;
@@ -371,6 +371,7 @@ void Battle::GetSpoils(AList *losers, ItemList *spoils, int ass)
 		int numdead = u->losses;
 		if (!numalive) {
 			if (quests.CheckQuestKillTarget(u, spoils, &quest_rewards)) {
+				// TODO why doesn't the unit get an event here?
 				AddLine(AString("Quest completed! ") + quest_rewards);
 			}
 		}
@@ -1093,7 +1094,7 @@ int Game::RunBattle(ARegion * r,Unit * attacker,Unit * target,int ass,
 
 	if (ass) {
 		if (attacker->GetAttitude(r,target) == A_ALLY) {
-			attacker->Error("ASSASSINATE: Can't assassinate an ally.");
+			attacker->error("ASSASSINATE: Can't assassinate an ally.");
 			return BATTLE_IMPOSSIBLE;
 		}
 		/* Assassination attempt */
@@ -1105,11 +1106,11 @@ int Game::RunBattle(ARegion * r,Unit * attacker,Unit * target,int ass,
 		dfacs.Add(p);
 	} else {
 		if ( r->IsSafeRegion() ) {
-			attacker->Error("ATTACK: No battles allowed in safe regions.");
+			attacker->error("ATTACK: No battles allowed in safe regions.");
 			return BATTLE_IMPOSSIBLE;
 		}
 		if (attacker->GetAttitude(r,target) == A_ALLY) {
-			attacker->Error("ATTACK: Can't attack an ally.");
+			attacker->error("ATTACK: Can't attack an ally.");
 			if (adv) {
 				attacker->canattack = 0;
 				if (attacker->advancefrom) {
@@ -1120,7 +1121,7 @@ int Game::RunBattle(ARegion * r,Unit * attacker,Unit * target,int ass,
 		}
 		GetDFacs(r,target,dfacs);
 		if (GetFaction2(&dfacs,attacker->faction->num)) {
-			attacker->Error("ATTACK: Can't attack an ally.");
+			attacker->error("ATTACK: Can't attack an ally.");
 			if (adv) {
 				attacker->canattack = 0;
 				if (attacker->advancefrom) {

--- a/edit.cpp
+++ b/edit.cpp
@@ -748,7 +748,7 @@ void Game::EditGameRegionMarkets( ARegion *pReg )
 		Awrite("Wanted: ");
 		for (const auto &m : pReg->markets) {
 			if (m->type == M_SELL) {
-				AString temp = ItemString(m->item, m->amount) + " at $" + m->price + "(" + m->baseprice + ").";
+				AString temp = AString(ItemString(m->item, m->amount)) + " at $" + m->price + "(" + m->baseprice + ").";
 				temp += AString(" Pop: ") + m->minpop + "/" + m->maxpop + ".";
 				temp += AString(" Amount: ") + m->minamt + "/" + m->maxamt + ".";
 				Awrite(temp);
@@ -757,7 +757,7 @@ void Game::EditGameRegionMarkets( ARegion *pReg )
 		Awrite("For Sale: ");
 		for (const auto &m : pReg->markets) {
 			if (m->type == M_BUY) {
-				AString temp = ItemString(m->item, m->amount) + " at $" + m->price + "(" + m->baseprice + ").";
+				AString temp = AString(ItemString(m->item, m->amount)) + " at $" + m->price + "(" + m->baseprice + ").";
 				temp += AString(" Pop: ") + m->minpop + "/" + m->maxpop + ".";
 				temp += AString(" Amount: ") + m->minamt + "/" + m->maxamt + ".";
 				Awrite(temp);

--- a/faction.h
+++ b/faction.h
@@ -51,8 +51,6 @@ using json = nlohmann::json;
 #include <iostream>
 #include <sstream>
 
-using namespace std;
-
 enum
 {
 	A_HOSTILE,
@@ -119,9 +117,8 @@ public:
 };
 
 // Collect the faction statistics for display in the report
-struct FactionStatistic
-{
-	string item_name;
+struct FactionStatistic {
+	std::string item_name;
 	size_t rank;
 	size_t max;
 	size_t total;
@@ -130,16 +127,25 @@ struct FactionStatistic
 	// objects/structs that require no additional parameters to be passed in.  On the other hand, for simple
 	// structures this is nice, and works with things like STL containers of structs to make the entire container
 	// serializable to json.
-	friend void to_json(json &j, const FactionStatistic &s)
-	{
+	friend void to_json(json &j, const FactionStatistic &s) {
 		j = json{{"item_name", s.item_name}, {"rank", s.rank}, {"max", s.max}, {"total", s.total}};
 	};
+};
 
-	friend ostream &operator<<(ostream &os, const FactionStatistic &s)
-	{
-		os << left << setw(42) << s.item_name << setw(6) << s.rank << setw(11) << s.max << s.total << right;
-		return os;
-	};
+struct FactionError {
+	std::string message;
+	Unit *unit;
+
+	friend void to_json(json &j, const FactionError &e);
+};
+
+struct FactionEvent {
+	std::string message;
+	std::string category;
+	Unit *unit;
+	ARegion *region;
+
+	friend void to_json(json &j, const FactionEvent &e);
 };
 
 class Faction : public AListElem
@@ -149,8 +155,8 @@ public:
 	Faction(int);
 	~Faction();
 
-	void Readin(istream &f);
-	void Writeout(ostream &f);
+	void Readin(std::istream &f);
+	void Writeout(std::ostream &f);
 	void View();
 
 	void SetName(AString *);
@@ -158,12 +164,12 @@ public:
 	void SetAddress(AString &strNewAddress);
 
 	void CheckExist(ARegionList *);
-	void error(const string &s);
-	void event(const string &s);
+	void error(const std::string& s, Unit *u = nullptr);
+	void event(const std::string& message, const std::string& category, ARegion *r = nullptr, Unit *u = nullptr);
 
 	void build_json_report(json& j, Game *pGame, size_t **citems);
 
-	void WriteFacInfo(ostream &f);
+	void WriteFacInfo(std::ostream &f);
 
 	void set_attitude(int faction_id, int attitude); // attitude -1 clears it
 	int get_attitude(int faction_id);
@@ -219,28 +225,28 @@ public:
 	bool gets_gm_report(Game *game);
 
 	/* Used when writing reports */
-	vector<ARegion *> present_regions;
+	std::vector<ARegion *> present_regions;
 
 	int defaultattitude;
 	// TODO: Convert this to a hashmap of <attitude, vector<factionid>>
 	// For now, just making it a vector of attitudes.  More will come later.
-	vector<Attitude> attitudes;
+	std::vector<Attitude> attitudes;
 
 	// These need to not be ALists wrapped with extra behavior at some point.
 	SkillList skills;
 	ItemList items;
 
 	// Extra lines/data from the players.in file for this faction.  Stored and dumped, not used.
-	vector<string> extra_player_data;
+	std::vector<std::string> extra_player_data;
 
 	// Errors and events during turn processing
-	vector<string> errors;
-	vector<string> events;
+	std::vector<FactionError> errors;
+	std::vector<FactionEvent> events;
 
-	vector<Battle *> battles;
-	vector<ShowSkill> shows;
-	vector<string> itemshows;
-	vector<string> objectshows;
+	std::vector<Battle *> battles;
+	std::vector<ShowSkill> shows;
+	std::vector<std::string> itemshows;
+	std::vector<std::string> objectshows;
 
 	// These are used for 'granting' units to a faction via the players.in
 	// file

--- a/fracas/map.cpp
+++ b/fracas/map.cpp
@@ -274,6 +274,7 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				reg->race = -1;  
 				reg->wages = -1; 
 				
+				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 			}

--- a/game.cpp
+++ b/game.cpp
@@ -762,7 +762,7 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 	} else if (*pToken == "Reward:") {
 		pTemp = pLine->gettoken();
 		int nAmt = pTemp->value();
-		pFac->event("Reward of " + to_string(nAmt) + " silver.");
+		pFac->event("Reward of " + to_string(nAmt) + " silver.", "reward");
 		pFac->unclaimed += nAmt;
 	} else if (*pToken == "SendTimes:") {
 		// get the token, but otherwise ignore it
@@ -821,7 +821,7 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 					Unit *u = GetNewUnit(pFac);
 					u->gm_alias = val;
 					u->MoveUnit(pFac->pReg->GetDummy());
-					u->Event("Is given to your faction.");
+					u->event("Is given to your faction.", "gm_gift");
 				}
 			}
 		}
@@ -868,9 +868,7 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 									int has = u->items.GetNum(it);
 									u->items.SetNum(it, has + v);
 									if (!u->gm_alias) {
-										u->Event(AString("Is given ") +
-												ItemString(it, v) +
-												" by the gods.");
+										u->event("Is given " + ItemString(it, v) + " by the gods.", "gm_gift");
 									}
 									u->faction->DiscoverItem(it, 0, 1);
 								}
@@ -926,10 +924,8 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 										pFac->shows.push_back({ .skill = sk, .level = lvl });
 									}
 									if (!u->gm_alias) {
-										u->Event(AString("Is taught ") +
-												days + " days of " +
-												SkillStrs(sk) +
-												" by the gods.");
+										u->event("Is taught " + to_string(days) + " days of " +
+											SkillStrs(sk).const_str() + " by the gods.", "gm_gift");
 									}
 									/*
 									 * This is NOT quite the same, but the gods
@@ -1667,12 +1663,9 @@ void Game::MonsterCheck(ARegion *r, Unit *u)
 						losses = 0;
 				}
 				if (losses) {
-					tmp = ItemString(i->type, losses);
-					tmp += " decay";
-					if (losses == 1)
-						tmp += "s";
-					tmp += " into nothingness.";
-					u->Event(tmp);
+					string temp = ItemString(i->type, losses) + plural(losses, " decay", " decays") +
+						" into nothingness.";
+					u->event(temp, "decay");
 					u->items.SetNum(i->type,i->num - losses);
 				}
 			} else if (ItemDefs[i->type].escape & ItemType::HAS_SKILL) {
@@ -1691,8 +1684,7 @@ void Game::MonsterCheck(ARegion *r, Unit *u)
 						mon->free = Globals->MONSTER_NO_SPOILS +
 							Globals->MONSTER_SPOILS_RECOVERY;
 					}
-					u->Event(AString("Loses control of ") +
-							ItemString(i->type, i->num) + ".");
+					u->event("Loses control of " + ItemString(i->type, i->num) + ".", "escape");
 					u->items.SetNum(i->type, 0);
 				}
 			} else {
@@ -1742,8 +1734,7 @@ void Game::MonsterCheck(ARegion *r, Unit *u)
 						mon->free = Globals->MONSTER_NO_SPOILS +
 							Globals->MONSTER_SPOILS_RECOVERY;
 					}
-					u->Event(AString("Loses control of ") +
-							ItemString(i->type, i->num) + ".");
+					u->event("Loses control of " + ItemString(i->type, i->num) + ".", "escape");
 					u->items.SetNum(i->type, 0);
 				}
 			}
@@ -1771,8 +1762,7 @@ void Game::MonsterCheck(ARegion *r, Unit *u)
 							mon->free = Globals->MONSTER_NO_SPOILS +
 								Globals->MONSTER_SPOILS_RECOVERY;
 						}
-						u->Event(AString("Loses control of ") +
-								ItemString(it->type, it->num) + ".");
+						u->event("Loses control of " + ItemString(it->type, it->num) + ".", "escape");
 						u->items.SetNum(it->type, 0);
 					}
 				}

--- a/game.h
+++ b/game.h
@@ -49,7 +49,7 @@ public:
 	int numshows;
 	int numerrors;
 
-	void Error(const AString &error);
+	void error(const std::string& err);
 };
 
 /// The main game class
@@ -328,8 +328,7 @@ private:
 	//
 	// Parsing functions
 	//
-	void ParseError(OrdersCheck *pCheck, Unit *pUnit, Faction *pFac,
-					const AString &strError);
+	void parse_error(OrdersCheck *order_chec, Unit *unit, Faction *faction, const std::string &error);
 	UnitId *ParseUnit(AString *s);
 	int ParseDir(AString *token);
 

--- a/gamedefs.cpp
+++ b/gamedefs.cpp
@@ -25,7 +25,7 @@
 #include "gamedefs.h"
 #include <string>
 
-char const *dr[] = {
+const std::string DirectionStrs[] = {
 	"North",
 	"Northeast",
 	"Southeast",
@@ -33,8 +33,6 @@ char const *dr[] = {
 	"Southwest",
 	"Northwest"
 };
-
-char const ** DirectionStrs = dr;
 
 char const *da[] = {
 	"N",

--- a/gamedefs.h
+++ b/gamedefs.h
@@ -40,7 +40,7 @@ enum {
 	NDIRS
 };
 
-extern char const **DirectionStrs;
+extern const std::string DirectionStrs[];
 extern char const **DirectionAbrs;
 
 extern char const **MonthNames;

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -671,7 +671,7 @@ Faction *Game::CheckVictory()
 			temp += " and returned to the Eternal City.";
 			message = AString("You") + temp;
 			times = *f->name + temp;
-			f->event(message.const_str());
+			f->event(message.const_str(), "gameover");
 			message = "You";
 			times += "\n\nThey";
 			temp = " returned after ";
@@ -747,7 +747,7 @@ Faction *Game::CheckVictory()
 				times += "  They";
 				times += temp;
 			}
-			f->event(message.const_str());
+			f->event(message.const_str(), "gameover");
 			WriteTimesArticle(times);
 
 			string filename = "winner." + to_string(f->num);

--- a/havilah/map.cpp
+++ b/havilah/map.cpp
@@ -280,6 +280,7 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				reg->race = -1;  
 				reg->wages = -1; 
 				
+				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 			}

--- a/items.cpp
+++ b/items.cpp
@@ -285,23 +285,19 @@ int ParseTransportableItem(AString *token)
 	return r;
 }
 
-AString ItemString(int type, int num, int flags)
+string ItemString(int type, int num, int flags)
 {
-	AString temp;
+	string temp;
 	if (num == 1) {
 		if (flags & FULLNUM)
-			temp += AString(num) + " ";
-		temp +=
-			AString((flags & ALWAYSPLURAL) ?
-				ItemDefs[type].names: ItemDefs[type].name) +
+			temp += to_string(num) + " ";
+		temp += string((flags & ALWAYSPLURAL) ? ItemDefs[type].names : ItemDefs[type].name) +
 			" [" + ItemDefs[type].abr + "]";
 	} else {
 		if (num == -1) {
-			temp += AString("unlimited ") + ItemDefs[type].names + " [" +
-				ItemDefs[type].abr + "]";
+			temp += string("unlimited ") + ItemDefs[type].names + " [" + ItemDefs[type].abr + "]";
 		} else {
-			temp += AString(num) + " " + ItemDefs[type].names + " [" +
-				ItemDefs[type].abr + "]";
+			temp += to_string(num) + " " + ItemDefs[type].names + " [" + ItemDefs[type].abr + "]";
 		}
 	}
 	return temp;

--- a/items.h
+++ b/items.h
@@ -78,8 +78,8 @@ struct Materials
 class ItemType
 {
 	public:
-		char const *name;
-		char const *names;
+		std::string name;
+		std::string names;
 		char const *abr;
 
 		enum {
@@ -433,7 +433,7 @@ enum {
 	FULLNUM = 0x01,
 	ALWAYSPLURAL = 0x02
 };
-extern AString ItemString(int type, int num, int flags=0);
+extern std::string ItemString(int type, int num, int flags = 0);
 extern AString *ItemDescription(int item, int full);
 
 extern int IsSoldier(int);

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -404,7 +404,7 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
 				
-
+				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 			}

--- a/market.cpp
+++ b/market.cpp
@@ -122,9 +122,11 @@ void Market::Readin(istream& f)
 	f >> baseprice;
 }
 
+/*
 AString Market::Report()
 {
 	AString temp;
 	temp += ItemString(item, amount) + " at $" + price;
 	return temp;
 }
+*/

--- a/market.h
+++ b/market.h
@@ -59,7 +59,7 @@ public:
 	void PostTurn(int, int);
 	void Writeout(ostream& f);
 	void Readin(istream& f);
-	AString Report();
+	//AString Report();
 };
 
 class MarketList : std::vector<Market*> {

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -167,7 +167,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				// Quest reward is based on QUEST_MAX_REWARD silver
 				reward_count = (QUEST_MAX_REWARD + getrandom(QUEST_MAX_REWARD / 2)) / ItemDefs[i].baseprice;
 
-				printf("\nQuest reward: %s x %d.\n", ItemDefs[i].name, reward_count);
+				printf("\nQuest reward: %s x %d.\n", ItemDefs[i].name.c_str(), reward_count);
 				
 				// Setup reward
 				item = new Item;

--- a/neworigins/map.cpp
+++ b/neworigins/map.cpp
@@ -1936,6 +1936,7 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				reg->race = -1;  
 				reg->wages = -1; 
 				
+				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 			}

--- a/quests.cpp
+++ b/quests.cpp
@@ -51,10 +51,10 @@ Quest::~Quest()
 	}
 }
 
-AString Quest::GetRewardsStr()
+string Quest::GetRewardsStr()
 {
 	Item *i;
-	AString quest_rewards;
+	string quest_rewards;
 	int first_i = 1;
 
 	quest_rewards = "Quest rewards: ";
@@ -200,7 +200,7 @@ void QuestList::WriteQuests(ostream& f)
 	f << 0 << '\n';
 }
 
-int QuestList::CheckQuestKillTarget(Unit *u, ItemList *reward, AString *quest_rewards)
+int QuestList::CheckQuestKillTarget(Unit *u, ItemList *reward, string *quest_rewards)
 {
 	Quest *q;
 	Item *i;
@@ -223,9 +223,7 @@ int QuestList::CheckQuestKillTarget(Unit *u, ItemList *reward, AString *quest_re
 	return 0;
 }
 
-int QuestList::CheckQuestHarvestTarget(ARegion *r,
-		int item, int harvested, int max,
-		Unit *u, AString *quest_rewards)
+int QuestList::CheckQuestHarvestTarget(ARegion *r, int item, int harvested, int max, Unit *u, string *quest_rewards)
 {
 	Quest *q;
 	Item *i;
@@ -253,8 +251,7 @@ int QuestList::CheckQuestHarvestTarget(ARegion *r,
 	return 0;
 }
 
-int QuestList::CheckQuestBuildTarget(ARegion *r, int building,
-		Unit *u, AString *quest_rewards)
+int QuestList::CheckQuestBuildTarget(ARegion *r, int building, Unit *u, string *quest_rewards)
 {
 	Quest *q;
 	Item *i;
@@ -280,7 +277,7 @@ int QuestList::CheckQuestBuildTarget(ARegion *r, int building,
 	return 0;
 }
 
-int QuestList::CheckQuestVisitTarget(ARegion *r, Unit *u, AString *quest_rewards)
+int QuestList::CheckQuestVisitTarget(ARegion *r, Unit *u, string *quest_rewards)
 {
 	Quest *q;
 	Object *o;
@@ -329,8 +326,7 @@ int QuestList::CheckQuestVisitTarget(ARegion *r, Unit *u, AString *quest_rewards
 	return 0;
 }
 
-int QuestList::CheckQuestDemolishTarget(ARegion *r, int building,
-		Unit *u, AString *quest_rewards)
+int QuestList::CheckQuestDemolishTarget(ARegion *r, int building, Unit *u, string *quest_rewards)
 {
 	Quest *q;
 	Item *i;

--- a/quests.h
+++ b/quests.h
@@ -54,9 +54,9 @@ class Quest : public AListElem
 		int	building;
 		int	regionnum;
 		AString	regionname;
-		set<string> destinations;
+		set<std::string> destinations;
 		AList	rewards;
-		AString GetRewardsStr();
+		std::string GetRewardsStr();
 };
 
 class QuestList : public AList
@@ -65,15 +65,11 @@ class QuestList : public AList
 		int ReadQuests(istream& f);
 		void WriteQuests(ostream& f);
 
-		int CheckQuestKillTarget(Unit *u, ItemList *reward, AString *quest_rewards);
-		int CheckQuestHarvestTarget(ARegion *r,
-				int item, int harvested, int max,
-				Unit *u, AString *quest_rewards);
-		int CheckQuestBuildTarget(ARegion *r, int building,
-				Unit *u, AString *quest_rewards);
-		int CheckQuestVisitTarget(ARegion *r, Unit *u, AString *quest_rewards);
-		int CheckQuestDemolishTarget(ARegion *r, int building,
-				Unit *u, AString *quest_rewards);
+		int CheckQuestKillTarget(Unit *u, ItemList *reward, std::string *quest_rewards);
+		int CheckQuestHarvestTarget(ARegion *r,	int item, int harvested, int max, Unit *u, std::string *quest_rewards);
+		int CheckQuestBuildTarget(ARegion *r, int building, Unit *u, std::string *quest_rewards);
+		int CheckQuestVisitTarget(ARegion *r, Unit *u, std::string *quest_rewards);
+		int CheckQuestDemolishTarget(ARegion *r, int building, Unit *u, std::string *quest_rewards);
 };
 
 extern QuestList quests;

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -252,29 +252,28 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 	Unit *tar = r->GetUnitId(so->target, u->faction->num);
 
 	if (!tar) {
-		u->Error("ASSASSINATE: Invalid unit given.");
+		u->error("ASSASSINATE: Invalid unit given.");
 		return;
 	}
 	if (!tar->IsAlive()) {
-		u->Error("ASSASSINATE: Invalid unit given.");
+		u->error("ASSASSINATE: Invalid unit given.");
 		return;
 	}
 
 	// New rule -- You can only assassinate someone you can see
 	if (!u->CanSee(r, tar)) {
-		u->Error("ASSASSINATE: Invalid unit given.");
+		u->error("ASSASSINATE: Invalid unit given.");
 		return;
 	}
 
 	if (tar->type == U_GUARD || tar->type == U_WMON ||
 			tar->type == U_GUARDMAGE) {
-		u->Error("ASSASSINATE: Can only assassinate other player's "
-				"units.");
+		u->error("ASSASSINATE: Can only assassinate other player's units.");
 		return;
 	}
 
 	if (u->GetMen() != 1) {
-		u->Error("ASSASSINATE: Must be executed by a 1-man unit.");
+		u->error("ASSASSINATE: Must be executed by a 1-man unit.");
 		return;
 	}
 
@@ -296,12 +295,11 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 		}
 	}
 	if (!succ) {
-		stringstream temp;
-		temp << u->name << " is caught attempting to assassinate " << tar->name << " in " << r->name << ".";
-		string temp2 = temp.str();
+		string temp = string(u->name->const_str()) + " is caught attempting to assassinate " +
+			tar->name->const_str() + " in " + r->name->const_str() + ".";
 		forlist(seers) {
 			Faction *f = ((FactionPtr *) elem)->ptr;
-			f->event(temp2);
+			f->event(temp, "combat");
 		}
 		// One learns from one's mistakes.  Surviving them is another matter!
 		u->PracticeAttribute("stealth");
@@ -314,9 +312,9 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 		// New rule: if a target has an amulet of true seeing they
 		// cannot be assassinated by someone with a ring of invisibility
 		if (tar->AmtsPreventCrime(u)) {
-			tar->Event("Assassination prevented by amulet of true seeing.");
-			u->Event(AString("Attempts to assassinate ") + *(tar->name) +
-					", but is prevented by amulet of true seeing.");
+			tar->event("Assassination prevented by amulet of true seeing.", "combat");
+			u->event("Attempts to assassinate " + string(tar->name->const_str()) +
+				", but is prevented by amulet of true seeing.", "combat");
 			return;
 		}
 	}
@@ -330,25 +328,25 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 	Unit *tar = r->GetUnitId(so->target, u->faction->num);
 
 	if (!tar) {
-		u->Error("STEAL: Invalid unit given.");
+		u->error("STEAL: Invalid unit given.");
 		return;
 	}
 
 	// New RULE!! You can only steal from someone you can see.
 	if (!u->CanSee(r, tar)) {
-		u->Error("STEAL: Invalid unit given.");
+		u->error("STEAL: Invalid unit given.");
 		return;
 	}
 
 	if (tar->type == U_GUARD || tar->type == U_WMON ||
 			tar->type == U_GUARDMAGE) {
-		u->Error("STEAL: Can only steal from other player's "
+		u->error("STEAL: Can only steal from other player's "
 				"units.");
 		return;
 	}
 
 	if (u->GetMen() != 1) {
-		u->Error("STEAL: Must be executed by a 1-man unit.");
+		u->error("STEAL: Must be executed by a 1-man unit.");
 		return;
 	}
 
@@ -371,12 +369,11 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 	}
 
 	if (!succ) {
-		stringstream temp;
-		temp << u->name << " is caught attempting to steal from " << tar->name << " in " << r->name << ".";
-		string temp2 = temp.str();
+		string temp = string(u->name->const_str()) + " is caught attempting to steal from " +
+			tar->name->const_str() + " in " + r->name->const_str() + ".";
 		forlist(seers) {
 			Faction *f = ((FactionPtr *) elem)->ptr;
-			f->event(temp2);
+			f->event(temp, "theft");
 		}
 		// One learns from one's mistakes.  Surviving them is another matter!
 		u->PracticeAttribute("stealth");
@@ -388,9 +385,9 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 	// stolen from by someone with a ring of invisibility
 	//
 	if (tar->AmtsPreventCrime(u)) {
-		tar->Event("Theft prevented by amulet of true seeing.");
-		u->Event(AString("Attempts to steal from ") + *(tar->name) + ", but "
-				"is prevented by amulet of true seeing.");
+		tar->event("Theft prevented by amulet of true seeing.", "theft");
+		u->event("Attempts to steal from " + string(tar->name->const_str()) +
+			", but is prevented by amulet of true seeing.", "theft");
 		return;
 	}
 
@@ -410,16 +407,15 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 	tar->items.SetNum(so->item, tar->items.GetNum(so->item) - amt);
 
 	{
-		stringstream temp;
-		temp << u->name << " steals " << ItemString(so->item, amt) << " from " << tar->name << ".";
-		string temp2 = temp.str();
+		string temp = string(u->name->const_str()) + " steals " +
+			ItemString(so->item, amt) + " from "+  tar->name->const_str() + ".";
 		forlist(seers) {
 			Faction *f = ((FactionPtr *) elem)->ptr;
-			f->event(temp2);
+			f->event(temp, "theft");
 		}
 	}
 
-	tar->Event(AString("Has ") + ItemString(so->item, amt) + " stolen.");
+	tar->event("Has " + ItemString(so->item, amt) + " stolen.", "theft");
 	u->PracticeAttribute("stealth");
 	return;
 }
@@ -451,7 +447,7 @@ void Game::DrownUnits()
 					}
 					if (drown) {
 						r->Kill(u);
-						u->Event("Drowns in the ocean.");
+						u->event("Drowns in the ocean.", "drown");
 					}
 				}
 			}
@@ -478,7 +474,7 @@ void Game::RunForgetOrders()
 				forlist(&u->forgetorders) {
 					ForgetOrder *fo = (ForgetOrder *) elem;
 					u->ForgetSkill(fo->skill);
-					u->Event(AString("Forgets ") + SkillStrs(fo->skill) + ".");
+					u->event("Forgets " + string(SkillStrs(fo->skill).const_str()) + ".", "forget");
 				}
 				u->forgetorders.DeleteAll();
 			}
@@ -532,10 +528,10 @@ void Game::RunDestroyOrders()
 }
 
 void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
-	AString quest_rewards;
+	string quest_rewards;
 
 	if (TerrainDefs[r->type].similar_type == R_OCEAN) {
-		u->Error("DESTROY: Can't destroy a ship while at sea.");
+		u->error("DESTROY: Can't destroy a ship while at sea.");
 		forlist(&o->units) {
 			((Unit *) elem)->destroy = 0;
 		}
@@ -543,7 +539,7 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 	}
 
 	if (!u->GetMen()) {
-		u->Error("DESTROY: Empty units cannot destroy structures.");
+		u->error("DESTROY: Empty units cannot destroy structures.");
 		forlist(&o->units) {
 			((Unit *) elem)->destroy = 0;
 		}
@@ -578,7 +574,7 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 
 		willDestroy = std::min(destroyablePoints, destroyPower);
 		if (willDestroy == 0) {
-			u->Error(AString("Can't destroy ") + *(o->name) + " more.");
+			u->error(string("Can't destroy ") + o->name->const_str() + " more.");
 			forlist(&o->units) {
 				((Unit *) elem)->destroy = 0;
 			}
@@ -591,10 +587,11 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 			o->destroyed += willDestroy;
 			o->incomplete += willDestroy;
 
-			u->Event(AString("Destroys ") + willDestroy + " structure points from the " + *(o->name) + ".");
+			u->event("Destroys " + to_string(willDestroy) + " structure points from the " +
+				o->name->const_str() + ".", "destroy");
 		}
 		else {
-			u->Event(AString("Destroys ") + *(o->name) + ".");
+			u->event("Destroys " + string(o->name->const_str()) + ".", "destroy");
 	
 			Object *dest = r->GetDummy();
 			forlist(&o->units) {
@@ -604,14 +601,14 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 			}
 
 			if (quests.CheckQuestDemolishTarget(r, o->num, u, &quest_rewards)) {
-				u->Event(AString("You have completed a quest!") + quest_rewards);
+				u->event("You have completed a quest!" + quest_rewards, "quest");
 			}
 
 			r->objects.Remove(o);
 			delete o;
 		}
 	} else {
-		u->Error("DESTROY: Can't destroy that.");
+		u->error("DESTROY: Can't destroy that.");
 		forlist(&o->units) {
 			((Unit *) elem)->destroy = 0;
 		}
@@ -642,20 +639,19 @@ void Game::RunFindUnit(Unit *u)
 		if (!all) {
 			fac = GetFaction(&factions, f->find);
 			if (fac) {
-				stringstream temp;
-				temp << "The address of " << fac->name << " is " << fac->address << ".";
-				u->faction->event(temp.str());
+				string temp = string("The address of ") + fac->name->const_str() + " is " +
+					fac->address->const_str() + ".";
+				u->faction->event(temp, "find");
 			} else {
-				u->Error(AString("FIND: ") + f->find + " is not a valid "
-						"faction number.");
+				u->error(string("FIND: ") + to_string(f->find) + " is not a valid faction number.");
 			}
 		} else {
 			forlist(&factions) {
 				fac = (Faction *)elem;
 				if (fac) {
-					stringstream temp;
-					temp << "The address of " << fac->name << " is " << fac->address << ".";
-					u->faction->event(temp.str());
+					string temp = string("The address of ") + fac->name->const_str() + " is " +
+						fac->address->const_str() + ".";
+					u->faction->event(temp, "find");
 				}
 			}
 		}
@@ -707,10 +703,10 @@ int Game::CountTaxes(ARegion *reg)
 
 			if (u->taxing == TAX_TAX) {
 				if (reg->Population() < 1) {
-					u->Error("TAX: No population to tax.");
+					u->error("TAX: No population to tax.");
 					u->taxing = TAX_NONE;
 				} else if (!reg->CanTax(u)) {
-					u->Error("TAX: A unit is on guard.");
+					u->error("TAX: A unit is on guard.");
 					u->taxing = TAX_NONE;
 				} else {
 					int men = u->Taxers(0);
@@ -720,14 +716,14 @@ int Game::CountTaxes(ARegion *reg)
 					if (protect < 0) protect = 0;
 					if (men) {
 						if (!ActivityCheck(reg, u->faction, FactionActivity::TAX)) {
-							u->Error("TAX: Faction can't tax that many "
+							u->error("TAX: Faction can't tax that many "
 									"regions.");
 							u->taxing = TAX_NONE;
 						} else {
 							t += men + fortbonus * Globals->TAX_BONUS_FORT;
 						}
 					} else {
-						u->Error("TAX: Unit cannot tax.");
+						u->error("TAX: Unit cannot tax.");
 						u->taxing = TAX_NONE;
 						u->SetFlag(FLAG_AUTOTAX, 0);
 					}
@@ -756,8 +752,8 @@ void Game::RunTaxRegion(ARegion *reg)
 				reg->wealth -= amt;
 				desired -= t;
 				u->SetMoney(u->GetMoney() + amt);
-				u->Event(AString("Collects $") + amt + " in taxes in " +
-						reg->ShortPrint(&regions) + ".");
+				u->event("Collects $" + to_string(amt) + " in taxes in " +
+					reg->ShortPrint(&regions).const_str() + ".", "tax", reg);
 				u->taxing = TAX_NONE;
 			}
 		}
@@ -780,20 +776,20 @@ int Game::CountPillagers(ARegion *reg)
 			Unit *u = (Unit *) elem;
 			if (u->taxing == TAX_PILLAGE) {
 				if (!reg->CanPillage(u)) {
-					u->Error("PILLAGE: A unit is on guard.");
+					u->error("PILLAGE: A unit is on guard.");
 					u->taxing = TAX_NONE;
 				} else {
 					int men = u->Taxers(1);
 					if (men) {
 						if (!ActivityCheck(reg, u->faction, FactionActivity::TAX)) {
-							u->Error("PILLAGE: Faction can't tax that many "
+							u->error("PILLAGE: Faction can't tax that many "
 									"regions.");
 							u->taxing = TAX_NONE;
 						} else {
 							p += men;
 						}
 					} else {
-						u->Error("PILLAGE: Not a combat ready unit.");
+						u->error("PILLAGE: Not a combat ready unit.");
 						u->taxing = TAX_NONE;
 					}
 				}
@@ -810,7 +806,7 @@ void Game::ClearPillagers(ARegion *reg)
 		forlist(&o->units) {
 			Unit *u = (Unit *) elem;
 			if (u->taxing == TAX_PILLAGE) {
-				u->Error("PILLAGE: Not enough men to pillage.");
+				u->error("PILLAGE: Not enough men to pillage.");
 				u->taxing = TAX_NONE;
 			}
 		}
@@ -844,14 +840,13 @@ void Game::RunPillageRegion(ARegion *reg)
 				amt -= temp;
 				pillagers -= num;
 				u->SetMoney(u->GetMoney() + temp);
-				u->Event(AString("Pillages $") + temp + " from " +
-						reg->ShortPrint(&regions) + ".");
+				u->event("Pillages $" + to_string(temp) + " from " +
+					reg->ShortPrint(&regions).const_str() + ".", "tax", reg);
 				forlist(facs) {
 					Faction *fp = ((FactionPtr *) elem)->ptr;
 					if (fp != u->faction) {
-						stringstream temp;
-						temp << u->name << " pillages " << reg->name << ".";
-						fp->event(temp.str());
+						string temp = string(u->name->const_str()) + " pillages " + reg->name->const_str() + ".";
+						fp->event(temp, "tax");
 					}
 				}
 			}
@@ -912,22 +907,22 @@ void Game::RunPromoteOrders()
 					u = (Unit *) elem;
 					if (u->promote) {
 						if (o->type != O_DUMMY) {
-							u->Error("PROMOTE: Must be owner");
+							u->error("PROMOTE: Must be owner");
 							delete u->promote;
 							u->promote = 0;
 						} else {
-							u->Error("PROMOTE: Can only promote inside structures.");
+							u->error("PROMOTE: Can only promote inside structures.");
 							delete u->promote;
 							u->promote = 0;
 						}
 					}
 					if (u->evictorders) {
 						if (o->type != O_DUMMY) {
-							u->Error("EVICT: Must be owner");
+							u->error("EVICT: Must be owner");
 							delete u->evictorders;
 							u->evictorders = 0;
 						} else {
-							u->Error("EVICT: Can only evict inside structures.");
+							u->error("EVICT: Can only evict inside structures.");
 							delete u->evictorders;
 							u->evictorders = 0;
 						}
@@ -942,7 +937,7 @@ void Game::Do1PromoteOrder(Object *obj, Unit *u)
 {
 	Unit *tar = obj->GetUnitId(u->promote, u->faction->num);
 	if (!tar) {
-		u->Error("PROMOTE: Can't find target.");
+		u->error("PROMOTE: Can't find target.");
 		return;
 	}
 	obj->units.Remove(tar);
@@ -954,7 +949,7 @@ void Game::Do1EvictOrder(Object *obj, Unit *u)
 	EvictOrder *ord = u->evictorders;
 
 	if (obj->region->type == R_NEXUS) {
-		u->Error("Evict: Evict does not work in the Nexus.");
+		u->error("Evict: Evict does not work in the Nexus.");
 		return;
 	}
 
@@ -968,13 +963,13 @@ void Game::Do1EvictOrder(Object *obj, Unit *u)
 		if (obj->IsFleet() &&
 			(TerrainDefs[obj->region->type].similar_type == R_OCEAN) &&
 			(!tar->CanReallySwim() || tar->GetFlag(FLAG_NOCROSS_WATER))) {
-			u->Error("EVICT: Cannot forcibly evict units over ocean.");
+			u->error("EVICT: Cannot forcibly evict units over ocean.");
 			continue;
 		}
 		Object *to = obj->region->GetDummy();
 		tar->MoveUnit(to);
-		tar->Event(AString("Evicted from ") + *obj->name + " by " + *u->name);
-		u->Event(AString("Evicted ") + *tar->name + " from " + *obj->name);
+		tar->event("Evicted from " + string(obj->name->const_str()) + " by " + u->name->const_str(), "evict");
+		u->event("Evicted " + string(tar->name->const_str()) + " from " + obj->name->const_str(), "evict");
 	}
 }
 
@@ -1011,7 +1006,7 @@ void Game::Do1EnterOrder(ARegion *r, Object *in, Unit *u)
 		u->enter = 0;
 		if ((TerrainDefs[r->type].similar_type == R_OCEAN) &&
 				(!u->CanSwim() || u->GetFlag(FLAG_NOCROSS_WATER))) {
-			u->Error("LEAVE: Can't leave a ship in the ocean.");
+			u->error("LEAVE: Can't leave a ship in the ocean.");
 			return;
 		}
 	} else {
@@ -1019,15 +1014,15 @@ void Game::Do1EnterOrder(ARegion *r, Object *in, Unit *u)
 		to = r->GetObject(on);
 		u->enter = 0;
 		if (!to) {
-			u->Error("ENTER: Can't enter that.");
+			u->error("ENTER: Can't enter that.");
 			return;
 		}
 		if (!to->CanEnter(r, u)) {
-			u->Error("ENTER: Can't enter that.");
+			u->error("ENTER: Can't enter that.");
 			return;
 		}
 		if (to->ForbiddenBy(r, u)) {
-			u->Error("ENTER: Is refused entry.");
+			u->error("ENTER: Is refused entry.");
 			return;
 		}
 	}
@@ -1045,13 +1040,13 @@ void Game::Do1JoinOrder(ARegion *r, Object *in, Unit *u)
 	tar = r->GetUnitId(jo->target, u->faction->num);
 
 	if (!tar) {
-		u->Error("JOIN: No such unit.");
+		u->error("JOIN: No such unit.");
 		return;
 	}
 
 	to = tar->object;
 	if (!to) {
-		u->Error("JOIN: Can't enter that.");
+		u->error("JOIN: Can't enter that.");
 		return;
 	}
 
@@ -1063,17 +1058,17 @@ void Game::Do1JoinOrder(ARegion *r, Object *in, Unit *u)
 	if (jo->merge) {
 		if (!u->object->IsFleet() ||
 				u->object->GetOwner()->num != u->num) {
-			u->Error("JOIN MERGE: Not fleet owner.");
+			u->error("JOIN MERGE: Not fleet owner.");
 			return;
 		}
 		if (!to->IsFleet()) {
-			u->Error("JOIN MERGE: Target unit is not in a fleet.");
+			u->error("JOIN MERGE: Target unit is not in a fleet.");
 			return;
 		}
 		forlist(&u->object->units) {
 			pass = (Unit *) elem;
 			if (to->ForbiddenBy(r, pass)) {
-				u->Error("JOIN MERGE: A unit would be refused entry.");
+				u->error("JOIN MERGE: A unit would be refused entry.");
 				return;
 			}
 		}
@@ -1105,22 +1100,22 @@ void Game::Do1JoinOrder(ARegion *r, Object *in, Unit *u)
 	if (to == r->GetDummy()) {
 		if ((TerrainDefs[r->type].similar_type == R_OCEAN) &&
 				(!u->CanSwim() || u->GetFlag(FLAG_NOCROSS_WATER))) {
-			u->Error("JOIN: Can't leave a ship in the ocean.");
+			u->error("JOIN: Can't leave a ship in the ocean.");
 			return;
 		}
 	} else {
 		if (!to->CanEnter(r, u)) {
-			u->Error("JOIN: Can't enter that.");
+			u->error("JOIN: Can't enter that.");
 			return;
 		}
 		if (to->ForbiddenBy(r, u)) {
-			u->Error("JOIN: Is refused entry.");
+			u->error("JOIN: Is refused entry.");
 			return;
 		}
 		if (to->IsFleet() &&
 				!jo->overload &&
 				to->FleetCapacity() < to->FleetLoad() + u->Weight()) {
-			u->Event("JOIN: Fleet would be overloaded.");
+			u->event("JOIN: Fleet would be overloaded.", "join");
 			return;
 		}
 	}
@@ -1176,9 +1171,9 @@ void Game::EndGame(Faction *pVictor)
 
 		if (pVictor) {
 			string temp(pVictor->name->const_str());
-			pFac->event(temp + " has won the game!");
+			pFac->event(temp + " has won the game!", "gameover");
 		} else
-			pFac->event("The game has ended with no winner.");
+			pFac->event("The game has ended with no winner.", "gameover");
 	}
 
 	gameStatus = GAME_STATUS_FINISHED;
@@ -1446,7 +1441,7 @@ void Game::DoAttackOrders()
 								if (t) {
 									AttemptAttack(r, u, t, 0);
 								} else {
-									u->Error("ATTACK: Non-existent unit.");
+									u->error("ATTACK: Non-existent unit.");
 								}
 							}
 						}
@@ -1472,17 +1467,17 @@ void Game::AttemptAttack(ARegion *r, Unit *u, Unit *t, int silent, int adv)
 	if (!t->IsAlive()) return;
 
 	if (!u->CanSee(r, t)) {
-		if (!silent) u->Error("ATTACK: Non-existent unit.");
+		if (!silent) u->error("ATTACK: Non-existent unit.");
 		return;
 	}
 
 	if (!u->CanCatch(r, t)) {
-		if (!silent) u->Error("ATTACK: Can't catch that unit.");
+		if (!silent) u->error("ATTACK: Can't catch that unit.");
 		return;
 	}
 
 	if (t->routed && Globals->ONLY_ROUT_ONCE) {
-		if (!silent) u->Event("ATTACK: Target is already routed and scattered.");
+		if (!silent) u->event("ATTACK: Target is already routed and scattered.", "combat");
 		return;
 	}
 
@@ -1502,7 +1497,7 @@ void Game::RunSellOrders()
 			forlist((&obj->units)) {
 				Unit *u = (Unit *) elem;
 				forlist((&u->sellorders)) {
-					u->Error("SELL: Can't sell that.");
+					u->error("SELL: Can't sell that.");
 				}
 				u->sellorders.DeleteAll();
 			}
@@ -1554,8 +1549,7 @@ void Game::DoSell(ARegion *r, Market *m)
 					int temp = 0;
 					if (o->num > u->GetSharedNum(o->item)) {
 						o->num = u->GetSharedNum(o->item);
-						u->Error("SELL: Unit attempted to sell "
-								"more than it had.");
+						u->error("SELL: Unit attempted to sell more than it had.");
 					}
 					if (attempted) {
 						temp = (m->amount *o->num + getrandom(attempted))
@@ -1568,8 +1562,7 @@ void Game::DoSell(ARegion *r, Market *m)
 					u->ConsumeShared(o->item, temp);
 					u->SetMoney(u->GetMoney() + temp * m->price);
 					u->sellorders.Remove(o);
-					u->Event(AString("Sells ") + ItemString(o->item, temp)
-							+ " at $" + m->price + " each.");
+					u->event("Sells " + ItemString(o->item, temp) + " at $" + to_string(m->price) + " each.", "sell");
 					delete o;
 				}
 			}
@@ -1590,7 +1583,7 @@ void Game::RunBuyOrders()
 			forlist((&obj->units)) {
 				Unit *u = (Unit *) elem;
 				forlist((&u->buyorders)) {
-					u->Error("BUY: Can't buy that.");
+					u->error("BUY: Can't buy that.");
 				}
 				u->buyorders.DeleteAll();
 			}
@@ -1610,34 +1603,28 @@ int Game::GetBuyAmount(ARegion *r, Market *m)
 				if (o->item == m->item) {
 					if (ItemDefs[o->item].type & IT_MAN) {
 						if (u->type == U_MAGE) {
-							u->Error("BUY: Mages can't recruit more men.");
+							u->error("BUY: Mages can't recruit more men.");
 							o->num = 0;
 						}
 						if (u->type == U_APPRENTICE) {
-							AString temp = "BUY: ";
-							temp += (char) toupper(Globals->APPRENTICE_NAME[0]);
-							temp += Globals->APPRENTICE_NAME + 1;
-							temp += "s can't recruit more men.";
-							u->Error(temp);
+							string name = Globals->APPRENTICE_NAME;
+							name[0] = toupper(name[0]);
+							string temp = "BUY: " + name + "s can't recruit more men.";
+							u->error(temp);
 							o->num = 0;
 						}
 						// XXX: there has to be a better way
 						if (u->GetSkill(S_QUARTERMASTER)) {
-							u->Error("BUY: Quartermasters can't recruit more "
-									"men.");
+							u->error("BUY: Quartermasters can't recruit more men.");
 							o->num = 0;
 						}
-						if (Globals->TACTICS_NEEDS_WAR &&
-									u->GetSkill(S_TACTICS) == 5) {
-							u->Error("BUY: Tacticians can't recruit more "
-									"men.");
+						if (Globals->TACTICS_NEEDS_WAR && u->GetSkill(S_TACTICS) == 5) {
+							u->error("BUY: Tacticians can't recruit more men.");
 							o->num = 0;
 						}
-						if (((ItemDefs[o->item].type & IT_LEADER) &&
-								u->IsNormal()) ||
-								(!(ItemDefs[o->item].type & IT_LEADER) &&
-								 u->IsLeader())) {
-							u->Error("BUY: Can't mix leaders and normal men.");
+						if (((ItemDefs[o->item].type & IT_LEADER) && u->IsNormal()) ||
+							(!(ItemDefs[o->item].type & IT_LEADER) && u->IsLeader())) {
+							u->error("BUY: Can't mix leaders and normal men.");
 							o->num = 0;
 						}
 					}
@@ -1649,12 +1636,11 @@ int Game::GetBuyAmount(ARegion *r, Market *m)
 					}
 					if (m->amount != -1 && o->num > m->amount) {
 						o->num = m->amount;
-						u->Error("BUY: Unit attempted to buy more than were for sale.");
+						u->error("BUY: Unit attempted to buy more than were for sale.");
 					}
 					if (o->num * m->price > u->GetSharedMoney()) {
 						o->num = u->GetSharedMoney() / m->price;
-						u->Error("BUY: Unit attempted to buy more than it "
-								"could afford.");
+						u->error("BUY: Unit attempted to buy more than it could afford.");
 					}
 					num += o->num;
 				}
@@ -1727,8 +1713,7 @@ void Game::DoBuy(ARegion *r, Market *m)
 					u->faction->DiscoverItem(o->item, 0, 1);
 					u->ConsumeSharedMoney(temp * m->price);
 					u->buyorders.Remove(o);
-					u->Event(AString("Buys ") + ItemString(o->item, temp)
-							+ " at $" + m->price + " each.");
+					u->event("Buys " + ItemString(o->item, temp) + " at $" + to_string(m->price) + " each.", "buy");
 					delete o;
 				}
 			}
@@ -1868,13 +1853,10 @@ void Game::CheckAllyMaintenanceItem(int item, int value)
 									if (eat) {
 										u->needed -= eat * value;
 										u2->items.SetNum(item, amount - eat);
-										u2->Event(*(u->name) + " borrows " +
-												ItemString(item, eat) +
-												" for maintenance.");
-										u->Event(AString("Borrows ") +
-												ItemString(item, eat) +
-												" from " + *(u2->name) +
-												" for maintenance.");
+										u2->event(string(u->name->const_str()) + " borrows " +
+											ItemString(item, eat) + " for maintenance.", "maintainence");
+										u->event("Borrows " + ItemString(item, eat) + " from " +
+											u2->name->const_str() + " for maintenance.", "maintainence");
 										u2->items.SetNum(item, amount - eat);
 									}
 								}
@@ -1991,13 +1973,10 @@ void Game::CheckAllyHungerItem(int item, int value)
 										u->stomach_space = 0;
 									}
 									u2->items.SetNum(item, amount - eat);
-										u2->Event(*(u->name) + " borrows " +
-												ItemString(item, eat) +
-												" to fend off starvation.");
-										u->Event(AString("Borrows ") +
-												ItemString(item, eat) +
-												" from " + *(u2->name) +
-												" to fend off starvation.");
+										u2->event(string(u->name->const_str()) + " borrows " +
+											ItemString(item, eat) + " to fend off starvation.", "maintainence");
+										u->event("Borrows " + ItemString(item, eat) + " from " +
+											u2->name->const_str() + " to fend off starvation.", "maintainence");
 										u2->items.SetNum(item, amount - eat);
 								}
 							}
@@ -2013,7 +1992,7 @@ void Game::CheckAllyHungerItem(int item, int value)
 
 void Game::AssessMaintenance()
 {
-	AString quest_rewards;
+	string quest_rewards;
 
 	/* First pass: set needed */
 	forlist((&regions)) {
@@ -2025,7 +2004,7 @@ void Game::AssessMaintenance()
 				if (!(u->faction->is_npc)) {
 					r->visited = 1;
 					if (quests.CheckQuestVisitTarget(r, u, &quest_rewards)) {
-						u->Event(AString("You have completed a pilgrimage!") + quest_rewards);
+						u->event("You have completed a pilgrimage!" + quest_rewards, "quest");
 					}
 				}
 				u->needed = u->MaintCost();
@@ -2033,8 +2012,7 @@ void Game::AssessMaintenance()
 				if (Globals->UPKEEP_MAXIMUM_FOOD < 0)
 					u->stomach_space = -1;
 				else
-					u->stomach_space = u->GetMen() *
-										Globals->UPKEEP_MAXIMUM_FOOD;
+					u->stomach_space = u->GetMen() * Globals->UPKEEP_MAXIMUM_FOOD;
 			}
 		}
 	}
@@ -2067,18 +2045,14 @@ void Game::AssessMaintenance()
 								int eat = (u->hunger + value - 1) / value;
 								/* Now see if faction has money */
 								if (u->faction->unclaimed >= eat * cost) {
-									u->Event(AString("Withdraws ") +
-											ItemString(i, eat) +
-											" for maintenance.");
+									u->event("Withdraws " + ItemString(i, eat) + " for maintenance.", "maintainence");
 									u->faction->unclaimed -= eat * cost;
 									u->hunger -= eat * value;
 									u->stomach_space -= eat * value;
 									u->needed -= eat * value;
 								} else {
 									int amount = u->faction->unclaimed / cost;
-									u->Event(AString("Withdraws ") +
-											ItemString(i, amount) +
-											" for maintenance.");
+									u->event("Withdraws " + ItemString(i, amount) + " for maintenance.", "maintainence");
 									u->faction->unclaimed -= amount * cost;
 									u->hunger -= amount * value;
 									u->stomach_space -= amount * value;
@@ -2136,14 +2110,12 @@ void Game::AssessMaintenance()
 					if (u->needed > 0 && u->faction->unclaimed) {
 						/* Now see if faction has money */
 						if (u->faction->unclaimed >= u->needed) {
-							u->Event(AString("Claims ") + u->needed +
-									 " silver for maintenance.");
+							u->event("Claims " + to_string(u->needed) + " silver for maintenance.", "maintainence");
 							u->faction->unclaimed -= u->needed;
 							u->needed = 0;
 						} else {
-							u->Event(AString("Claims ") +
-									u->faction->unclaimed +
-									" silver for maintenance.");
+							u->event("Claims " + to_string(u->faction->unclaimed) +
+								" silver for maintenance.", "maintainence");
 							u->needed -= u->faction->unclaimed;
 							u->faction->unclaimed = 0;
 						}
@@ -2208,27 +2180,25 @@ int Game::DoWithdrawOrder(ARegion *r, Unit *u, WithdrawOrder *o)
 	int cost = (ItemDefs[itm].baseprice *5/2)*amt;
 
 	if (r->type == R_NEXUS) {
-		u->Error("WITHDRAW: Withdraw does not work in the Nexus.");
+		u->error("WITHDRAW: Withdraw does not work in the Nexus.");
 		return 1;
 	}
 
 	if (cost > u->faction->unclaimed) {
-		u->Error(AString("WITHDRAW: Too little unclaimed silver to withdraw ")+
-				ItemString(itm, amt)+".");
+		u->error(string("WITHDRAW: Too little unclaimed silver to withdraw ") +	ItemString(itm, amt) + ".");
 		return 0;
 	}
 
 	if (ItemDefs[itm].max_inventory) {
 		int cur = u->items.GetNum(itm) + amt;
 		if (cur > ItemDefs[itm].max_inventory) {
-			u->Error(AString("WITHDRAW: Unit cannot have more than ")+
-					ItemString(itm, ItemDefs[itm].max_inventory));
+			u->error(string("WITHDRAW: Unit cannot have more than ") + ItemString(itm, ItemDefs[itm].max_inventory));
 			return 0;
 		}
 	}
 
 	u->faction->unclaimed -= cost;
-	u->Event(AString("Withdraws ") + ItemString(o->item, amt) + ".");
+	u->event("Withdraws " + ItemString(o->item, amt) + ".", "withdraw");
 	u->items.SetNum(itm, u->items.GetNum(itm) + amt);
 	u->faction->DiscoverItem(itm, 0, 1);
 	return 0;
@@ -2256,12 +2226,10 @@ void Game::DoGiveOrders()
 							if (o->type == O_TAKE) {
 								s = r->GetUnitId(o->target, u->faction->num);
 								if (!s || !u->CanSee(r, s)) {
-									u->Error(AString("TAKE: Nonexistant target (") +
-											o->target->Print() + ").");
+									u->error("TAKE: Nonexistant target (" +	o->target->Print() + ").");
 									continue;
 								} else if (u->faction != s->faction) {
-									u->Error(AString("TAKE: ") + o->target->Print() +
-											" is not a member of your faction.");
+									u->error("TAKE: " + o->target->Print() + " is not a member of your faction.");
 									continue;
 								}
 								fleet = s->object;
@@ -2316,9 +2284,9 @@ void Game::DoGiveOrders()
 							}
 						} else {
 							if (o->type == O_TAKE)
-								u->Error("TAKE: Invalid item.");
+								u->error("TAKE: Invalid item.");
 							else
-								u->Error("GIVE: Invalid item.");
+								u->error("GIVE: Invalid item.");
 						}
 					} else if (DoGiveOrder(r, u, o)) {
 						break;
@@ -2352,52 +2320,46 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
 	// Check if the destination unit exists
 	Unit *t = r->GetUnitId(o->target, u->faction->num);
 	if (!t) {
-		u->Error(AString("EXCHANGE: Nonexistant target (") +
-				o->target->Print() + ").");
+		u->error("EXCHANGE: Nonexistant target (" + o->target->Print() + ").");
 		u->exchangeorders.Remove(o);
 		return;
 	}
 
 	// Check each Item can be given
 	if (ItemDefs[o->giveItem].flags & ItemType::CANTGIVE) {
-		u->Error(AString("EXCHANGE: Can't trade ") +
-				ItemDefs[o->giveItem].names + ".");
+		u->error(string("EXCHANGE: Can't trade ") + ItemDefs[o->giveItem].names + ".");
 		u->exchangeorders.Remove(o);
 		return;
 	}
 
 	if (ItemDefs[o->expectItem].flags & ItemType::CANTGIVE) {
-		u->Error(AString("EXCHANGE: Can't trade ") +
-				ItemDefs[o->expectItem].names + ".");
+		u->error(string("EXCHANGE: Can't trade ") +	ItemDefs[o->expectItem].names + ".");
 		u->exchangeorders.Remove(o);
 		return;
 	}
 
 	if (ItemDefs[o->giveItem].type & IT_MAN) {
-		u->Error("EXCHANGE: Exchange aborted.  Men may not be traded.");
+		u->error("EXCHANGE: Exchange aborted.  Men may not be traded.");
 		u->exchangeorders.Remove(o);
 		return;
 	}
 
 	if (ItemDefs[o->expectItem].type & IT_MAN) {
-		u->Error("EXCHANGE: Exchange aborted. Men may not be traded.");
+		u->error("EXCHANGE: Exchange aborted. Men may not be traded.");
 		u->exchangeorders.Remove(o);
 		return;
 	}
 
 	// New RULE -- Must be able to see unit to give something to them!
 	if (!u->CanSee(r, t)) {
-		u->Error(AString("EXCHANGE: Nonexistant target (") +
-				o->target->Print() + ").");
+		u->error("EXCHANGE: Nonexistant target (" + o->target->Print() + ").");
 		return;
 	}
 	// Check other unit has enough to give
 	int amtRecieve = o->expectAmount;
 	if (amtRecieve > t->GetSharedNum(o->expectItem)) {
-		t->Error(AString("EXCHANGE: Not giving enough. Expecting ") +
-				ItemString(o->expectItem, o->expectAmount) + ".");
-		u->Error(AString("EXCHANGE: Exchange aborted.  Not enough ") +
-				"recieved. Expecting " +
+		t->error(string("EXCHANGE: Not giving enough. Expecting ") + ItemString(o->expectItem, o->expectAmount) + ".");
+		u->error(string("EXCHANGE: Exchange aborted.  Not enough recieved. Expecting ") +
 			ItemString(o->expectItem, o->expectAmount) + ".");
 		o->exchangeStatus = 0;
 		return;
@@ -2413,26 +2375,18 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
 				if (tOrder->giveItem == o->expectItem) {
 					exchangeOrderFound = 1;
 					if (tOrder->giveAmount < o->expectAmount) {
-						t->Error(AString("EXCHANGE: Not giving enough. ") +
-								"Expecting " +
-								ItemString(o->expectItem, o->expectAmount) +
-								".");
-						u->Error(AString("EXCHANGE: Exchange aborted. ") +
-								"Not enough recieved. Expecting " +
-								ItemString(o->expectItem, o->expectAmount) +
-								".");
+						t->error(string("EXCHANGE: Not giving enough. Expecting ") +
+							ItemString(o->expectItem, o->expectAmount) + ".");
+						u->error(string("EXCHANGE: Exchange aborted. Not enough recieved. Expecting ") +
+							ItemString(o->expectItem, o->expectAmount) + ".");
 						tOrder->exchangeStatus = 0;
 						o->exchangeStatus = 0;
 						return;
 					} else if (tOrder->giveAmount > o->expectAmount) {
-						t->Error(AString("EXCHANGE: Exchange aborted. Too ") +
-								"much given. Expecting " +
-								ItemString(o->expectItem, o->expectAmount) +
-								".");
-						u->Error(AString("EXCHANGE: Exchange aborted. Too ") +
-								"much offered. Expecting " +
-								ItemString(o->expectItem, o->expectAmount) +
-								".");
+						t->error(string("EXCHANGE: Exchange aborted. Too much given. Expecting ") +
+							ItemString(o->expectItem, o->expectAmount) + ".");
+						u->error(string("EXCHANGE: Exchange aborted. Too much offered. Expecting ") +
+							ItemString(o->expectItem, o->expectAmount) + ".");
 						tOrder->exchangeStatus = 0;
 						o->exchangeStatus = 0;
 					} else if (tOrder->giveAmount == o->expectAmount)
@@ -2440,17 +2394,11 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
 
 					if ((o->exchangeStatus == 1) &&
 							(tOrder->exchangeStatus == 1)) {
-						u->Event(AString("Exchanges ") +
-								ItemString(o->giveItem, o->giveAmount) +
-								" with " + *t->name + " for " +
-								ItemString(tOrder->giveItem,
-									tOrder->giveAmount) +
-								".");
-						t->Event(AString("Exchanges ") +
-								ItemString(tOrder->giveItem,
-									tOrder->giveAmount) + " with " +
-								*u->name + " for " +
-								ItemString(o->giveItem, o->giveAmount) + ".");
+						u->event("Exchanges " + ItemString(o->giveItem, o->giveAmount) + " with " +
+							t->name->const_str() + " for " + ItemString(tOrder->giveItem, tOrder->giveAmount) +	".",
+							"exchange");
+						t->event("Exchanges " + ItemString(tOrder->giveItem, tOrder->giveAmount) + " with " +
+							u->name->const_str() + " for " + ItemString(o->giveItem, o->giveAmount) + ".", "exchange");
 						u->ConsumeShared(o->giveItem, o->giveAmount);
 						t->items.SetNum(o->giveItem,
 								t->items.GetNum(o->giveItem) + o->giveAmount);
@@ -2474,13 +2422,11 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
 	}
 	if (!exchangeOrderFound) {
 		if (!u->CanSee(r, t)) {
-			u->Error(AString("EXCHANGE: Nonexistant target (") +
-					o->target->Print() + ").");
+			u->error("EXCHANGE: Nonexistant target (" + o->target->Print() + ").");
 			u->exchangeorders.Remove(o);
 			return;
 		} else {
-			u->Error("EXCHANGE: target unit did not issue a matching "
-					"exchange order.");
+			u->error("EXCHANGE: target unit did not issue a matching exchange order.");
 			u->exchangeorders.Remove(o);
 			return;
 		}
@@ -2494,32 +2440,28 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 	Item *it, *sh;
 	Unit *p, *t, *s;
 	Object *fleet;
-	AString temp, ord;
 	Skill *skill;
 	SkillList *skills;
 
-	if (o->type == O_TAKE)
-		ord = "TAKE";
-	else
-		ord = "GIVE";
+	string ord = (o->type == O_TAKE) ? "TAKE" : "GIVE";
+	string event_type = (o->type == O_TAKE) ? "take" : "give";
 
 	/* Transfer/GIVE ship items: */
 	if ((o->item >= 0) && (ItemDefs[o->item].type & IT_SHIP)) {
 		// GIVE 0
 		if (o->target->unitnum == -1) {
 			hasitem = u->items.GetNum(o->item);
-			temp = "Abandons ";
 			// discard unfinished ships from inventory
 			if (o->unfinished) {
 				if (!hasitem || o->amount > 1) {
-					u->Error("GIVE: not enough.");
+					u->error(ord + ": not enough.");
 					return 0;
 				}
 				ship = -1;
 				forlist(&u->items) {
 					it = (Item *) elem;
 					if (it->type == o->item) {
-						u->Event(temp + it->Report(1) + ".");
+						u->event("Abandons " + string(it->Report(1).const_str()) + ".", event_type);
 						ship = it->type;
 					}
 				}
@@ -2528,18 +2470,18 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 			// abandon fleet ships
 			} else if (!(u->object->IsFleet()) || 
 				(u->num != u->object->GetOwner()->num)) {
-				u->Error("GIVE: only fleet owner can give ships.");
+				u->error(ord + ": only fleet owner can give ships.");
 				return 0;
 			}
 
 			// Check amount
 			num = u->object->GetNumShips(o->item);
 			if (num < 1) {
-				u->Error("GIVE: no such ship in fleet.");
+				u->error(ord + ": no such ship in fleet.");
 				return 0;
 			}
 			if ((num < o->amount) && (o->amount != -2)) {
-				u->Error("GIVE: not enough ships.");
+				u->error(ord + ": not enough ships.");
 				o->amount = num;
 			}
 
@@ -2554,7 +2496,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 					forlist(&(u->object->units)) {
 						p = (Unit *) elem;
 						if ((!p->CanSwim() || p->GetFlag(FLAG_NOCROSS_WATER))) {
-							u->Error("GIVE: Can't abandon our last ship in the ocean.");
+							u->error(ord + ": Can't abandon our last ship in the ocean.");
 							return 0;
 						}
 					}
@@ -2562,50 +2504,42 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 			}
 
 			u->object->SetNumShips(o->item, num - o->amount);
-			u->Event(AString(temp) + ItemString(o->item, num - o->amount) + ".");
+			u->event("Abandons " + ItemString(o->item, num - o->amount) + ".", event_type);
 			return 0;
 		}
 		// GIVE to unit:	
 		t = r->GetUnitId(o->target, u->faction->num);
 		if (!t) {
-			u->Error(ord + ": Nonexistant target (" +
-				o->target->Print() + ").");
+			u->error(ord + ": Nonexistant target (" + o->target->Print() + ").");
 			return 0;
 		} else if (o->type == O_TAKE && u->faction != t->faction) {
-			u->Error(ord + ": " + o->target->Print() +
-					" is not a member of your faction.");
+			u->error(ord + ": " + o->target->Print() + " is not a member of your faction.");
 			return 0;
 		} else if (u->faction != t->faction && t->faction->is_npc) {
-			u->Error(ord + ": Can't give to non-player unit (" +
-				o->target->Print() + ").");
+			u->error(ord + ": Can't give to non-player unit (" + o->target->Print() + ").");
 			return 0;
 		}
 		if (u == t) {
 			if (o->type == O_TAKE)
-				u->Error(ord + ": Attempt to take " +
-					ItemDefs[o->item].names + " from self.");
+				u->error(ord + ": Attempt to take " + ItemDefs[o->item].names + " from self.");
 			else
-				u->Error(ord + ": Attempt to give " +
-					ItemDefs[o->item].names + " to self.");
+				u->error(ord + ": Attempt to give " + ItemDefs[o->item].names + " to self.");
 			return 0;
 		}
 		if (!u->CanSee(r, t) &&
 			(t->faction->get_attitude(u->faction->num) < A_FRIENDLY)) {
-				u->Error(ord + ": Nonexistant target (" +
-					o->target->Print() + ").");
+				u->error(ord + ": Nonexistant target (" + o->target->Print() + ").");
 				return 0;
 		}
 		if (t->faction->get_attitude(u->faction->num) < A_FRIENDLY) {
-				u->Error(ord + ": Target is not a member of a friendly faction.");
+				u->error(ord + ": Target is not a member of a friendly faction.");
 				return 0;
 		}
 		if (ItemDefs[o->item].flags & ItemType::CANTGIVE) {
 			if (o->type == O_TAKE)
-				u->Error(ord + ": Can't take " +
-					ItemDefs[o->item].names + ".");
+				u->error(ord + ": Can't take " + ItemDefs[o->item].names + ".");
 			else
-				u->Error(ord + ": Can't give " +
-					ItemDefs[o->item].names + ".");
+				u->error(ord + ": Can't give " + ItemDefs[o->item].names + ".");
 			return 0;
 		}
 		s = u;
@@ -2616,27 +2550,26 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		// Check amount
 		if (o->unfinished) {
 			num = s->items.GetNum(o->item) > 0;
-		} else if (!(s->object->IsFleet()) || 
-			(s->num != s->object->GetOwner()->num)) {
-			u->Error(ord + ": only fleet owner can transfer ships.");
+		} else if (!(s->object->IsFleet()) || (s->num != s->object->GetOwner()->num)) {
+			u->error(ord + ": only fleet owner can transfer ships.");
 			return 0;
 		} else {
 			num = s->object->GetNumShips(o->item);
 			if (num < 1) {
-				u->Error(ord + ": no such ship in fleet.");
+				u->error(ord + ": no such ship in fleet.");
 				return 0;
 			}
 		}
 		amt = o->amount;
 		if (amt != -2 && amt > num) {
-			u->Error(ord + ": Not enough.");
+			u->error(ord + ": Not enough.");
 			amt = num;
 		} else if (amt == -2) {
 			amt = num;
 			if (o->except) {
 				if (o->except > amt) {
 					amt = 0;
-					u->Error(ord + ": EXCEPT value greater than amount on hand.");
+					u->error(ord + ": EXCEPT value greater than amount on hand.");
 				} else {
 					amt = amt - o->except;
 				}
@@ -2650,23 +2583,23 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		if (o->unfinished) {
 			if (t->items.GetNum(o->item) > 0) {
 				if (o->type == O_TAKE)
-					u->Error(ord + ": Already have an unfinished ship of that type.");
+					u->error(ord + ": Already have an unfinished ship of that type.");
 				else
-					u->Error(ord + ": Target already has an unfinished ship of that type.");
+					u->error(ord + ": Target already has an unfinished ship of that type.");
 				return 0;
 			}
 			it = new Item();
 			it->type = o->item;
 			it->num = s->items.GetNum(o->item);
 			if (o->type == O_TAKE) {
-				u->Event(AString("Takes ") + it->Report(1) +
-					" from " + *s->name + ".");
+				u->event("Takes " + string(it->Report(1).const_str()) + " from " + s->name->const_str() +
+					".", event_type);
 			} else {
-				u->Event(AString("Gives ") + it->Report(1) +
-					" to " + *t->name + ".");
+				u->event("Gives " + string(it->Report(1).const_str()) + " to " + t->name->const_str() + ".",
+					event_type);
 				if (s->faction != t->faction) {
-					t->Event(AString("Receives ") + it->Report(1) +
-						" from " + *s->name + ".");
+					t->event("Receives " + string(it->Report(1).const_str()) + " from " + s->name->const_str() +
+						".", event_type);
 				}
 			}
 			s->items.SetNum(o->item, 0);
@@ -2685,7 +2618,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 					forlist(&(s->object->units)) {
 						p = (Unit *) elem;
 						if ((!p->CanSwim() || p->GetFlag(FLAG_NOCROSS_WATER))) {
-							u->Error(ord + ": Can't give away our last ship in the ocean.");
+							u->error(ord + ": Can't give away our last ship in the ocean.");
 							return 0;
 						}
 					}
@@ -2716,9 +2649,8 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 			if (ItemDefs[o->item].max_inventory) {
 				cur = t->object->GetNumShips(o->item) + amt;
 				if (cur > ItemDefs[o->item].max_inventory) {
-					u->Error(ord + ": Fleets cannot have more than " +
-						ItemString(o->item, ItemDefs[o->item].max_inventory) +
-						".");
+					u->error(ord + ": Fleets cannot have more than " +
+						ItemString(o->item, ItemDefs[o->item].max_inventory) + ".");
 					return 0;
 				}
 			}
@@ -2734,18 +2666,15 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 				} else {
 					// check that source ship is compatible with its new fleet
 					if (s->object->SailThroughCheck(fleet->prevdir) == 0) {
-						u->Error(ord +
-								": Ships cannot be transferred through land.");
+						u->error(ord + ": Ships cannot be transferred through land.");
 						return 0;
 					}
 				}
 			}
 
-			s->Event(AString("Transfers ") + ItemString(o->item, amt) + " to " +
-				*t->object->name + ".");
+			s->event("Transfers " + ItemString(o->item, amt) + " to " + t->object->name->const_str() + ".", ord);
 			if (s->faction != t->faction) {
-				t->Event(AString("Receives ") + ItemString(o->item, amt) +
-					" from " + *s->object->name + ".");
+				t->event("Receives " + ItemString(o->item, amt) + " from " + s->object->name->const_str() + ".", ord);
 			}
 			s->object->SetNumShips(o->item, s->object->GetNumShips(o->item)-amt);
 			t->object->SetNumShips(o->item, t->object->GetNumShips(o->item)+amt);
@@ -2759,30 +2688,30 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		// Check there is enough to give
 		amt = o->amount;
 		if (amt != -2 && amt > u->GetSharedNum(o->item)) {
-			u->Error(ord + ": Not enough.");
+			u->error(ord + ": Not enough.");
 			amt = u->GetSharedNum(o->item);
 		} else if (amt == -2) {
 			amt = u->items.GetNum(o->item);
 			if (o->except) {
 				if (o->except > amt) {
 					amt = 0;
-					u->Error("GIVE: EXCEPT value greater than amount on hand.");
+					u->error(ord + ": EXCEPT value greater than amount on hand.");
 				} else {
 					amt = amt - o->except;
 				}
 			}
 		}
 		if (amt == -1) {
-			u->Error("Can't discard a whole unit.");
+			u->error("Can't discard a whole unit.");
 			return 0;
 		}
 
 		if (amt < 0) {
-			u->Error("Cannot give a negative number of items.");
+			u->error("Cannot give a negative number of items.");
 			return 0;
 		}
 
-		temp = "Discards ";
+		string temp = "Discards ";
 		if (ItemDefs[o->item].type & IT_MAN) {
 			u->SetMen(o->item, u->GetMen(o->item) - amt);
 			r->DisbandInRegion(o->item, amt);
@@ -2807,45 +2736,36 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		} else {
 			u->ConsumeShared(o->item, amt);
 		}
-		u->Event(temp + ItemString(o->item, amt) + ".");
+		u->event(temp + ItemString(o->item, amt) + ".", event_type);
 		return 0;
 	}
 
 	amt = o->amount;
 	t = r->GetUnitId(o->target, u->faction->num);
 	if (!t) {
-		u->Error(ord + ": Nonexistant target (" +
-				o->target->Print() + ").");
+		u->error(ord + ": Nonexistant target (" + o->target->Print() + ").");
 		return 0;
 	} else if (o->type == O_TAKE && u->faction != t->faction) {
-		u->Error(ord + ": " + o->target->Print() +
-				" is not a member of your faction.");
+		u->error(ord + ": " + o->target->Print() + " is not a member of your faction.");
 		return 0;
 	} else if (u->faction != t->faction && t->faction->is_npc) {
-		u->Error(ord + ": Can't give to non-player unit (" +
-				o->target->Print() + ").");
+		u->error(ord + ": Can't give to non-player unit (" + o->target->Print() + ").");
 		return 0;
 	}
 	if (amt == -1 && u->faction == t->faction) {
-		u->Error(ord + ": Unit already belongs to our faction!");
+		u->error(ord + ": Unit already belongs to our faction!");
 		return 0;
 	}
 	if (u == t) {
 		if (o->type == O_TAKE)
-			u->Error(ord + ": Attempt to take " + 
-					ItemString(o->item, amt) +
-					" from self.");
+			u->error(ord + ": Attempt to take " + ItemString(o->item, amt) + " from self.");
 		else
-			u->Error(ord + ": Attempt to give " + 
-					ItemString(o->item, amt) +
-					" to self.");
+			u->error(ord + ": Attempt to give " + ItemString(o->item, amt) + " to self.");
 		return 0;
 	}
 	// New RULE -- Must be able to see unit to give something to them!
-	if (!u->CanSee(r, t) &&
-			(t->faction->get_attitude(u->faction->num) < A_FRIENDLY)) {
-		u->Error(ord + ": Nonexistant target (" +
-				o->target->Print() + ").");
+	if (!u->CanSee(r, t) && (t->faction->get_attitude(u->faction->num) < A_FRIENDLY)) {
+		u->error(ord + ": Nonexistant target (" + o->target->Print() + ").");
 		return 0;
 	}
 
@@ -2857,23 +2777,22 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 
 	// Check there is enough to give
 	if (amt != -2 && amt > s->GetSharedNum(o->item)) {
-		u->Error(ord + ": Not enough.");
+		u->error(ord + ": Not enough.");
 		amt = s->GetSharedNum(o->item);
 	} else if (amt == -2) {
 		amt = s->items.GetNum(o->item);
 		if (o->except) {
 			if (o->except > amt) {
 				amt = 0;
-				u->Error(ord + ": EXCEPT value greater than amount on hand.");
+				u->error(ord + ": EXCEPT value greater than amount on hand.");
 			} else {
 				amt = amt - o->except;
 			}
 		}
 	}
 
-	if (o->item != I_SILVER &&
-			t->faction->get_attitude(s->faction->num) < A_FRIENDLY) {
-		u->Error("GIVE: Target is not a member of a friendly faction.");
+	if (o->item != I_SILVER && t->faction->get_attitude(s->faction->num) < A_FRIENDLY) {
+		u->error(ord + ": Target is not a member of a friendly faction.");
 		return 0;
 	}
 
@@ -2882,19 +2801,15 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		if (u->type == U_MAGE) {
 			if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
 				if (CountMages(t->faction) >= AllowedMages(t->faction)) {
-					u->Error("GIVE: Faction has too many mages.");
+					u->error(ord + ": Faction has too many mages.");
 					return 0;
 				}
 			}
 		}
 		if (u->type == U_APPRENTICE) {
 			if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
-				if (CountApprentices(t->faction) >=
-						AllowedApprentices(t->faction)){
-					temp = "GIVE: Faction has too many ";
-					temp += Globals->APPRENTICE_NAME;
-					temp += "s.";
-					u->Error(temp);
+				if (CountApprentices(t->faction) >= AllowedApprentices(t->faction)) {
+					u->error(ord + ": Faction has too many " + Globals->APPRENTICE_NAME + "s.");
 					return 0;
 				}
 			}
@@ -2903,9 +2818,8 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		if (u->GetSkill(S_QUARTERMASTER)) {
 			if (Globals->FACTION_LIMIT_TYPE == GameDefs::FACLIM_FACTION_TYPES) {
 				if (Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT) {
-					if (CountQuarterMasters(t->faction) >=
-							AllowedQuarterMasters(t->faction)) {
-						u->Error("GIVE: Faction has too many quartermasters.");
+					if (CountQuarterMasters(t->faction) >= AllowedQuarterMasters(t->faction)) {
+						u->error(ord + ": Faction has too many quartermasters.");
 						return 0;
 					}
 				}
@@ -2914,12 +2828,9 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 
 		if (u->GetSkill(S_TACTICS) == 5) {
 			if (Globals->FACTION_LIMIT_TYPE == GameDefs::FACLIM_FACTION_TYPES) {
-				if (Globals->TACTICS_NEEDS_WAR) {
-					if (CountTacticians(t->faction) >=
-							AllowedTacticians(t->faction)) {
-						u->Error("GIVE: Faction has too many tacticians.");
-						return 0;
-					}
+				if (Globals->TACTICS_NEEDS_WAR && (CountTacticians(t->faction) >= AllowedTacticians(t->faction))) {
+					u->error(ord + ": Faction has too many tacticians.");
+					return 0;
 				}
 			}
 		}
@@ -2940,13 +2851,13 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 			notallied = 0;
 		}
 
-		u->Event(AString("Gives unit to ") + *(t->faction->name) + ".");
+		u->event("Gives unit to " + string(t->faction->name->const_str()) + ".", event_type);
 		u->faction = t->faction;
-		u->Event("Is given to your faction.");
+		u->event("Is given to your faction.", event_type);
 
 		if (notallied && u->monthorders && u->monthorders->type == O_MOVE &&
-				((MoveOrder *) u->monthorders)->advancing) {
-			u->Error("Unit cannot advance after being given.");
+			((MoveOrder *) u->monthorders)->advancing) {
+			u->error("Unit cannot advance after being given.");
 			delete u->monthorders;
 			u->monthorders = 0;
 		}
@@ -2978,38 +2889,38 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 	if (ItemDefs[o->item].type & IT_MAN) {
 		if (s->type == U_MAGE || s->type == U_APPRENTICE ||
 				t->type == U_MAGE || t->type == U_APPRENTICE) {
-			u->Error(ord + ": Magicians can't transfer men.");
+			u->error(ord + ": Magicians can't transfer men.");
 			return 0;
 		}
 		if (Globals->TACTICS_NEEDS_WAR) {
 			if (s->GetSkill(S_TACTICS) == 5 ||
 					t->GetSkill(S_TACTICS) == 5) {
-				u->Error(ord + ": Tacticians can't transfer men.");
+				u->error(ord + ": Tacticians can't transfer men.");
 				return 0;
 			}
 		}
 		if (s->GetSkill(S_QUARTERMASTER) > 0 || t->GetSkill(S_QUARTERMASTER) > 0) {
-			u->Error(ord + ": Quartermasters can't transfer men.");
+			u->error(ord + ": Quartermasters can't transfer men.");
 			return 0;
 		}
 
 		if ((ItemDefs[o->item].type & IT_LEADER) && t->IsNormal()) {
-			u->Error(ord + ": Can't mix leaders and normal men.");
+			u->error(ord + ": Can't mix leaders and normal men.");
 			return 0;
 		} else {
 			if (!(ItemDefs[o->item].type & IT_LEADER) && t->IsLeader()) {
-				u->Error(ord + ": Can't mix leaders and normal men.");
+				u->error(ord + ": Can't mix leaders and normal men.");
 				return 0;
 			}
 		}
 		// Small hack for Ceran
 		if (o->item == I_MERC && t->GetMen()) {
-			u->Error("GIVE: Can't mix mercenaries with other men.");
+			u->error(ord + ": Can't mix mercenaries with other men.");
 			return 0;
 		}
 
 		if (u->faction != t->faction) {
-			u->Error(ord + ": Can't give men to another faction.");
+			u->error(ord + ": Can't give men to another faction.");
 			return 0;
 		}
 
@@ -3021,28 +2932,24 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 	}
 
 	if (ItemDefs[o->item].flags & ItemType::CANTGIVE) {
-		u->Error(ord + ": Can't give " + ItemDefs[o->item].names + ".");
+		u->error(ord + ": Can't give " + ItemDefs[o->item].names + ".");
 		return 0;
 	}
 
 	if (ItemDefs[o->item].max_inventory) {
 		cur = t->items.GetNum(o->item) + amt;
 		if (cur > ItemDefs[o->item].max_inventory) {
-			u->Error(ord + ": Unit cannot have more than "+
-					ItemString(o->item, ItemDefs[o->item].max_inventory));
+			u->error(ord + ": Unit cannot have more than " + ItemString(o->item, ItemDefs[o->item].max_inventory));
 			return 0;
 		}
 	}
 
 	if (o->type == O_TAKE) {
-		u->Event(AString("Takes ") + ItemString(o->item, amt) +
-				" from " + *s->name + ".");
+		u->event("Takes " + ItemString(o->item, amt) + " from " + s->name->const_str() + ".", event_type);
 	} else {
-		u->Event(AString("Gives ") + ItemString(o->item, amt) + " to " +
-				*t->name + ".");
+		u->event("Gives " + ItemString(o->item, amt) + " to " + t->name->const_str() + ".", event_type);
 		if (s->faction != t->faction) {
-			t->Event(AString("Receives ") + ItemString(o->item, amt) +
-					" from " + *s->name + ".");
+			t->event("Receives " + ItemString(o->item, amt) + " from " + s->name->const_str() + ".", event_type);
 		}
 	}
 	s->ConsumeShared(o->item, amt);
@@ -3068,26 +2975,26 @@ void Game::DoGuard1Orders()
 					(u->guard == GUARD_SET || u->guard == GUARD_GUARD) &&
 					TerrainDefs[r->type].similar_type == R_OCEAN) {
 					u->guard = GUARD_NONE;
-					u->Error("Can not guard in oceans.");
+					u->error("Can not guard in oceans.");
 					continue;
 				}
 
 				// Only one faction and it's allies can be on guard at the same time
 				if (Globals->STRICT_GUARD && u->guard == GUARD_SET && !r->CanGuard(u)) {
 					u->guard = GUARD_NONE;
-					u->Error("Is prevented from guarding by another unit.");
+					u->error("Is prevented from guarding by another unit.");
 					continue;
 				}
 
 				if (u->guard == GUARD_SET || u->guard == GUARD_GUARD) {
 					if (!u->Taxers(1)) {
 						u->guard = GUARD_NONE;
-						u->Error("Must be combat ready to be on guard.");
+						u->error("Must be combat ready to be on guard.");
 						continue;
 					}
 					if (u->type != U_GUARD && r->HasCityGuard()) {
 						u->guard = GUARD_NONE;
-						u->Error("Is prevented from guarding by the "
+						u->error("Is prevented from guarding by the "
 								"Guardsmen.");
 						continue;
 					}
@@ -3140,11 +3047,9 @@ void Game::CheckTransportOrders()
 				forlist ((&u->transportorders)) {
 					// make sure target exists
 					TransportOrder *o = (TransportOrder *)elem;
-					AString ordertype =
-						(o->type == O_DISTRIBUTE) ? "DISTRIBUTE" :
-						"TRANSPORT";
+					string ordertype = (o->type == O_DISTRIBUTE) ? "DISTRIBUTE" : "TRANSPORT";
 					if (!o->target || o->target->unitnum == -1) {
-						u->Error(ordertype + ": Target does not exist.");
+						u->error(ordertype + ": Target does not exist.");
 						o->type = NORDERS;
 						continue;
 					}
@@ -3152,23 +3057,22 @@ void Game::CheckTransportOrders()
 					Location *tar = regions.GetUnitId(o->target,
 							u->faction->num, r);
 					if (!tar) {
-						u->Error(ordertype + ": Target does not exist.");
+						u->error(ordertype + ": Target does not exist.");
 						o->type = NORDERS;
 						continue;
 					}
 
 					// Make sure target isn't self
 					if (tar->unit == u) {
-						u->Error(ordertype + ": Target is self.");
+						u->error(ordertype + ": Target is self.");
 						o->type = NORDERS;
 						continue;
 					}
 
 					// Make sure the target and unit are at least friendly
 					if (tar->unit->faction->get_attitude(u->faction->num) <	A_FRIENDLY) {
-						u->Error(ordertype +
-								": Target " + AString(*tar->unit->name) + " is not a member of a friendly "
-								"faction.");
+						u->error(ordertype + ": Target " + tar->unit->name->const_str() +
+							" is not a member of a friendly faction.");
 						o->type = NORDERS;
 						continue;
 					}
@@ -3178,8 +3082,8 @@ void Game::CheckTransportOrders()
 					// structure
 					if (o->type == O_TRANSPORT) {
 						if (tar->unit->GetSkill(S_QUARTERMASTER) == 0) {
-							u->Error(ordertype +
-									": Target " + AString(*tar->unit->name) + " is not a quartermaster");
+							u->error(ordertype + ": Target " + tar->unit->name->const_str() +
+								" is not a quartermaster");
 							o->type = NORDERS;
 							continue;
 						}
@@ -3187,8 +3091,8 @@ void Game::CheckTransportOrders()
 								!(ObjectDefs[tar->obj->type].flags &
 									ObjectType::TRANSPORT) ||
 								(tar->obj->incomplete > 0)) {
-							u->Error(ordertype + ": Target " + AString(*tar->unit->name) + " does not own "
-									"a transport structure.");
+							u->error(ordertype + ": Target " + tar->unit->name->const_str() +
+								" does not own a transport structure.");
 							o->type = NORDERS;
 							continue;
 						}
@@ -3214,7 +3118,7 @@ void Game::CheckTransportOrders()
 						// 0 maxdist represents unlimited range
 						dist = regions.GetPlanarDistance(r, tar->region, penalty, maxdist);
 						if (dist > maxdist) {
-							u->Error(ordertype + ": Recipient " + AString(*tar->unit->name) + " is too far away.");
+							u->error(ordertype + ": Recipient " + tar->unit->name->const_str() + " is too far away.");
 							o->type = NORDERS;
 							continue;
 						}
@@ -3228,8 +3132,7 @@ void Game::CheckTransportOrders()
 						((dist > Globals->LOCAL_TRANSPORT) &&
 						 (o->type == O_TRANSPORT))) {
 						if (u->GetSkill(S_QUARTERMASTER) == 0) {
-							u->Error(ordertype +
-									": Unit is not a quartermaster");
+							u->error(ordertype + ": Unit is not a quartermaster");
 							o->type = NORDERS;
 							continue;
 						}
@@ -3237,7 +3140,7 @@ void Game::CheckTransportOrders()
 							!(ObjectDefs[obj->type].flags &
 								ObjectType::TRANSPORT) ||
 							(obj->incomplete > 0)) {
-						u->Error(ordertype +
+						u->error(ordertype +
 								": Unit does not own transport structure.");
 						o->type = NORDERS;
 						continue;
@@ -3246,7 +3149,7 @@ void Game::CheckTransportOrders()
 
 					// make sure amount is available (all handled later)
 					if (o->amount > 0 && o->amount > u->GetSharedNum(o->item)) {
-						u->Error(ordertype + ": Not enough " + ItemDefs[o->item].name + ".");
+						u->error(ordertype + ": Not enough " + ItemDefs[o->item].name + ".");
 						o->type = NORDERS;
 						continue;
 					}
@@ -3254,10 +3157,8 @@ void Game::CheckTransportOrders()
 					if (o->amount > 0 && ItemDefs[o->item].max_inventory) {
 						int cur = tar->unit->items.GetNum(o->item) + o->amount;
 						if (cur > ItemDefs[o->item].max_inventory) {
-							u->Error(ordertype +
-									": Target cannot have more than " +
-									ItemString(o->item,
-										ItemDefs[o->item].max_inventory));
+							u->error(ordertype + ": Target cannot have more than " +
+								ItemString(o->item, ItemDefs[o->item].max_inventory));
 							o->type = NORDERS;
 							continue;
 						}
@@ -3265,8 +3166,7 @@ void Game::CheckTransportOrders()
 
 					// Check if we have a trade hex
 					if (!Globals->TRANSPORT_NO_TRADE && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
-						u->Error(ordertype + ": Faction cannot transport or "
-								"distribute in that many hexes.");
+						u->error(ordertype + ": Faction cannot transport or distribute in that many hexes.");
 						o->type = NORDERS;
 						continue;
 					}
@@ -3293,8 +3193,7 @@ void Game::RunTransportOrders()
 					Location *tar = regions.GetUnitId(t->target,
 							u->faction->num, r);
 					if (!tar) continue;
-					AString ordertype = (t->type == O_TRANSPORT) ?
-						"TRANSPORT" : "DISTRIBUTE";
+					string ordertype = (t->type == O_TRANSPORT) ? "TRANSPORT" : "DISTRIBUTE";
 
 					int amt = t->amount;
 					if (amt < 0) {
@@ -3302,25 +3201,21 @@ void Game::RunTransportOrders()
 						if (t->except) {
 							if (t->except > amt) {
 								amt = 0;
-								u->Error(ordertype +
-										": EXCEPT value greater than amount "
-										"on hand.");
+								u->error(ordertype + ": EXCEPT value greater than amount on hand.");
 							} else {
 								amt = amt - t->except;
 							}
 						}
 					} else if (amt > u->GetSharedNum(t->item)) {
-						u->Error(ordertype + ": Not enough.");
+						u->error(ordertype + ": Not enough.");
 						amt = u->GetSharedNum(t->item);
 					}
 
 					if (ItemDefs[t->item].max_inventory) {
 						int cur = tar->unit->items.GetNum(t->item) + amt;
 						if (cur > ItemDefs[t->item].max_inventory) {
-							u->Error(ordertype +
-									": Target cannot have more than " +
-									ItemString(t->item,
-										ItemDefs[t->item].max_inventory));
+							u->error(ordertype + ": Target cannot have more than " +
+									ItemString(t->item, ItemDefs[t->item].max_inventory));
 							continue;
 						}
 					}
@@ -3343,20 +3238,18 @@ void Game::RunTransportOrders()
 
 					// if not, give it back
 					if (cost > u->GetSharedMoney()) {
-						u->Error(ordertype + ": Cannot afford shipping cost.");
+						u->error(ordertype + ": Cannot afford shipping cost.");
 						u->items.SetNum(t->item, u->items.GetNum(t->item)+amt);
 						continue;
 					}
 					u->ConsumeSharedMoney(cost);
 
-					ordertype = (t->type == O_TRANSPORT) ?
-						"Transports " : "Distributes ";
-					u->Event(ordertype + ItemString(t->item, amt) + " to " +
-							*tar->unit->name + " for $" + cost + ".");
+					string orderverb = (t->type == O_TRANSPORT) ? "Transports " : "Distributes ";
+					u->event(orderverb + ItemString(t->item, amt) + " to " + tar->unit->name->const_str() +
+						" for $" + to_string(cost) + ".", "transport");
 					if (u->faction != tar->unit->faction) {
-						tar->unit->Event(AString("Receives ") +
-								ItemString(t->item, amt) + " from " +
-								*u->name + ".");
+						tar->unit->event("Receives " + ItemString(t->item, amt) + " from " +
+							u->name->const_str() + ".", "transport");
 					}
 
 					tar->unit->items.SetNum(t->item,

--- a/skills.h
+++ b/skills.h
@@ -65,7 +65,7 @@ struct SkillDepend
 class SkillType
 {
 	public:
-		char const * name;
+		std::string name;
 		char const * abbr;
 		int cost;
 

--- a/spells.cpp
+++ b/spells.cpp
@@ -46,23 +46,23 @@ void Game::ProcessCastOrder(Unit * u,AString * o, OrdersCheck *pCheck )
 {
 	AString * token = o->gettoken();
 	if (!token) {
-		ParseError( pCheck, u, 0, "CAST: No skill given.");
+		parse_error( pCheck, u, 0, "CAST: No skill given.");
 		return;
 	}
 
 	int sk = ParseSkill(token);
 	delete token;
 	if (sk==-1) {
-		ParseError( pCheck, u, 0, "CAST: Invalid skill.");
+		parse_error( pCheck, u, 0, "CAST: Invalid skill.");
 		return;
 	}
 
 	if ( !( SkillDefs[sk].flags & SkillType::MAGIC )) {
-		ParseError( pCheck, u, 0, "CAST: That is not a magic skill.");
+		parse_error( pCheck, u, 0, "CAST: That is not a magic skill.");
 		return;
 	}
 	if ( !( SkillDefs[sk].flags & SkillType::CAST )) {
-		ParseError( pCheck, u, 0, "CAST: That skill cannot be CAST.");
+		parse_error( pCheck, u, 0, "CAST: That skill cannot be CAST.");
 		return;
 	}
 
@@ -160,7 +160,7 @@ void Game::ProcessMindReading(Unit *u,AString *o, OrdersCheck *pCheck )
 	UnitId *id = ParseUnit(o);
 
 	if (!id) {
-		u->Error("CAST: No unit specified.");
+		u->error("CAST: No unit specified.");
 		return;
 	}
 
@@ -178,7 +178,7 @@ void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck *pCheck )
 	AString *token = o->gettoken();
 
 	if (!token) {
-		u->Error("CAST: Missing arguments.");
+		u->error("CAST: Missing arguments.");
 		return;
 	}
 
@@ -196,14 +196,14 @@ void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck *pCheck )
 		token = o->gettoken();
 
 		if (!token) {
-			u->Error("CAST: Missing arguments.");
+			u->error("CAST: Missing arguments.");
 			return;
 		}
 
 		int dir = ParseDir(token);
 		delete token;
 		if (dir == -1 || dir > NDIRS) {
-			u->Error("CAST: Invalid direction.");
+			u->error("CAST: Invalid direction.");
 			return;
 		}
 
@@ -217,7 +217,7 @@ void Game::ProcessBirdLore(Unit *u,AString *o, OrdersCheck *pCheck )
 		return;
 	}
 
-	u->Error("CAST: Invalid arguments.");
+	u->error("CAST: Invalid arguments.");
 	delete token;
 }
 
@@ -226,7 +226,7 @@ void Game::ProcessInvisibility(Unit *u,AString *o, OrdersCheck *pCheck )
 	AString *token = o->gettoken();
 
 	if (!token || !(*token == "units")) {
-		u->Error("CAST: Must specify units to render invisible.");
+		u->error("CAST: Must specify units to render invisible.");
 		return;
 	}
 	delete token;
@@ -261,7 +261,7 @@ void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck *pCheck )
 	AString *token = o->gettoken();
 
 	if (!token) {
-		u->Error("CAST: Illusion to summon must be given.");
+		u->error("CAST: Illusion to summon must be given.");
 		delete order;
 		return;
 	}
@@ -281,7 +281,7 @@ void Game::ProcessPhanDemons(Unit *u,AString *o, OrdersCheck *pCheck )
 	delete token;
 
 	if (!order->level) {
-		u->Error("CAST: Can't summon that illusion.");
+		u->error("CAST: Can't summon that illusion.");
 		delete order;
 		return;
 	}
@@ -309,7 +309,7 @@ void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck *pCheck)
 	AString *token = o->gettoken();
 
 	if (!token) {
-		u->Error("CAST: Must specify which illusion to summon.");
+		u->error("CAST: Must specify which illusion to summon.");
 		delete order;
 		return;
 	}
@@ -329,7 +329,7 @@ void Game::ProcessPhanUndead(Unit *u,AString *o, OrdersCheck *pCheck)
 	delete token;
 
 	if (!order->level) {
-		u->Error("CAST: Must specify which illusion to summon.");
+		u->error("CAST: Must specify which illusion to summon.");
 		delete order;
 		return;
 	}
@@ -357,7 +357,7 @@ void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck *pCheck )
 	AString *token = o->gettoken();
 
 	if (!token) {
-		u->Error("CAST: Must specify which illusion to summon.");
+		u->error("CAST: Must specify which illusion to summon.");
 		delete order;
 		return;
 	}
@@ -375,7 +375,7 @@ void Game::ProcessPhanBeasts(Unit *u,AString *o, OrdersCheck *pCheck )
 	delete token;
 	if (!order->level) {
 		delete order;
-		u->Error("CAST: Must specify which illusion to summon.");
+		u->error("CAST: Must specify which illusion to summon.");
 		return;
 	}
 
@@ -412,7 +412,7 @@ void Game::ProcessRegionSpell(Unit *u, AString *o, int spell,
 			delete token;
 			token = o->gettoken();
 			if (!token) {
-				u->Error("CAST: Region X coordinate not specified.");
+				u->error("CAST: Region X coordinate not specified.");
 				return;
 			}
 			x = token->value();
@@ -420,7 +420,7 @@ void Game::ProcessRegionSpell(Unit *u, AString *o, int spell,
 
 			token = o->gettoken();
 			if (!token) {
-				u->Error("CAST: Region Y coordinate not specified.");
+				u->error("CAST: Region Y coordinate not specified.");
 				return;
 			}
 			y = token->value();
@@ -434,7 +434,7 @@ void Game::ProcessRegionSpell(Unit *u, AString *o, int spell,
 					if (z < 0 || (z >= Globals->UNDERWORLD_LEVELS +
 								Globals->UNDERDEEP_LEVELS +
 								Globals->ABYSS_LEVEL + 2)) {
-						u->Error("CAST: Invalid Z coordinate specified.");
+						u->error("CAST: Invalid Z coordinate specified.");
 						return;
 					}
 				}
@@ -470,7 +470,7 @@ void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck *pCheck )
 {
 	AString *token = o->gettoken();
 	if (!token) {
-		u->Error("CAST: Requires a target mage.");
+		u->error("CAST: Requires a target mage.");
 		return;
 	}
 	int gate = token->value();
@@ -478,12 +478,12 @@ void Game::ProcessCastPortalLore(Unit *u,AString *o, OrdersCheck *pCheck )
 	token = o->gettoken();
 
 	if (!token) {
-		u->Error("CAST: No units to teleport.");
+		u->error("CAST: No units to teleport.");
 		return;
 	}
 
 	if (!(*token == "units")) {
-		u->Error("CAST: No units to teleport.");
+		u->error("CAST: No units to teleport.");
 		delete token;
 		return;
 	}
@@ -514,7 +514,7 @@ void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck *pCheck )
 	AString *token = o->gettoken();
 
 	if (!token) {
-		u->Error("CAST: Missing argument.");
+		u->error("CAST: Missing argument.");
 		return;
 	}
 
@@ -523,7 +523,7 @@ void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck *pCheck )
 		token = o->gettoken();
 
 		if (!token || token->value() < 1) {
-			u->Error("CAST: Requires a target gate.");
+			u->error("CAST: Requires a target gate.");
 			return;
 		}
 
@@ -613,7 +613,7 @@ void Game::ProcessCastGateLore(Unit *u,AString *o, OrdersCheck *pCheck )
 	}
 
 	delete token;
-	u->Error("CAST: Invalid argument.");
+	u->error("CAST: Invalid argument.");
 }
 
 void Game::ProcessTransmutation(Unit *u, AString *o, OrdersCheck *pCheck)
@@ -629,7 +629,7 @@ void Game::ProcessTransmutation(Unit *u, AString *o, OrdersCheck *pCheck)
 
 	token = o->gettoken();
 	if (!token) {
-		u->Error("CAST: You must specify what you wish to create.");
+		u->error("CAST: You must specify what you wish to create.");
 		delete order;
 		return;
 	}
@@ -642,7 +642,7 @@ void Game::ProcessTransmutation(Unit *u, AString *o, OrdersCheck *pCheck)
 	order->item = ParseEnabledItem(token);
 	delete token;
 	if (order->item == -1) {
-		u->Error("CAST: You must specify what you wish to create.");
+		u->error("CAST: You must specify what you wish to create.");
 		delete order;
 		return;
 	}
@@ -668,7 +668,7 @@ void Game::ProcessTransmutation(Unit *u, AString *o, OrdersCheck *pCheck)
 			order->level = 5;
 			break;
 		default:
-			u->Error("CAST: Can't create that by transmutation.");
+			u->error("CAST: Can't create that by transmutation.");
 			delete order;
 			return;
 	}
@@ -683,7 +683,7 @@ void Game::RunACastOrder(ARegion * r,Object *o,Unit * u)
 {
 	int val;
 	if (u->type != U_MAGE && u->type != U_APPRENTICE) {
-		u->Error("CAST: Unit is not a mage.");
+		u->error("CAST: Unit is not a mage.");
 		return;
 	}
 
@@ -693,7 +693,7 @@ void Game::RunACastOrder(ARegion * r,Object *o,Unit * u)
 
 	if (u->GetSkill(u->castorders->spell) < u->castorders->level ||
 			u->castorders->level == 0) {
-		u->Error("CAST: Skill level isn't that high.");
+		u->error("CAST: Skill level isn't that high.");
 		return;
 	}
 
@@ -857,42 +857,42 @@ int Game::GetRegionInRange(ARegion *r, ARegion *tar, Unit *u, int spell)
 {
 	int level = u->GetSkill(spell);
 	if (!level) {
-		u->Error("CAST: You don't know that spell.");
+		u->error("CAST: You don't know that spell.");
 		return 0;
 	}
 
 	RangeType *range = FindRange(SkillDefs[spell].range);
 	if (range == NULL) {
-		u->Error("CAST: Spell is not castable at range.");
+		u->error("CAST: Spell is not castable at range.");
 		return 0;
 	}
 
 	int rtype = regions.GetRegionArray(r->zloc)->levelType;
 	if ((rtype == ARegionArray::LEVEL_NEXUS) &&
 			!(range->flags & RangeType::RNG_NEXUS_SOURCE)) {
-		u->Error("CAST: Spell does not work from the Nexus.");
+		u->error("CAST: Spell does not work from the Nexus.");
 		return 0;
 	}
 
 	if (!tar) {
-		u->Error("CAST: No such region.");
+		u->error("CAST: No such region.");
 		return 0;
 	}
 
 	rtype = regions.GetRegionArray(tar->zloc)->levelType;
 	if ((rtype == ARegionArray::LEVEL_NEXUS) &&
 			!(range->flags & RangeType::RNG_NEXUS_TARGET)) {
-		u->Error("CAST: Spell does not work to the Nexus.");
+		u->error("CAST: Spell does not work to the Nexus.");
 		return 0;
 	}
 
 	if ((rtype != ARegionArray::LEVEL_SURFACE) &&
 			(range->flags & RangeType::RNG_SURFACE_ONLY)) {
-		u->Error("CAST: Spell can only target regions on the surface.");
+		u->error("CAST: Spell can only target regions on the surface.");
 		return 0;
 	}
 	if (!(range->flags&RangeType::RNG_CROSS_LEVELS) && (r->zloc != tar->zloc)) {
-		u->Error("CAST: Spell is not able to work across levels.");
+		u->error("CAST: Spell is not able to work across levels.");
 		return 0;
 	}
 
@@ -917,7 +917,7 @@ int Game::GetRegionInRange(ARegion *r, ARegion *tar, Unit *u, int spell)
 	int dist;
 	dist = regions.GetPlanarDistance(tar, r, range->crossLevelPenalty, maxdist);
 	if (dist > maxdist) {
-		u->Error("CAST: Target region out of range.");
+		u->error("CAST: Target region out of range.");
 		return 0;
 	}
 	return 1;
@@ -930,22 +930,21 @@ int Game::RunMindReading(ARegion *r,Unit *u)
 
 	Unit *tar = r->GetUnitId(order->id,u->faction->num);
 	if (!tar) {
-		u->Error("No such unit.");
+		u->error("No such unit.");
 		return 0;
 	}
 
-	AString temp = AString("Casts Mind Reading: ") + *(tar->name) + ", " +
-		*(tar->faction->name);
+	string temp = "Casts Mind Reading: " + string(tar->name->const_str()) + ", " + tar->faction->name->const_str();
 
 	if (level < 3) {
-		u->Event(temp + ".");
+		u->event(temp + ".", "spell");
 		return 1;
 	}
 
-	temp += tar->items.Report(2,5,0) + ". Skills: ";
-	temp += tar->skills.Report(tar->GetMen()) + ".";
+	temp += string(tar->items.Report(2,5,0).const_str()) + ". Skills: ";
+	temp += string(tar->skills.Report(tar->GetMen()).const_str()) + ".";
 
-	u->Event(temp);
+	u->event(temp, "spell");
 	return 1;
 }
 
@@ -980,7 +979,7 @@ int Game::RunEnchant(ARegion *r,Unit *u, int skill, int item)
 
 	// Add the created items
 	u->items.SetNum(item, u->items.GetNum(item) + num);
-	u->Event(AString("Enchants ") + num + " " + ItemDefs[item].names + ".");
+	u->event("Enchants " + to_string(num) + " " + ItemDefs[item].names + ".", "spell");
 	if (num == 0) return 0;
 	return 1;
 }
@@ -990,17 +989,17 @@ int Game::RunConstructGate(ARegion *r,Unit *u, int spell)
 	int ngates, log10, *used, i;
 
 	if (TerrainDefs[r->type].similar_type == R_OCEAN) {
-		u->Error("Gates may not be constructed at sea.");
+		u->error("Gates may not be constructed at sea.");
 		return 0;
 	}
 
 	if (r->gate) {
-		u->Error("There is already a gate in that region.");
+		u->error("There is already a gate in that region.");
 		return 0;
 	}
 
 	if (u->GetSharedMoney() < 1000) {
-		u->Error("Can't afford to construct a Gate.");
+		u->error("Can't afford to construct a Gate.");
 		return 0;
 	}
 
@@ -1009,11 +1008,11 @@ int Game::RunConstructGate(ARegion *r,Unit *u, int spell)
 	int level = u->GetSkill(spell);
 	int chance = level * 20;
 	if (getrandom(100) >= chance) {
-		u->Event("Attempts to construct a gate, but fails.");
+		u->event("Attempts to construct a gate, but fails.", "spell");
 		return 0;
 	}
 
-	u->Event(AString("Constructs a Gate in ")+r->ShortPrint( &regions )+".");
+	u->event("Constructs a Gate in " + string(r->ShortPrint( &regions).const_str()) + ".", "spell");
 	regions.numberofgates++;
 	if (Globals->DISPERSE_GATE_NUMBERS) {
 		log10 = 0;
@@ -1055,12 +1054,12 @@ int Game::RunConstructGate(ARegion *r,Unit *u, int spell)
 int Game::RunEngraveRunes(ARegion *r,Object *o,Unit *u)
 {
 	if (o->IsFleet() || !o->IsBuilding()) {
-		u->Error("Runes of Warding may only be engraved on a building.");
+		u->error("Runes of Warding may only be engraved on a building.");
 		return 0;
 	}
 
 	if (o->incomplete > 0) {
-		u->Error( "Runes of Warding may only be engraved on a completed "
+		u->error( "Runes of Warding may only be engraved on a completed "
 				"building.");
 		return 0;
 	}
@@ -1082,13 +1081,13 @@ int Game::RunEngraveRunes(ARegion *r,Object *o,Unit *u)
 		case 1:
 			if (o->type == O_TOWER) break;
 		default:
-			u->Error("Not high enough level to engrave Runes of Warding on "
+			u->error("Not high enough level to engrave Runes of Warding on "
 					"that building.");
 			return 0;
 	}
 
 	if (u->GetSharedMoney() < 600) {
-		u->Error("Can't afford to engrave Runes of Warding.");
+		u->error("Can't afford to engrave Runes of Warding.");
 		return 0;
 	}
 
@@ -1104,19 +1103,19 @@ int Game::RunEngraveRunes(ARegion *r,Object *o,Unit *u)
 	} else {
 		o->runes = 3;
 	}
-	u->Event(AString("Engraves Runes of Warding on ") + *(o->name) + ".");
+	u->event("Engraves Runes of Warding on " + string(o->name->const_str()) + ".", "spell");
 	return 1;
 }
 
 int Game::RunSummonBalrog(ARegion *r,Unit *u)
 {
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
 	if (u->items.GetNum(I_BALROG) >= ItemDefs[I_BALROG].max_inventory) {
-		u->Error("Can't control any more balrogs.");
+		u->error("Can't control any more balrogs.");
 		return 0;
 	}
 
@@ -1127,14 +1126,14 @@ int Game::RunSummonBalrog(ARegion *r,Unit *u)
 		num = ItemDefs[I_BALROG].max_inventory - u->items.GetNum(I_BALROG);
 
 	u->items.SetNum(I_BALROG,u->items.GetNum(I_BALROG) + num);
-	u->Event(AString("Summons ") + ItemString(I_BALROG,num) + ".");
+	u->event("Summons " + ItemString(I_BALROG, num) + ".", "spell");
 	return 1;
 }
 
 int Game::RunSummonDemon(ARegion *r,Unit *u)
 {
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1144,14 +1143,14 @@ int Game::RunSummonDemon(ARegion *r,Unit *u)
 	if (num < 1)
 		num = 1;
 	u->items.SetNum(I_DEMON,u->items.GetNum(I_DEMON) + num);
-	u->Event(AString("Summons ") + ItemString(I_DEMON,num) + ".");
+	u->event("Summons " + ItemString(I_DEMON, num) + ".", "spell");
 	return 1;
 }
 
 int Game::RunSummonImps(ARegion *r,Unit *u)
 {
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1160,7 +1159,7 @@ int Game::RunSummonImps(ARegion *r,Unit *u)
 	num = RandomiseSummonAmount(num);
 
 	u->items.SetNum(I_IMP,u->items.GetNum(I_IMP) + num);
-	u->Event(AString("Summons ") + ItemString(I_IMP,num) + ".");
+	u->event("Summons " + ItemString(I_IMP, num) + ".", "spell");
 	return 1;
 }
 
@@ -1168,7 +1167,7 @@ int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
 {
 	int level = u->GetSkill(skill);
 	if (level < ItemDefs[item].mLevel) {
-		u->Error("CAST: Skill level isn't that high.");
+		u->error("CAST: Skill level isn't that high.");
 		return 0;
 	}
 	unsigned int c;
@@ -1177,9 +1176,7 @@ int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
 		int amt = u->GetSharedNum(ItemDefs[item].mInput[c].item);
 		int cost = ItemDefs[item].mInput[c].amt;
 		if (amt < cost) {
-			u->Error(AString("Doesn't have sufficient ") +
-					ItemDefs[ItemDefs[item].mInput[c].item].name +
-					" to create that.");
+			u->error("Doesn't have sufficient " + ItemDefs[ItemDefs[item].mInput[c].item].name + " to create that.");
 			return 0;
 		}
 	}
@@ -1199,7 +1196,7 @@ int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
 	} else {
 		u->items.SetNum(item,u->items.GetNum(item) + num);
 	}
-	u->Event(AString("Creates ") + ItemString(item,num) + ".");
+	u->event("Creates " + ItemString(item, num) + ".", "spell");
 	if (num == 0) return 0;
 	return 1;
 }
@@ -1207,7 +1204,7 @@ int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
 int Game::RunSummonLich(ARegion *r,Unit *u)
 {
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1219,7 +1216,7 @@ int Game::RunSummonLich(ARegion *r,Unit *u)
 	int num = (chance + getrandom(100))/100;
 
 	u->items.SetNum(I_LICH,u->items.GetNum(I_LICH) + num);
-	u->Event(AString("Summons ") + ItemString(I_LICH,num) + ".");
+	u->event("Summons " + ItemString(I_LICH, num) + ".", "spell");
 	if (num == 0) return 0;
 	return 1;
 }
@@ -1227,7 +1224,7 @@ int Game::RunSummonLich(ARegion *r,Unit *u)
 int Game::RunRaiseUndead(ARegion *r,Unit *u)
 {
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1240,7 +1237,7 @@ int Game::RunRaiseUndead(ARegion *r,Unit *u)
 	num = RandomiseSummonAmount(num);
 
 	u->items.SetNum(I_UNDEAD,u->items.GetNum(I_UNDEAD) + num);
-	u->Event(AString("Raises ") + ItemString(I_UNDEAD,num) + ".");
+	u->event("Raises " + ItemString(I_UNDEAD, num) + ".", "spell");
 	if (num == 0) return 0;
 	return 1;
 }
@@ -1248,7 +1245,7 @@ int Game::RunRaiseUndead(ARegion *r,Unit *u)
 int Game::RunSummonSkeletons(ARegion *r,Unit *u)
 {
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1261,7 +1258,7 @@ int Game::RunSummonSkeletons(ARegion *r,Unit *u)
 	num = RandomiseSummonAmount(num);
 
 	u->items.SetNum(I_SKELETON,u->items.GetNum(I_SKELETON) + num);
-	u->Event(AString("Summons ") + ItemString(I_SKELETON,num) + ".");
+	u->event("Summons " + ItemString(I_SKELETON, num) + ".", "spell");
 	if (num == 0) return 0;
 	return 1;
 }
@@ -1269,7 +1266,7 @@ int Game::RunSummonSkeletons(ARegion *r,Unit *u)
 int Game::RunDragonLore(ARegion *r, Unit *u)
 {
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1277,7 +1274,7 @@ int Game::RunDragonLore(ARegion *r, Unit *u)
 
 	int num = u->items.GetNum(I_DRAGON);
 	if (num >= level) {
-		u->Error("Mage may not summon more dragons.");
+		u->error("Mage may not summon more dragons.");
 		return 0;
 	}
 
@@ -1286,10 +1283,10 @@ int Game::RunDragonLore(ARegion *r, Unit *u)
 		chance = level * level * 4;
 	if (getrandom(100) < chance) {
 		u->items.SetNum(I_DRAGON,num + 1);
-		u->Event("Summons a dragon.");
+		u->event("Summons a dragon.", "spell");
 		num = 1;
 	} else {
-		u->Event("Attempts to summon a dragon, but fails.");
+		u->event("Attempts to summon a dragon, but fails.", "spell");
 		num = 0;
 	}
 	if (num == 0) return 0;
@@ -1305,7 +1302,7 @@ int Game::RunBirdLore(ARegion *r,Unit *u)
 		AString error = "CAST: Bird Lore may only be cast on the surface of ";
 		error += Globals->WORLD_NAME;
 		error += ".";
-		u->Error(error.Str());
+		u->error(error.Str());
 		return 0;
 	}
 
@@ -1313,7 +1310,7 @@ int Game::RunBirdLore(ARegion *r,Unit *u)
 		int dir = order->target;
 		ARegion *tar = r->neighbors[dir];
 		if (!tar) {
-			u->Error("CAST: No such region.");
+			u->error("CAST: No such region.");
 			return 0;
 		}
 
@@ -1321,13 +1318,12 @@ int Game::RunBirdLore(ARegion *r,Unit *u)
 		f->faction = u->faction;
 		f->level = u->GetSkill(S_BIRD_LORE);
 		tar->farsees.Add(f);
-		u->Event(AString("Sends birds to spy on ") +
-				tar->Print( &regions ) + ".");
+		u->event("Sends birds to spy on " + string(tar->Print(&regions).const_str()) + ".", "spell");
 		return 1;
 	}
 
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1339,7 +1335,7 @@ int Game::RunBirdLore(ARegion *r,Unit *u)
 		num = 1;
 
 	if (u->items.GetNum(I_EAGLE) >= max) {
-		u->Error("CAST: Mage can't summon more eagles.");
+		u->error("CAST: Mage can't summon more eagles.");
 		return 0;
 	}
 
@@ -1347,7 +1343,7 @@ int Game::RunBirdLore(ARegion *r,Unit *u)
 		num = max - u->items.GetNum(I_EAGLE);
 
 	u->items.SetNum(I_EAGLE,u->items.GetNum(I_EAGLE) + num);
-	u->Event(AString("Summons ") + ItemString(I_EAGLE,num) + ".");
+	u->event("Summons " + ItemString(I_EAGLE, num) + ".", "spell");
 	return 1;
 }
 
@@ -1355,7 +1351,7 @@ int Game::RunWolfLore(ARegion *r,Unit *u)
 {
 	// if (TerrainDefs[r->type].similar_type != R_MOUNTAIN &&
 	// 	TerrainDefs[r->type].similar_type != R_FOREST) {
-	// 	u->Error("CAST: Can only summon wolves in mountain and "
+	// 	u->error("CAST: Can only summon wolves in mountain and "
 	// 			 "forest regions.");
 	// 	return 0;
 	// }
@@ -1371,9 +1367,8 @@ int Game::RunWolfLore(ARegion *r,Unit *u)
 		num = max - curr;
 	if (num < 0) num = 0;
 
-	u->Event(AString("Casts Wolf Lore, summoning ") +
-			ItemString(I_WOLF,num) + ".");
-	u->items.SetNum(I_WOLF,num + curr);
+	u->event("Casts Wolf Lore, summoning " + ItemString(I_WOLF, num) + ".", "spell");
+	u->items.SetNum(I_WOLF, num + curr);
 	if (num == 0) return 0;
 	return 1;
 }
@@ -1394,12 +1389,12 @@ int Game::RunInvisibility(ARegion *r,Unit *u)
 	}
 
 	if (num > max) {
-		u->Error("CAST: Can't render that many men or creatures invisible.");
+		u->error("CAST: Can't render that many men or creatures invisible.");
 		return 0;
 	}
 
 	if (!num) {
-		u->Error("CAST: No valid targets to turn invisible.");
+		u->error("CAST: No valid targets to turn invisible.");
 		return 0;
 	}
 	forlist_reuse (&(order->units)) {
@@ -1407,11 +1402,10 @@ int Game::RunInvisibility(ARegion *r,Unit *u)
 		if (!tar) continue;
 		if (tar->GetAttitude(r,u) < A_FRIENDLY) continue;
 		tar->SetFlag(FLAG_INVIS,1);
-		tar->Event(AString("Is rendered invisible by ") +
-				*(u->name) + ".");
+		tar->event("Is rendered invisible by " + string(u->name->const_str()) + ".", "spell");
 	}
 
-	u->Event("Casts invisibility.");
+	u->event("Casts invisibility.", "spell");
 	return 1;
 }
 
@@ -1422,7 +1416,7 @@ int Game::RunPhanDemons(ARegion *r,Unit *u)
 	int create,max;
 
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1440,12 +1434,12 @@ int Game::RunPhanDemons(ARegion *r,Unit *u)
 	}
 
 	if (order->target > max || order->target <= 0) {
-		u->Error("CAST: Can't create that many Phantasmal Demons.");
+		u->error("CAST: Can't create that many Phantasmal Demons.");
 		return 0;
 	}
 
 	u->items.SetNum(create,order->target);
-	u->Event("Casts Create Phantasmal Demons.");
+	u->event("Casts Create Phantasmal Demons.", "spell");
 	return 1;
 }
 
@@ -1456,7 +1450,7 @@ int Game::RunPhanUndead(ARegion *r,Unit *u)
 	int create,max;
 
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1474,12 +1468,12 @@ int Game::RunPhanUndead(ARegion *r,Unit *u)
 	}
 
 	if (order->target > max || order->target <= 0) {
-		u->Error("CAST: Can't create that many Phantasmal Undead.");
+		u->error("CAST: Can't create that many Phantasmal Undead.");
 		return 0;
 	}
 
 	u->items.SetNum(create,order->target);
-	u->Event("Casts Create Phantasmal Undead.");
+	u->event("Casts Create Phantasmal Undead.", "spell");
 	return 1;
 }
 
@@ -1490,7 +1484,7 @@ int Game::RunPhanBeasts(ARegion *r,Unit *u)
 	int create,max;
 
 	if (r->type == R_NEXUS) {
-		u->Error("Can't summon creatures in the nexus.");
+		u->error("Can't summon creatures in the nexus.");
 		return 0;
 	}
 
@@ -1508,12 +1502,12 @@ int Game::RunPhanBeasts(ARegion *r,Unit *u)
 	}
 
 	if (order->target > max || order->target <= 0) {
-		u->Error("CAST: Can't create that many Phantasmal Beasts.");
+		u->error("CAST: Can't create that many Phantasmal Beasts.");
 		return 0;
 	}
 
 	u->items.SetNum(create,order->target);
-	u->Event("Casts Create Phantasmal Beasts.");
+	u->event("Casts Create Phantasmal Beasts.", "spell");
 	return 1;
 }
 
@@ -1525,7 +1519,7 @@ int Game::RunEarthLore(ARegion *r,Unit *u)
 	int amt = r->Wages() * level * 2 / 10;
 
 	u->items.SetNum(I_SILVER,u->items.GetNum(I_SILVER) + amt);
-	u->Event(AString("Casts Earth Lore, raising ") + amt + " silver.");
+	u->event("Casts Earth Lore, raising " + to_string(amt) + " silver.", "spell");
 	return 1;
 }
 
@@ -1548,14 +1542,14 @@ int Game::RunPhantasmalEntertainment(ARegion *r,Unit *u)
 	}
 
 	u->items.SetNum(I_SILVER, u->items.GetNum(I_SILVER) + amt);
-	u->Event(AString("Casts Phantasmal Entertainment, raising ") + amt + " silver.");
+	u->event("Casts Phantasmal Entertainment, raising " + to_string(amt) + " silver.", "spell");
 	return 1;
 }
 
 int Game::RunClearSkies(ARegion *r, Unit *u)
 {
 	ARegion *tar = r;
-	AString temp = "Casts Clear Skies";
+	string temp = "Casts Clear Skies";
 	int val;
 
 	CastRegionOrder *order = (CastRegionOrder *)u->castorders;
@@ -1565,13 +1559,12 @@ int Game::RunClearSkies(ARegion *r, Unit *u)
 		tar = regions.GetRegion(order->xloc, order->yloc, order->zloc);
 		val = GetRegionInRange(r, tar, u, S_CLEAR_SKIES);
 		if (!val) return 0;
-		temp += " on ";
-		temp += tar->ShortPrint(&regions);
+		temp += " on " + string(tar->ShortPrint(&regions).const_str());
 	}
 	temp += ".";
 	int level = u->GetSkill(S_CLEAR_SKIES);
 	if (level > r->clearskies) r->clearskies = level;
-	u->Event(temp);
+	u->event(temp, "spell");
 	return 1;
 }
 
@@ -1591,16 +1584,12 @@ int Game::RunWeatherLore(ARegion *r, Unit *u)
 	if (level >= 5) months = 12;
 	else if (level >= 3) months = 6;
 
-	AString temp = "Casts Weather Lore on ";
-	temp += tar->ShortPrint(&regions);
-	temp += ". It will be ";
+	string temp = "Casts Weather Lore on " + string(tar->ShortPrint(&regions).const_str()) + ". It will be ";
 	int weather, futuremonth;
 	for (i = 0; i <= months; i++) {
 		futuremonth = (month + i)%12;
 		weather=regions.GetWeather(tar, futuremonth);
-		temp += SeasonNames[weather];
-		temp += " in ";
-		temp += MonthNames[futuremonth];
+		temp += SeasonNames[weather] + " " + MonthNames[futuremonth];
 		if (i < (months-1))
 			temp += ", ";
 		else if (i == (months-1))
@@ -1608,7 +1597,7 @@ int Game::RunWeatherLore(ARegion *r, Unit *u)
 		else
 			temp += ".";
 	}
-	u->Event(temp);
+	u->event(temp, "spell");
 	return 1;
 }
 
@@ -1629,10 +1618,7 @@ int Game::RunFarsight(ARegion *r,Unit *u)
 	f->unit = u;
 	f->observation = u->GetAttribute("observation");
 	tar->farsees.Add(f);
-	AString temp = "Casts Farsight on ";
-	temp += tar->ShortPrint(&regions);
-	temp += ".";
-	u->Event(temp);
+	u->event("Casts Farsight on " + string(tar->ShortPrint(&regions).const_str()) + ".", "spell");
 	return 1;
 }
 
@@ -1641,34 +1627,31 @@ int Game::RunDetectGates(ARegion *r,Object *o,Unit *u)
 	int level = u->GetSkill(S_GATE_LORE);
 
 	if (level == 1) {
-		u->Error("CAST: Casting Gate Lore at level 1 has no effect.");
+		u->error("CAST: Casting Gate Lore at level 1 has no effect.");
 		return 0;
 	}
 
-	u->Event("Casts Gate Lore, detecting nearby Gates:");
+	u->event("Casts Gate Lore, detecting nearby Gates:", "spell");
 	int found = 0;
 	if ((r->gate) && (!r->gateopen)) {
-		u->Event(AString("Identified local gate number ") + (r->gate) +
-		" in " + r->ShortPrint(&regions) + ".");
+		u->event("Identified local gate number " + to_string(r->gate) + " in " +
+			string(r->ShortPrint(&regions).const_str()) + ".", "spell");
 	}
 	for (int i=0; i<NDIRS; i++) {
 		ARegion *tar = r->neighbors[i];
 		if (tar) {
 			if (tar->gate) {
 				if (Globals->DETECT_GATE_NUMBERS) {
-					u->Event(tar->Print(&regions) +
-						" contains Gate " + tar->gate +
-						".");
+					u->event(string(tar->Print(&regions).const_str()) +	" contains Gate " +
+						to_string(tar->gate) + ".", "spell");
 				} else {
-					u->Event(tar->Print(&regions) +
-						" contains a Gate.");
+					u->event(string(tar->Print(&regions).const_str()) +	" contains a Gate.", "spell");
 				}
 				found = 1;
 			}
 		}
 	}
-	if (!found)
-		u->Event("There are no nearby Gates.");
+	if (!found) u->event("There are no nearby Gates.", "spell");
 	return 1;
 }
 
@@ -1687,18 +1670,17 @@ int Game::RunTeleport(ARegion *r,Object *o,Unit *u)
 	int maxweight = level * 50;
 
 	if (u->Weight() > maxweight) {
-		u->Error("CAST: Can't carry that much when teleporting.");
+		u->error("CAST: Can't carry that much when teleporting.");
 		return 0;
 	}
 
 	// Presume they had to open the portal to see if target is ocean
 	if (TerrainDefs[tar->type].similar_type == R_OCEAN) {
-		u->Error(AString("CAST: ") + tar->Print(&regions) +
-			" is an ocean.");
+		u->error(string("CAST: ") + tar->Print(&regions).const_str() + " is an ocean.");
 		return 1;
 	}
 	u->DiscardUnfinishedShips();
-	u->Event(AString("Teleports to ") + tar->Print(&regions) + ".");
+	u->event("Teleports to " + string(tar->Print(&regions).const_str()) + ".", "spell");
 	u->MoveUnit(tar->GetDummy());
 	return 1;
 }
@@ -1708,7 +1690,7 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 	int level = u->GetSkill(S_GATE_LORE);
 	int nexgate = 0;
 	if ( !level ) {
-		u->Error( "CAST: Unit doesn't have that skill." );
+		u->error( "CAST: Unit doesn't have that skill." );
 		return 0;
 	}
 
@@ -1716,19 +1698,19 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 
 	if ((order->gate > 0 && level < 2) ||
 			(order->gate == -2 && level < 2)) {
-		u->Error("CAST: Unit Doesn't know Gate Lore at that level.");
+		u->error("CAST: Unit Doesn't know Gate Lore at that level.");
 		return 0;
 	}
 
 	nexgate = Globals->NEXUS_GATE_OUT &&
 		(TerrainDefs[r->type].similar_type == R_NEXUS);
 	if (!r->gate && !nexgate) {
-		u->Error("CAST: There is no gate in that region.");
+		u->error("CAST: There is no gate in that region.");
 		return 0;
 	}
 
 	if (!r->gateopen) {
-		u->Error("CAST: Gate not open at this time of year.");
+		u->error("CAST: Gate not open at this time of year.");
 		return 0;
 	}
 
@@ -1790,12 +1772,11 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 	}
 
 	if (weight > maxweight) {
-		u->Error( "CAST: Can't carry that much weight through a Gate.");
+		u->error( "CAST: Can't carry that much weight through a Gate.");
 		return 0;
 	}
 
 	ARegion *tar;
-	AString jump_text;
 	if (order->gate < 0) {
 		int good = 0;
 
@@ -1815,25 +1796,26 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 				good = 0;
 		} while (!good);
 
-		jump_text = AString("Casts Random Gate Jump. Capacity: ") + AString(weight) + AString("/") + AString(maxweight) + ".";
-		u->Event(jump_text);
+		string jump_text = "Casts Random Gate Jump. Capacity: " + to_string(weight) + "/" + to_string(maxweight) + ".";
+		u->event(jump_text, "spell");
 	} else {
 		tar = regions.FindGate(order->gate);
 		if (!tar) {
-			u->Error("CAST: No such target gate.");
+			u->error("CAST: No such target gate.");
 			return 0;
 		}
 		if (!tar->gateopen) {
-			u->Error("CAST: Target gate is not open at this time of year.");
+			u->error("CAST: Target gate is not open at this time of year.");
 			return 0;
 		}
 
-		jump_text = AString("Casts Gate Jump. Capacity: ") + AString(weight) + "/" + AString(maxweight) + ".";
-		u->Event(jump_text);
+		string jump_text = "Casts Gate Jump. Capacity: " + to_string(weight) + "/" + to_string(maxweight) + ".";
+		u->event(jump_text, "spell");
 	}
 
 	int comma = 0;
-	AString unitlist; {
+	string unitlist;
+	{
 		forlist(&(order->units)) {
 			Location *loc = r->GetLocation((UnitId *) elem,u->faction->num);
 			if (loc) {
@@ -1844,32 +1826,26 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
 				}
 
 				if (loc->unit->GetAttitude(r,u) < A_ALLY) {
-					u->Error("CAST: Unit is not allied.");
+					u->error("CAST: Unit is not allied.");
 				} else {
-					if (comma) {
-						unitlist += AString(", ") + AString(loc->unit->num);
-					} else {
-						unitlist += AString(loc->unit->num);
-						comma = 1;
-					}
+					unitlist += (comma ? ", " : "") + to_string(loc->unit->num);
+					comma = 1;
 					loc->unit->DiscardUnfinishedShips();
-					loc->unit->Event(AString("Is teleported through a ") +
-							"Gate to " + tar->Print(&regions) + " by " +
-							*u->name + ".");
+					loc->unit->event("Is teleported through a Gate to " + string(tar->Print(&regions).const_str()) +
+						" by " + string(u->name->const_str()) + ".", "spell");
 					loc->unit->MoveUnit( tar->GetDummy() );
 					if (loc->unit != u) loc->unit->ClearCastOrders();
 				}
 				delete loc;
 			} else {
-				u->Error("CAST: No such unit.");
+				u->error("CAST: No such unit.");
 			}
 		}
 	}
 	u->DiscardUnfinishedShips();
-	u->Event(AString("Jumps through a Gate to ") +
-			tar->Print( &regions ) + ".");
+	u->event("Jumps through a Gate to " + string(tar->Print(&regions).const_str()) + ".", "spell");
 	if (comma) {
-		u->Event(unitlist + " follow through the Gate.");
+		u->event(unitlist + " follow through the Gate.", "spell");
 	}
 	u->MoveUnit( tar->GetDummy() );
 	return 1;
@@ -1881,12 +1857,12 @@ int Game::RunPortalLore(ARegion *r,Object *o,Unit *u)
 	TeleportOrder *order = u->teleportorders;
 
 	if (!level) {
-		u->Error("CAST: Doesn't know Portal Lore.");
+		u->error("CAST: Doesn't know Portal Lore.");
 		return 0;
 	}
 
 	if (!u->items.GetNum(I_PORTAL)) {
-		u->Error("CAST: Unit doesn't have a Portal.");
+		u->error("CAST: Unit doesn't have a Portal.");
 		return 0;
 	}
 
@@ -1899,53 +1875,52 @@ int Game::RunPortalLore(ARegion *r,Object *o,Unit *u)
 	}
 
 	if (weight > maxweight) {
-		u->Error("CAST: That mage cannot teleport that much weight through a "
+		u->error("CAST: That mage cannot teleport that much weight through a "
 				"Portal.");
 		return 0;
 	}
 
 	Location *tar = regions.FindUnit(order->gate);
 	if (!tar) {
-		u->Error("CAST: No such target mage.");
+		u->error("CAST: No such target mage.");
 		return 0;
 	}
 
 	if (tar->unit->faction->get_attitude(u->faction->num) < A_FRIENDLY) {
-		u->Error("CAST: Target mage is not friendly.");
+		u->error("CAST: Target mage is not friendly.");
 		return 0;
 	}
 
 	if (tar->unit->type != U_MAGE && tar->unit->type != U_APPRENTICE) {
-		u->Error("CAST: Target is not a mage.");
+		u->error("CAST: Target is not a mage.");
 		return 0;
 	}
 
 	if (!tar->unit->items.GetNum(I_PORTAL)) {
-		u->Error("CAST: Target does not have a Portal.");
+		u->error("CAST: Target does not have a Portal.");
 		return 0;
 	}
 
 	if (!GetRegionInRange(r, tar->region, u, S_PORTAL_LORE)) return 0;
 
-	u->Event("Casts Portal Jump.");
+	u->event("Casts Portal Jump.", "spell");
 
 	{
 		forlist(&(order->units)) {
 			Location *loc = r->GetLocation((UnitId *) elem,u->faction->num);
 			if (loc) {
 				if (loc->unit->GetAttitude(r,u) < A_ALLY) {
-					u->Error("CAST: Unit is not allied.");
+					u->error("CAST: Unit is not allied.");
 				} else {
 					loc->unit->DiscardUnfinishedShips();
-					loc->unit->Event(AString("Is teleported to ") +
-							tar->region->Print( &regions ) +
-							" by " + *u->name + ".");
+					loc->unit->event("Is teleported to " + string(tar->region->Print(&regions).const_str()) +
+						" by " + string(u->name->const_str()) + ".", "spell");
 					loc->unit->MoveUnit( tar->obj );
 					if (loc->unit != u) loc->unit->ClearCastOrders();
 				}
 				delete loc;
 			} else {
-				u->Error("CAST: No such unit.");
+				u->error("CAST: No such unit.");
 			}
 		}
 	}
@@ -1962,11 +1937,11 @@ int Game::RunTransmutation(ARegion *r, Unit *u)
 	order = (CastTransmuteOrder *) u->castorders;
 	level = u->GetSkill(S_TRANSMUTATION);
 	if (!level) {
-		u->Error("CAST: Unit doesn't have that skill.");
+		u->error("CAST: Unit doesn't have that skill.");
 		return 0;
 	}
 	if (level < order->level) {
-		u->Error("CAST: Can't create that by transmutation.");
+		u->error("CAST: Can't create that by transmutation.");
 		return 0;
 	}
 	
@@ -1996,15 +1971,11 @@ int Game::RunTransmutation(ARegion *r, Unit *u)
 	if (order->number != -1 && num > order->number)
 		num = order->number;
 	if (num < order->number)
-		u->Error("CAST: Can't create that many.");
+		u->error("CAST: Can't create that many.");
 	u->ConsumeShared(source, num);
 	u->items.SetNum(order->item, u->items.GetNum(order->item) + num);
-	u->Event(AString("Transmutes ") +
-			ItemString(source, num) +
-			" into " +
-			ItemString(order->item, num) +
-			".");
-	
+	u->event("Transmutes " + ItemString(source, num) + " into " + ItemString(order->item, num) + ".", "spell");
+
 	return 1;
 }
 
@@ -2018,11 +1989,11 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 
 	level = mage->GetSkill(S_BLASPHEMOUS_RITUAL);
 	if (level < 1) {
-		mage->Error("CAST: Unit doesn't have that skill.");
+		mage->error("CAST: Unit doesn't have that skill.");
 		return 0;
 	}
 	if (TerrainDefs[r->type].similar_type == R_OCEAN) {
-		mage->Error(AString("CAST: Can't cast Ritual on water."));
+		mage->error("CAST: Can't cast Ritual on water.");
 		return 0;
 	}
 	num = level;
@@ -2050,7 +2021,7 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 	}
 
 	if (tower == 0) {
-		mage->Error(AString("CAST: Can't cast Ritual: no Black Tower in a region."));
+		mage->error("CAST: Can't cast Ritual: no Black Tower in a region.");
 		return 0;
 	}
 
@@ -2089,7 +2060,7 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 		message += "!";
 		WriteTimesArticle(message);
 
-		mage->Event(AString("Sacrifices ") + ItemDefs[sac].name + " from " + victim->name->Str());
+		mage->event("Sacrifices " + ItemDefs[sac].name + " from " + victim->name->const_str(), "spell");
 		if (!victim->GetMen())
 			r->Kill(victim);
 		if (!mage->GetMen())

--- a/standard/map.cpp
+++ b/standard/map.cpp
@@ -260,7 +260,8 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				reg->type = -1;
 				reg->race = -1;  
 				reg->wages = -1; 
-				
+
+				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 			}

--- a/text_report_generator.hpp
+++ b/text_report_generator.hpp
@@ -13,6 +13,8 @@ public:
     void output(std::ostream& f, const json& report, bool show_region_depth);
     void output_template(std::ostream& f, const json& report, int template_type, bool show_region_depth);
 private:
+    void output_error(std::ostream& f, const json& error);
+    void output_event(std::ostream& f, const json& event);
     void output_region(std::ostream& f, const json& region, bool show_unit_attitudes, bool show_region_depth);
     void output_region_header(std::ostream& f, const json& region, bool show_region_depth);
     void output_item_list(std::ostream& f, const json& item_list, string header);
@@ -25,6 +27,7 @@ private:
     void output_region_map_header(std::ostream& f, const json& region, bool show_region_depth);
     void output_region_map_header_line(std::ostream& f, std::string line);
     std::string next_map_header_line(int line, const json& region);
+    std::string map_header_item(const string& header, const json& item);
     void output_unit_template(std::ostream& f, const json& unit, int template_type);
     void output_unit_orders(std::ostream& f, const json& orders);
 

--- a/unit.h
+++ b/unit.h
@@ -105,7 +105,7 @@ class UnitId : public AListElem {
 	public:
 		UnitId();
 		~UnitId();
-		AString Print();
+		std::string Print();
 
 		int unitnum; /* if 0, it is a new unit */
 		int alias;
@@ -133,6 +133,7 @@ class Unit : public AListElem
 
 		AString SpoilsReport(void);
 		int CanGetSpoil(Item *i);
+		json build_json_descriptor();
 		void build_json_report(json& j, int obs, int truesight, int detfac, int autosee, int attitude, int showattitudes);
 		json write_json_orders();
 		AString GetName(int);
@@ -230,8 +231,8 @@ class Unit : public AListElem
 		void MoveUnit( Object *newobj );
 		void DiscardUnfinishedShips();
 
-		void Event(const AString &);
-		void Error(const AString &);
+		void event(const std::string& message, const std::string& category, ARegion *r = nullptr);
+		void error(const std::string& message);
 
 		Faction *faction;
 		Faction *formfaction;

--- a/unittest/json_report_test.cpp
+++ b/unittest/json_report_test.cpp
@@ -1,10 +1,10 @@
-#include "external/boost/ut.hpp"
-#include "external/nlohmann/json.hpp"
+#include "../external/boost/ut.hpp"
+#include "../external/nlohmann/json.hpp"
 
 using json = nlohmann::json;
 
-#include "game.h"
-#include "gamedata.h"
+#include "../game.h"
+#include "../gamedata.h"
 #include "testhelper.hpp"
 
 // Because boost::ut has it's own concept of events, as does Game, we cannot just use do
@@ -70,7 +70,7 @@ ut::suite<"JSON Report"> json_report_suite = []
 
     auto count = json_report["errors"].size();
     expect(count == 1_ul);
-    string error = json_report["errors"][0];
+    string error = json_report["errors"][0]["message"];
     string expected = "This is an error";
     expect(error == expected);
   };
@@ -89,11 +89,11 @@ ut::suite<"JSON Report"> json_report_suite = []
 
     auto count = json_report["errors"].size();
     expect(count == 1001_ul);
-    string error = json_report["errors"][1000];
+    string error = json_report["errors"][1000]["message"];
     string expected = "Too many errors!";
     expect(error == expected);
 
-    error = json_report["errors"][999];
+    error = json_report["errors"][999]["message"];
     expected = "This is error #1000";
     expect(error == expected);
   };
@@ -105,8 +105,8 @@ ut::suite<"JSON Report"> json_report_suite = []
     helper.setup_turn();
 
     Faction *faction = helper.create_faction("Test Faction");
-    faction->event("This is event 1");
-    faction->event("This is event 2");
+    faction->event("This is event 1", "type1");
+    faction->event("This is event 2", "type2");
 
     json json_report;
     faction->build_json_report(json_report, &helper.game_object(), nullptr);
@@ -115,13 +115,19 @@ ut::suite<"JSON Report"> json_report_suite = []
     expect(count == 2_ul);
 
     // make sure they are in the right order
-    string event = json_report["events"][0];
+    string event = json_report["events"][0]["message"];
+    string type = json_report["events"][0]["category"];
     string expected = "This is event 1";
+    string expected_type = "type1";
     expect(event == expected);
+    expect(type == expected_type);
 
-    event = json_report["events"][1];
+    event = json_report["events"][1]["message"];
+    type = json_report["events"][1]["category"];
     expected = "This is event 2";
+    expected_type = "type2";
     expect(event == expected);
+    expect(type == expected_type);
   };
 
 

--- a/unittest/map.cpp
+++ b/unittest/map.cpp
@@ -25,8 +25,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "game.h"
-#include "gamedata.h"
+#include "../game.h"
+#include "../gamedata.h"
 
 /// For unit testing, just do nothing.
 int ARegion::CheckSea(int dir, int range, int remainocean) { return 1; }
@@ -76,6 +76,7 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				reg->race = -1;  
 				reg->wages = -1; 
 				
+				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 				Adot();

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -1,4 +1,4 @@
-#include "game.h"
+#include "../game.h"
 #include "testhelper.hpp"
 
 static void seed_random() { seedrandom(0xdeadbeef); }

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -2,7 +2,7 @@
 #ifndef __UNIT_TEST_HELPER_HPP__
 #define __UNIT_TEST_HELPER_HPP__
 
-#include "game.h"
+#include "../game.h"
 
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Cleanup event/error to be more json-like.   This changes them to take some additional parameters, and outputs some information such as an event category and unit or region information for some events in the json.   This information is already in the text for the events, so this is just making it nicer for json-based clients in the future.