### PR TITLE
This fixes a bug in fleet output for the new text report generation

### DIFF
--- a/text_report_generator.cpp
+++ b/text_report_generator.cpp
@@ -337,7 +337,14 @@ void TextReportGenerator::output_unit(ostream& f, const json& unit, bool show_un
 void TextReportGenerator::output_structure(ostream& f, const json& structure, bool show_unit_attitudes) {
     f << "+ " << to_s(structure["name"]) << " [" << structure["number"] << "] : ";
     if (structure.contains("ships")) {
-        output_items(f, structure["ships"], false, true);
+        // Fleets are wierd. If you have a fleet of a single ship, the structure type is just the ships item name.
+        // If you have a fleet of ships, then the structure name if the name of the fleet type, and the ships are listed.
+        if (structure["ships"].size() == 1) {
+            output_item(f, structure["ships"][0], false, false);
+        } else {
+            f << to_s(structure["type"]) << ", ";
+            output_items(f, structure["ships"], false, true);
+        }
         if (structure.contains("damage_percent")) f << "; " << structure["damage_percent"] << "% damaged; ";
         if (structure.contains("load"))
             f << "; " << "Load: " << structure["load"] << "/" << structure["capacity"] << "; ";


### PR DESCRIPTION
The code for outputting fleets is actually a bit stranger than I had accounted for in my initial changes.  The type of a fleet is output as 'Fleet' if there are multiple ships in a fleet.  If the fleet consists of exactly one ship, then the type of the fleet is the type of that single ship.  This should correct that problem.  There might be other bugs still.  I found this due to a question that Balvatah asked me on slack, and I am not sure if it's related to what he was seeing, but this is definitely a bug.