### PR TITLE
Fix reported bug around PHBE and illusionary dragons

### DIFF
--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -1062,17 +1062,13 @@ void ARegionList::SetFractalTerrain(ARegionArray *pArr)
 
 void ARegionList::NameRegions(ARegionArray *pArr)
 {
-	int seed = 0;
-	int grown = 0;
 	Awrite("Naming Regions");
 	int unnamed = 1;
-	int toname = 0;
 	for (int x = 0; x < pArr->x; x++) {
 		for (int y = 0; y < pArr->y; y++) {
 			ARegion *r = pArr->GetRegion(x,y);
 			if (!r) continue;
 			r->wages = -1;
-			if (r->type != R_OCEAN) toname++;
 			// r->wages = AGetName(0, reg);
 			r->population = 1;
 		}
@@ -1115,7 +1111,6 @@ void ARegionList::NameRegions(ARegionArray *pArr)
 					if (r1->yloc > ymin)
 						tnamedy[TerrainDefs[r1->type].similar_type] = r1->yloc;
 					unnamed = 1;	
-					seed++;
 				}
 			}
 		}
@@ -1157,7 +1152,6 @@ void ARegionList::NameRegions(ARegionArray *pArr)
 							if (npop > (nw1 / nc1)) npop = nw1 / nc1;
 							reg->population = (int) npop;
 							named_a_reg = 1;
-							grown++;
 						} else {
 							reg->wages = name2;
 							float npop = (nc2 * (nw2 + nc2) / (nc2 + 1 + nn))
@@ -1165,7 +1159,6 @@ void ARegionList::NameRegions(ARegionArray *pArr)
 							if (npop > (nw2 / nc2)) npop = nw2 / nc2;
 							reg->population = (int) npop;
 							named_a_reg = 1;
-							grown++;
 						}
 					}
 				}
@@ -1699,9 +1692,7 @@ void GeoMap::Generate(int spread, int smoothness)
 		}
 	}
 	int frac = 25;
