### PR TITLE
Update item/skill/object discovery to be json-y

### DIFF
--- a/faction.h
+++ b/faction.h
@@ -32,6 +32,7 @@
 
 class Faction;
 class Game;
+struct ShowObject;
 
 #include "gameio.h"
 #include "aregion.h"
@@ -245,8 +246,8 @@ public:
 
 	std::vector<Battle *> battles;
 	std::vector<ShowSkill> shows;
-	std::vector<std::string> itemshows;
-	std::vector<std::string> objectshows;
+	std::vector<ShowItem> itemshows;
+	std::vector<ShowObject> objectshows;
 
 	// These are used for 'granting' units to a faction via the players.in
 	// file

--- a/items.cpp
+++ b/items.cpp
@@ -648,6 +648,22 @@ static AString WeapType(int flags, int wclass)
 	return type;
 }
 
+string ShowItem::display_name()
+{
+	if (ItemDefs[item].type & IT_ILLUSION) {
+		return "illusory " + ItemDefs[item].name;
+	}
+	return ItemDefs[item].name;
+}
+
+string ShowItem::display_tag() {
+	if (ItemDefs[item].type & IT_ILLUSION) {
+		return "I" + string(ItemDefs[item].abr);
+	}
+	return ItemDefs[item].abr;
+
+}
+
 AString *ItemDescription(int item, int full)
 {
 	int i;
@@ -655,7 +671,7 @@ AString *ItemDescription(int item, int full)
 	SkillType *pS;
 
 	if (ItemDefs[item].flags & ItemType::DISABLED)
-		return NULL;
+		return new AString("");
 
 	AString *temp = new AString;
 	int illusion = (ItemDefs[item].type & IT_ILLUSION);

--- a/items.h
+++ b/items.h
@@ -75,6 +75,14 @@ struct Materials
 	int amt;
 };
 
+struct ShowItem {
+	int item;
+	bool full;
+
+	std::string display_name();
+    std::string display_tag();
+};
+
 class ItemType
 {
 	public:

--- a/object.cpp
+++ b/object.cpp
@@ -778,11 +778,10 @@ int Object::GetFleetSpeed(int report)
 AString *ObjectDescription(int obj)
 {
 	if (ObjectDefs[obj].flags & ObjectType::DISABLED)
-		return NULL;
+		return new AString("");
 
 	ObjectType *o = &ObjectDefs[obj];
 	AString *temp = new AString;
-	*temp += AString(o->name) + ": ";
 	if (ObjectDefs[obj].flags & ObjectType::GROUP) {
 		*temp += "This is a group of ships.";
 	} else if (o->capacity) {

--- a/object.h
+++ b/object.h
@@ -83,6 +83,10 @@ int ParseObject(AString *, int ships);
 
 int ObjectIsShip(int);
 
+struct ShowObject {
+	int obj;
+};
+
 class Object : public AListElem
 {
 	public:

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -822,11 +822,7 @@ void Game::ProcessReshowOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 				u->error("SHOW: No such object.");
 				return;
 			}
-			AString *desc = ObjectDescription(obj);
-			if (desc) {
-				u->faction->objectshows.push_back(desc->const_str());
-				delete desc;
-			}
+			u->faction->objectshows.push_back({.obj = obj});
 		}
 		if (obj >= -1)
 			return;

--- a/skills.h
+++ b/skills.h
@@ -106,14 +106,6 @@ int ParseSkill(AString *);
 AString SkillStrs(int);
 AString SkillStrs(SkillType *);
 
-class ShowType {
-	public:
-		int skill;
-		int level;
-		char const * desc;
-};
-extern ShowType * ShowDefs;
-
 int SkillCost(int);
 int SkillMax(char const *,int); /* skill, race */
 int GetLevelByDays(int);

--- a/skillshows.cpp
+++ b/skillshows.cpp
@@ -86,7 +86,7 @@ static void DescribeEscapeParameters(AString *desc, int item)
 
 AString *ShowSkill::Report(Faction *f) const
 {
-	if (SkillDefs[skill].flags & SkillType::DISABLED) return NULL;
+	if (SkillDefs[skill].flags & SkillType::DISABLED) return new AString("");
 
 	AString *str = new AString;
 	RangeType *range = NULL;
@@ -1793,11 +1793,7 @@ AString *ShowSkill::Report(Faction *f) const
 					temp2 += "]";
 			}
 			if (f) {
-				AString *desc = ObjectDescription(i);
-				if (desc) {
-					f->objectshows.push_back(desc->const_str());
-					delete desc;
-				}
+				f->objectshows.push_back({.obj = i});
 			}
 		}
 	}
@@ -1875,11 +1871,8 @@ AString *ShowSkill::Report(Faction *f) const
 		*str += "This skill cannot be increased through experience.";
 	}
 
-	temp1 = SkillStrs(skill) + " " + level + ": ";
 	if (*str == "") {
-		*str = temp1 + "No skill report.";
-	} else {
-		*str = temp1 + *str;
+		return(new AString("No skill report."));
 	}
 
 	return str;

--- a/text_report_generator.cpp
+++ b/text_report_generator.cpp
@@ -610,19 +610,26 @@ void TextReportGenerator::output(ostream& f, const json& report, bool show_regio
 
     if(report.contains("skill_reports") && !report["skill_reports"].empty()) {
         f << "Skill reports:\n";
-        for (const auto& skillshow : report["skill_reports"]) f << '\n' << to_s(skillshow) << '\n';
+        for (const auto& skillshow : report["skill_reports"]) {
+            f << '\n' << to_s(skillshow["name"]) << " [" << to_s(skillshow["tag"]) << "] "
+              << skillshow["level"] << ": " << to_s(skillshow["description"]) << '\n';
+        }
         f << '\n';
     }
 
     if (report.contains("item_reports") && !report["item_reports"].empty()) {
         f << "Item reports:\n";
-        for (const auto& itemshow : report["item_reports"]) f << '\n' << to_s(itemshow) << '\n';
+        for (const auto& itemshow : report["item_reports"]) {
+            f << '\n' << to_s(itemshow["description"]) << '\n';
+        }
         f << '\n';
     }
 
     if (report.contains("object_reports") && !report["object_reports"].empty()) {
         f << "Object reports:\n";
-        for (const auto& objectshow : report["object_reports"]) f << '\n' << to_s(objectshow) << '\n';
+        for (const auto& objectshow : report["object_reports"]) {
+            f << '\n' << to_s(objectshow["name"]) << ": " << to_s(objectshow["description"]) << '\n';
+        }
         f << '\n';
     }
 


### PR DESCRIPTION
This preserves the current text report, but moves the internal json data for skill/item/object shows into a format which is nicer for json parsing, including pulling the item/skill name and tag off into elements etc.