-	int count = 0;
 	while (step > 1) {
-		count++;
 		int nextstep = step/2 + step%2;
 		for (int x = 0; x <= size; x += step) {
 			for (int y = 0; y <= size; y += step) {

--- a/skillshows.cpp
+++ b/skillshows.cpp
@@ -842,7 +842,7 @@ AString *ShowSkill::Report(Faction *f) const
 					"transportation. A mage may summon ";
 				if (ItemDefs[I_EAGLE].mOut > 0) {
 					*str += "an average of ";
-					*str += ItemDefs[I_SKELETON].mOut;
+					*str += ItemDefs[I_EAGLE].mOut;
 					*str += " percent times his skill level minus 2 eagles";
 				}
 				else
@@ -1071,9 +1071,9 @@ AString *ShowSkill::Report(Faction *f) const
 			} else if (level == 3) {
 				if (ITEM_DISABLED(I_IDRAGON)) break;
 				*str += "Create Phantasmal Beasts at level 3 allows the "
-					"mage to summon an illusionary dragon into his "
-					"inventory. To summon an illusionary dragon, the mage "
-					"should CAST Create_Phantasmal_Beasts DRAGON. The number of dragons that a "
+					"mage to summon illusionary dragons into his "
+					"inventory. To summon illusionary dragons, the mage "
+					"should CAST Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that a "
 					"mage may have in his inventory is equal to mage's skill level.";
 			}
 			break;
@@ -1112,9 +1112,9 @@ AString *ShowSkill::Report(Faction *f) const
 			} else if (level == 3) {
 				if (ITEM_DISABLED(I_ILICH)) break;
 				*str += "Create Phantasmal Undead at level 3 allows the mage "
-					"to summon an illusionary lich into his inventory. To "
-					"summon an illusionary lich, the mage should CAST "
-					"Create_Phantasmal_Undead LICH; The number of liches that a "
+					"to summon illusionary liches into his inventory. To "
+					"summon illusionary liches, the mage should CAST "
+					"Create_Phantasmal_Undead LICH <number>; The number of liches that a "
 					"mage may have in his inventory is equal to mage's skill level.";
 			}
 			break;

--- a/snapshot-tests/neworigins_turns/turn_0/report.1
+++ b/snapshot-tests/neworigins_turns/turn_0/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_1/report.1
+++ b/snapshot-tests/neworigins_turns/turn_1/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_10/report.1
+++ b/snapshot-tests/neworigins_turns/turn_10/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_11/report.1
+++ b/snapshot-tests/neworigins_turns/turn_11/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_12/report.1
+++ b/snapshot-tests/neworigins_turns/turn_12/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_13/report.1
+++ b/snapshot-tests/neworigins_turns/turn_13/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_2/report.1
+++ b/snapshot-tests/neworigins_turns/turn_2/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_3/report.1
+++ b/snapshot-tests/neworigins_turns/turn_3/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_4/report.1
+++ b/snapshot-tests/neworigins_turns/turn_4/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_5/report.1
+++ b/snapshot-tests/neworigins_turns/turn_5/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_6/report.1
+++ b/snapshot-tests/neworigins_turns/turn_6/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_7/report.1
+++ b/snapshot-tests/neworigins_turns/turn_7/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_8/report.1
+++ b/snapshot-tests/neworigins_turns/turn_8/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/neworigins_turns/turn_9/report.1
+++ b/snapshot-tests/neworigins_turns/turn_9/report.1
@@ -859,7 +859,7 @@ bird lore [BIRD] 2: No skill report.
 
 bird lore [BIRD] 3: A mage with Bird Lore 3 can summon eagles to join
   him, who will aid him in combat, and provide for flying
-  transportation. A mage may summon an average of 200 percent times
+  transportation. A mage may summon an average of 100 percent times
   his skill level minus 2 eagles per month, and may control a number
   equal to his skill level minus 2, squared, times two. To summon an
   eagle, issue the order CAST Bird_Lore EAGLE; the eagles will appear
@@ -1177,10 +1177,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_0/report.1
+++ b/snapshot-tests/turns/turn_0/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_1/report.1
+++ b/snapshot-tests/turns/turn_1/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_10/report.1
+++ b/snapshot-tests/turns/turn_10/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_11/report.1
+++ b/snapshot-tests/turns/turn_11/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_12/report.1
+++ b/snapshot-tests/turns/turn_12/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_13/report.1
+++ b/snapshot-tests/turns/turn_13/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_2/report.1
+++ b/snapshot-tests/turns/turn_2/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_3/report.1
+++ b/snapshot-tests/turns/turn_3/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_4/report.1
+++ b/snapshot-tests/turns/turn_4/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_5/report.1
+++ b/snapshot-tests/turns/turn_5/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_6/report.1
+++ b/snapshot-tests/turns/turn_6/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_7/report.1
+++ b/snapshot-tests/turns/turn_7/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_8/report.1
+++ b/snapshot-tests/turns/turn_8/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/snapshot-tests/turns/turn_9/report.1
+++ b/snapshot-tests/turns/turn_9/report.1
@@ -1148,10 +1148,10 @@ create phantasmal beasts [PHBE] 2: Create Phantasmal Beasts at level 2
   inventory is equal to mage's skill squared.
 
 create phantasmal beasts [PHBE] 3: Create Phantasmal Beasts at level 3
-  allows the mage to summon an illusionary dragon into his inventory.
-  To summon an illusionary dragon, the mage should CAST
-  Create_Phantasmal_Beasts DRAGON. The number of dragons that a mage
-  may have in his inventory is equal to mage's skill level.
+  allows the mage to summon illusionary dragons into his inventory. To
+  summon illusionary dragons, the mage should CAST
+  Create_Phantasmal_Beasts DRAGON <number>. The number of dragons that
+  a mage may have in his inventory is equal to mage's skill level.
 
 create phantasmal beasts [PHBE] 4: No skill report.
 

--- a/spells.cpp
+++ b/spells.cpp
@@ -1463,7 +1463,7 @@ int Game::RunPhanUndead(ARegion *r,Unit *u)
 			max = level * level;
 		} else {
 			create = I_ILICH;
-			max = order->level;
+			max = level;
 		}
 	}
 
@@ -1497,7 +1497,7 @@ int Game::RunPhanBeasts(ARegion *r,Unit *u)
 			max = level * level;
 		} else {
 			create = I_IDRAGON;
-			max = order->level;
+			max = level;
 		}
 	}
 

--- a/unittest/spell_test.cpp
+++ b/unittest/spell_test.cpp
@@ -1,0 +1,102 @@
+#include "external/boost/ut.hpp"
+
+#include "game.h"
+#include "gamedata.h"
+#include "testhelper.hpp"
+
+// Because boost::ut has it's own concept of events, as does Game, we cannot just use do
+// using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
+// closure to make the user defined literals and all the other niceness available.
+namespace ut = boost::ut;
+
+// This suite will test various aspects of the Faction class in isolation.
+ut::suite<"Spells"> spell_suite = []
+{
+  using namespace ut;
+
+  "Unit with PHBE 3 cannot summon 4 dragons"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    string name("Test Faction");
+    Faction *faction = helper.create_faction(name);
+    ARegion *region = helper.get_region(0, 0, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    leader->Study(S_FORCE, 450);
+    leader->Study(S_PATTERN, 450);
+    leader->Study(S_ILLUSION, 450);
+    leader->Study(S_CREATE_PHANTASMAL_BEASTS, 180);
+
+    stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "cast create_phantasmal_beasts DRAGON 4\n";
+    helper.parse_orders(faction->num, ss);
+    helper.activate_spell(S_CREATE_PHANTASMAL_BEASTS, {
+        .region = region, .unit = leader, .object = nullptr, .val1 = 0, .val2 = 0
+    });
+
+    // verify that the unit has no illusionary dragons in it's inventory
+    expect(leader->items.GetNum(I_IDRAGON) == 0_i);
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Expect that we get an error message in the report.
+    auto count = json_report["errors"].size();
+    expect(count == 1_ul);
+    json error = json_report["errors"][0];
+    expect(error["message"] == "CAST: Can't create that many Phantasmal Beasts.");
+    expect(error["unit"]["number"] == 2_i);
+  };
+
+  "Unit with PHBE 4 can summon 4 dragons"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    string name("Test Faction");
+    Faction *faction = helper.create_faction(name);
+    ARegion *region = helper.get_region(0, 0, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    leader->Study(S_FORCE, 450);
+    leader->Study(S_PATTERN, 450);
+    leader->Study(S_ILLUSION, 450);
+    leader->Study(S_CREATE_PHANTASMAL_BEASTS, 300);
+
+    stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "cast create_phantasmal_beasts DRAGON 4\n";
+    helper.parse_orders(faction->num, ss);
+    helper.activate_spell(S_CREATE_PHANTASMAL_BEASTS, {
+        .region = region, .unit = leader, .object = nullptr, .val1 = 0, .val2 = 0
+    });
+
+    // verify that the unit has 4 illusionary dragons in it's inventory
+    expect(leader->items.GetNum(I_IDRAGON) == 4_i);
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Expect that we get no errors in the report
+    auto count = json_report["errors"].size();
+    expect(count == 0_ul);
+  };
+
+};

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -1,4 +1,5 @@
 #include "../game.h"
+#include "gamedata.h"
 #include "testhelper.hpp"
 
 static void seed_random() { seedrandom(0xdeadbeef); }
@@ -70,3 +71,17 @@ string UnitTestHelper::cout_data() {
 void UnitTestHelper::parse_orders(int faction_id, istream& orders) {
     game.ParseOrders(faction_id, orders, nullptr);
 }
+
+void UnitTestHelper::activate_spell(int spell, SpellTestHelper helper) {
+    // This is a bit of a hack, but it's the easiest way to get the game object to run the spell, especially since
+    // C++ doesn't have actual introspection/reflection and the spell executors take different arguments.   The intent
+    // is that you add the spell you want to test here as you need it by adding a case statement to call the appropriate
+    // Run<Spell> function based on the skill associated with the spell.  This assumes that orders for the unit have
+    // already been set up so that the unit is ready to cast the spell.
+    switch(spell) {
+        case S_CREATE_PHANTASMAL_BEASTS:
+            game.RunPhanBeasts(helper.region, helper.unit);
+            break;
+    }
+}
+

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -7,6 +7,16 @@
 #include <iostream>
 #include <sstream>
 
+// In order to allow testing spells, this is a generic structure to capture the Run<Spell> possible arguments.
+// Each spell takes a different number of arguments, though most of them take just the region and the unit.
+// However, some take an object and one or two integer values as well.
+struct SpellTestHelper {
+    ARegion *region;
+    Unit *unit;
+    Object *object;
+    int val1;
+    int val2;
+};
 
 // This class is used to access private members of Game for testing.
 // It also provides utilities to capture the output of cout into a string, as well as provide
@@ -18,7 +28,6 @@
 // framework, but a much more involved helper class to allow interception of those sorts of inputs/outputs
 // in the future if needed.
 class UnitTestHelper {
-
 public:
     UnitTestHelper();
     ~UnitTestHelper();
@@ -55,6 +64,10 @@ public:
 
     // Get the contents of cout as a string.
     string cout_data();
+
+    // Activate a specific spell for testing.   Since the spells can have different arguments, we use a helper struct
+    // to pass in the arguments and call the appropriate Run<Spell> function based on the skill associate with the spell.
+    void activate_spell(int spell, SpellTestHelper helper);
 
 private:
     stringstream cout_buffer;


### PR DESCRIPTION
Looking into this also revealed that liches suffered the same problem/bug, so they have been fixed as well.   Additionally the
spell descriptions were incorrect in that they implied you could only summon one dragon or lich per turn illusorily, but the code would actually allow you to summon up to the (incorrect) limit.  Allowing this to take a number mimics the other illusory spells, and the max a unit can hold of the illusory objects mimics the max they can hold of the real objects.

Note that the `create phantasmal undead` skill is disabled, so the lich bug never showed up in a live game but it's fixed now anyway.

Additional to this, while reviewing all the summon code, I discovered that the spell description for Bird Lore 3 was incorrectly using the `.mOut` value for skeletons rather than eagles.   The actual execution code was using the correct `.mOut` value, so the correct fix was to make the spell description correct to match reality.

This does cause the snapshot turns to need to be updated since those reflected the wrong value in the spell description.

It also revealed that the most recent version of CLANG (the MacOS compiler) detected unused variables which were set and incremented but never actually read, so they were in fact dead code.  The second commit in this PR cleans that up to fix the Mac compile.

- [x] Added unit tests validating fixed behavior.