### PR TITLE
Fix some additional rules issues.

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -3885,7 +3885,7 @@ void ARegionGraph::setInclusion(ARegionInclusionFunction includeFn) {
 	this->includeFn = includeFn;
 }
 
-void ARegionList::ResoucesStatistics() {
+void ARegionList::ResourcesStatistics() {
 	std::unordered_map<int, int> resources;
 	std::unordered_map<int, int> forSale;
 	std::unordered_map<int, int> wanted;

--- a/aregion.h
+++ b/aregion.h
@@ -505,7 +505,7 @@ class ARegionList : public AList
 		void GrowRaces(ARegionArray *pRegs);
 		
 		void TownStatistics();
-		void ResoucesStatistics();
+		void ResourcesStatistics();
 
 		void CalcDensities();
 		int GetLevelXScale(int level);

--- a/army.cpp
+++ b/army.cpp
@@ -1023,7 +1023,7 @@ void Army::Win(Battle * b,ItemList * spoils)
 		loses_percent = 100 - ((na * 100) / count);
 	}
 
-	if (loses_percent >= 5) wintype = WIN_DEAD;
+	if (loses_percent > 0 && loses_percent >= Globals->BATTLE_STOP_MOVE_PERCENT) wintype = WIN_DEAD;
 	else wintype = WIN_NO_DEAD;
 
 	AList units;

--- a/basic/rules.cpp
+++ b/basic/rules.cpp
@@ -252,6 +252,7 @@ static GameDefs g = {
 	33,	// MAX_DESTROY_PERCENT
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT,	// REPORT_FORMAT
+	5, // BATTLE_STOP_MOVE_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/basic/world.cpp
+++ b/basic/world.cpp
@@ -2224,7 +2224,7 @@ void Game::CreateWorld()
 
 	regions.TownStatistics();
 
-	regions.ResoucesStatistics();
+	regions.ResourcesStatistics();
 }
 
 int ARegionList::GetRegType( ARegion *pReg )

--- a/fracas/rules.cpp
+++ b/fracas/rules.cpp
@@ -255,6 +255,7 @@ static GameDefs g = {
 	34,	// MAX_DESTROY_PERCENT
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT,	// REPORT_FORMAT
+	5, // BATTLE_STOP_MOVE_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/fracas/world.cpp
+++ b/fracas/world.cpp
@@ -2231,7 +2231,7 @@ void Game::CreateWorld()
 
 	regions.TownStatistics();
 
-	regions.ResoucesStatistics();
+	regions.ResourcesStatistics();
 }
 
 int ARegionList::GetRegType( ARegion *pReg )

--- a/gamedefs.h
+++ b/gamedefs.h
@@ -812,6 +812,10 @@ public:
 		REPORT_FORMAT_JSON = 0x2,
 	};
 	int REPORT_FORMAT;
+
+	// BATTLE_STOP_MOVE_PERCENT is the percent of losses a unit can take and still move and attack.
+	// 0 means any losses will stop you from moving and attacking.
+	int BATTLE_STOP_MOVE_PERCENT;
 };
 
 extern GameDefs *Globals;

--- a/havilah/rules.cpp
+++ b/havilah/rules.cpp
@@ -260,6 +260,7 @@ static GameDefs g = {
 	34,	// MAX_DESTROY_PERCENT
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT, // REPORT_FORMAT
+	5, // BATTLE_STOP_MOVE_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/havilah/world.cpp
+++ b/havilah/world.cpp
@@ -501,7 +501,7 @@ void Game::CreateWorld()
 
 	regions.TownStatistics();
 
-	regions.ResoucesStatistics();
+	regions.ResourcesStatistics();
 }
 
 int ARegionList::GetRegType( ARegion *pReg )

--- a/kingdoms/rules.cpp
+++ b/kingdoms/rules.cpp
@@ -253,6 +253,7 @@ static GameDefs g = {
 	34,	// MAX_DESTROY_PERCENT
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT, // REPORT_FORMAT
+	5, // BATTLE_STOP_MOVE_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/kingdoms/world.cpp
+++ b/kingdoms/world.cpp
@@ -2224,7 +2224,7 @@ void Game::CreateWorld()
 
 	regions.TownStatistics();
 
-	regions.ResoucesStatistics();
+	regions.ResourcesStatistics();
 }
 
 int ARegionList::GetRegType( ARegion *pReg )

--- a/neworigins/rules.cpp
+++ b/neworigins/rules.cpp
@@ -259,6 +259,7 @@ static GameDefs g = {
 	34,	// MAX_DESTROY_PERCENT
 	1, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT, // REPORT_FORMAT
+	5, // BATTLE_STOP_MOVE_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/neworigins/world.cpp
+++ b/neworigins/world.cpp
@@ -521,7 +521,7 @@ void Game::CreateWorld()
 	
 	regions.TownStatistics();
 
-	regions.ResoucesStatistics();
+	regions.ResourcesStatistics();
 }
 
 int ARegionList::GetRegType( ARegion *pReg )

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -716,8 +716,7 @@ int Game::CountTaxes(ARegion *reg)
 					if (protect < 0) protect = 0;
 					if (men) {
 						if (!ActivityCheck(reg, u->faction, FactionActivity::TAX)) {
-							u->error("TAX: Faction can't tax that many "
-									"regions.");
+							u->error("TAX: Faction can't tax that many regions.");
 							u->taxing = TAX_NONE;
 						} else {
 							t += men + fortbonus * Globals->TAX_BONUS_FORT;
@@ -782,8 +781,7 @@ int Game::CountPillagers(ARegion *reg)
 					int men = u->Taxers(1);
 					if (men) {
 						if (!ActivityCheck(reg, u->faction, FactionActivity::TAX)) {
-							u->error("PILLAGE: Faction can't tax that many "
-									"regions.");
+							u->error("PILLAGE: Faction can't tax that many regions.");
 							u->taxing = TAX_NONE;
 						} else {
 							p += men;

--- a/snapshot-tests/rules/basic.html
+++ b/snapshot-tests/rules/basic.html
@@ -520,15 +520,15 @@
       character.)
     </p>
     <p>
-      Each faction has a type; this is decided by the player, and determines
+      Each faction has a type which is decided by the player, and determines
       what the faction may do.  The faction has 5 Faction Points, which may be
-      spent on any of the 3 Faction Areas, War, Trade, and Magic.  The faction
-      type may be changed at the beginning of each turn, so a faction can
-      change and adapt to the conditions around it.  Faction Points spent on
-      War determine the number of regions in which factions can obtain income
-      by taxing or pillaging. Faction Points spent on Trade determine the
-      number of regions in which a faction may conduct trade activity. Trade
-      activity includes producing goods and materials, building ships and
+      spent on the Faction Areas of War, Trade, and Magic.  The faction type
+      may be changed at the beginning of each turn, so a faction can change
+      and adapt to the conditions around it.  Faction Points spent on War
+      determine the number of regions in which factions can obtain income by
+      taxing or pillaging. Faction Points spent on Trade determine the number
+      of regions in which a faction may conduct trade activity. Trade activity
+      includes producing goods and materials and constructing ships and
       buildings. Faction Points spent on Magic determine the number of mages
       the faction may have (more information on all of the faction activities
       is in further sections of the rules). Here is a chart detailing the
@@ -2595,13 +2595,13 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       If an item requires raw materials, then the specified amount of each
       material is consumed for each item produced. The higher the skill of the
       unit, the more productive each man-month of work will be.  Thus, five
-      men at skill level one are exactly equivalent to one guy at skill level
+      men at skill level one are exactly equivalent to one man at skill level
       5 in terms of base output. Items which require multiple man-months to
-      produce will take still benefit from higher skill level units, just not
-      as quickly.  For example, if a unit of six level one men wanted to
-      produce something which required three man-months per item, that unit
-      could produce two of them in one month.  If their skill level was raised
-      to two, then they could produce four of them in a month. At level three,
+      produce will still benefit from higher skill level units, just not as
+      quickly.  For example, if a unit of six level one men wanted to produce
+      something which required three man-months per item, that unit could
+      produce two of them in one month.  If their skill level was raised to
+      two, then they could produce four of them in a month. At level three,
       they could then produce 6 per month.
     </p>
     <p>
@@ -2660,8 +2660,8 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       on a building requires a unit of the required resource and a man-month
       of work by a character with the appropriate skill and level; higher
       skill levels allow work to proceed faster (still using one unit of the
-      required resource per unit of work done). Again, only Trade factions can
-      issue <a href="#build">BUILD</a> orders. Here is a table of the various
+      required resource per unit of work done). Only Trade factions can issue
+      <a href="#build">BUILD</a> orders. Here is a table of the various
       building types:
     </p>
     <a name="tablebuildings"></a>
@@ -2965,13 +2965,12 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       href="#sail">SAIL</a>s while they have an unfinished ship in their
       possession, the ship will be discarded and lost. Finally, ships are
       never interacted with as objects directly, but when completed are placed
-      in Fleet objects.  Fleets may contain one or more ships, and may be
-      entered like other buildings.
+      in fleets. Fleets may contain one or more ships, and may be entered like
+      other buildings.
     </p>
     <p>
-      Only factions with at least one faction point spent on trade can issue
-      <a href="#build">BUILD</a> orders. Here is a table of the various ship
-      types:
+      Only Trade factions can issue can issue <a href="#build">BUILD</a>
+      orders. Here is a table of the various ship types:
     </p>
     <a name="tableshipinfo"></a>
     <center>
@@ -3055,11 +3054,11 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       the ship to sail.
     </p>
     <p>
-      When a ship is built, if its builder is already the owner of a fleet
-      object, then the ship will be added to that fleet; otherwise a new fleet
-      will be created to hold the ship.  A fleet has the combined capacity and
-      sailor requirement of its constituent vessels, and moves at the speed of
-      its slowest ship. 
+      When a ship is built, if its builder is already the owner of a fleet,
+      then the ship will be added to that fleet; otherwise a new fleet will be
+      created to hold the ship.  A fleet has the combined capacity and sailor
+      requirement of its constituent vessels, and moves at the speed of its
+      slowest ship.
     </p>
     <a name="economy_advanceditems"></a>
     <h3>
@@ -3492,9 +3491,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       orders to drop items (with the <a href="#give">GIVE</a> 0 order) or to
       prevent yourself picking up certain types of spoils (with the <a
       href="#spoils">SPOILS</a> order) in case you win the battle! Also, note
-      that if the winning side took any losses in the battle, any units on
-      this side will not be allowed to move, or attack again for the rest of
-      the turn.
+      that if the winning side took at least 5% casualties in the battle, any
+      units on this side will not be allowed to move, or attack again for the 
+      rest of the turn.
     </p>
     <a name="stealthobs"></a>
     <div class="rule">
@@ -5295,11 +5294,11 @@ FORGET Mining
       If the demand for recruits in that region that month is much higher than
       the supply, it may happen that the new unit does not gain all the
       recruits you ordered it to buy, or it may not gain any recruits at all. 
-      If the new units gains at least one recruit, the unit will form
-      possessing any unused silver and all the other items it was given.  If
-      no recruits are gained at all, the empty unit will be dissolved, and the
-      silver and any other items it was given will revert to the first unit
-      you have in that region.
+      If a new unit gains at least one recruit, the unit will form possessing
+      any unused silver and all the other items it was given.  If no recruits
+      are gained at all, the empty unit will be dissolved, and the silver and
+      any other items it was given will revert to the first unit you have in
+      that region.
     </p>
     <p>
       Example:
@@ -5374,7 +5373,7 @@ GIVE NEW 2 2000 silver
       or better.  If the target unit is not a member of your faction, then its
       faction must have declared you Friendly, with a couple of exceptions.
       First, silver may be given to any unit, regardless of factional
-      affiliation. Secondly, men may not be given to units in other factions
+      affiliation. Second, men may not be given to units in other factions
       (you must give the entire unit); the reason for this is to prevent
       highly skilled units from being sabotaged with a <a
       href="#give">GIVE</a> order.
@@ -5590,10 +5589,9 @@ LEAVE
       Attempt to move in the direction(s) specified.  If more than one
       direction is given, the unit will move multiple times, in the order
       specified by the MOVE order, until no more directions are given, or
-      until one of the moves fails.  A move can fail because the units runs
-      out of movement points, because the unit attempts to move into the
-      ocean, or because the units attempts to enter a structure, and is
-      rejected.
+      until one of the moves fails.  A move can fail because the unit runs out
+      of movement points, because the unit attempts to move into the ocean, or
+      because the unit attempts to enter a structure, and is rejected.
     </p>
     <p>
       Valid directions are:
@@ -6471,7 +6469,7 @@ TAKE FROM 4573 10 swords
     </h4>
     <p>
       Attempt to collect taxes from the region. Only War factions may collect
-      taxes, and then only if there are no non-Friendly units on guard. Only
+      taxes, but only if there are no non-Friendly units on guard. Only
       combat-ready units may issue this order. Note that the TAX order and the
       <a href="#pillage">PILLAGE</a> order are mutually exclusive; a unit may
       only attempt to do one in a turn.

--- a/snapshot-tests/rules/fracas.html
+++ b/snapshot-tests/rules/fracas.html
@@ -531,22 +531,22 @@
       character.)
     </p>
     <p>
-      Each faction has a type; this is decided by the player, and determines
+      Each faction has a type which is decided by the player, and determines
       what the faction may do.  The faction has 5 Faction Points, which may be
-      spent on any of the 3 Faction Areas, War, Trade, and Magic.  The faction
-      type may be changed at the beginning of each turn, so a faction can
-      change and adapt to the conditions around it.  Faction Points spent on
-      War determine the number of regions in which factions can obtain income
-      by taxing or pillaging, and also determines the number of level 5
-      tactics leaders (tacticians) that a faction can train. Faction Points
-      spent on Trade determine the number of regions in which a faction may
-      conduct trade activity. Trade activity includes producing goods and
-      materials, building ships and buildings.Faction points spent on Trade
-      also determine the of quartermaster units a trade faction can have.
-      Faction Points spent on Magic determine the number of mages the faction
-      may have (more information on all of the faction activities is in
-      further sections of the rules). Here is a chart detailing the limits on
-      factions by Faction Points:
+      spent on the Faction Areas of War, Trade, and Magic.  The faction type
+      may be changed at the beginning of each turn, so a faction can change
+      and adapt to the conditions around it.  Faction Points spent on War
+      determine the number of regions in which factions can obtain income by
+      taxing or pillaging, and also determines the number of level 5 tactics
+      leaders (tacticians) that a faction can train. Faction Points spent on
+      Trade determine the number of regions in which a faction may conduct
+      trade activity. Trade activity includes producing goods and materials, 
+      transporting items, and constructing ships and buildings. Faction points
+      spent on Trade also determine the number of quartermaster units a
+      faction can have. Faction Points spent on Magic determine the number of
+      mages the faction may have (more information on all of the faction
+      activities is in further sections of the rules). Here is a chart
+      detailing the limits on factions by Faction Points:
     </p>
     <a name="tablefactionpoints"></a>
     <center>
@@ -2647,13 +2647,13 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       If an item requires raw materials, then the specified amount of each
       material is consumed for each item produced. The higher the skill of the
       unit, the more productive each man-month of work will be.  Thus, five
-      men at skill level one are exactly equivalent to one guy at skill level
+      men at skill level one are exactly equivalent to one man at skill level
       5 in terms of base output. Items which require multiple man-months to
-      produce will take still benefit from higher skill level units, just not
-      as quickly.  For example, if a unit of six level one men wanted to
-      produce something which required three man-months per item, that unit
-      could produce two of them in one month.  If their skill level was raised
-      to two, then they could produce four of them in a month. At level three,
+      produce will still benefit from higher skill level units, just not as
+      quickly.  For example, if a unit of six level one men wanted to produce
+      something which required three man-months per item, that unit could
+      produce two of them in one month.  If their skill level was raised to
+      two, then they could produce four of them in a month. At level three,
       they could then produce 6 per month.
     </p>
     <p>
@@ -2712,8 +2712,8 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       on a building requires a unit of the required resource and a man-month
       of work by a character with the appropriate skill and level; higher
       skill levels allow work to proceed faster (still using one unit of the
-      required resource per unit of work done). Again, only Trade factions can
-      issue <a href="#build">BUILD</a> orders. Here is a table of the various
+      required resource per unit of work done). Only Trade factions can issue
+      <a href="#build">BUILD</a> orders. Here is a table of the various
       building types:
     </p>
     <a name="tablebuildings"></a>
@@ -3056,9 +3056,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       move along that road at half cost to a minimum of 1 movement point.
     </p>
     <p>
-      For example: If a unit is moving northwest, then hex it is in must have
-      a northwest road, and the hex it is moving into must have a southeast
-      road.
+      For example: If a unit is moving northwest, then the hex it is in must
+      have a northwest road, and the hex it is moving into must have a
+      southeast road.
     </p>
     <p>
       To gain an economy bonus, a hex must have roads that connect to roads in
@@ -3197,13 +3197,12 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       href="#sail">SAIL</a>s while they have an unfinished ship in their
       possession, the ship will be discarded and lost. Finally, ships are
       never interacted with as objects directly, but when completed are placed
-      in Fleet objects.  Fleets may contain one or more ships, and may be
-      entered like other buildings.
+      in fleets. Fleets may contain one or more ships, and may be entered like
+      other buildings.
     </p>
     <p>
-      Only factions with at least one faction point spent on trade can issue
-      <a href="#build">BUILD</a> orders. Here is a table of the various ship
-      types:
+      Only Trade factions can issue can issue <a href="#build">BUILD</a>
+      orders. Here is a table of the various ship types:
     </p>
     <a name="tableshipinfo"></a>
     <center>
@@ -3304,11 +3303,11 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       the ship to sail.
     </p>
     <p>
-      When a ship is built, if its builder is already the owner of a fleet
-      object, then the ship will be added to that fleet; otherwise a new fleet
-      will be created to hold the ship.  A fleet has the combined capacity and
-      sailor requirement of its constituent vessels, and moves at the speed of
-      its slowest ship. 
+      When a ship is built, if its builder is already the owner of a fleet,
+      then the ship will be added to that fleet; otherwise a new fleet will be
+      created to hold the ship.  A fleet has the combined capacity and sailor
+      requirement of its constituent vessels, and moves at the speed of its
+      slowest ship.
     </p>
     <a name="economy_advanceditems"></a>
     <h3>
@@ -3783,9 +3782,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       orders to drop items (with the <a href="#give">GIVE</a> 0 order) or to
       prevent yourself picking up certain types of spoils (with the <a
       href="#spoils">SPOILS</a> order) in case you win the battle! Also, note
-      that if the winning side took any losses in the battle, any units on
-      this side will not be allowed to move, or attack again for the rest of
-      the turn.
+      that if the winning side took at least 5% casualties in the battle, any
+      units on this side will not be allowed to move, or attack again for the 
+      rest of the turn.
     </p>
     <a name="stealthobs"></a>
     <div class="rule">
@@ -5552,9 +5551,10 @@ EXCHANGE 3453 10 SWOR 10 LBOW
       rid of one of your mages by either giving it to another faction or
       ordering it to <a href="#forget">FORGET</a> all its magic skills. If you
       have too many mages for the number of points you try to assign to MAGIC,
-      the FACTION order will fail. Similar problems could occur with
-      TRADE/MARTIAL points and the number of quartermasters controlled by the
-      faction.
+      the FACTION order will fail. Factions may have the same requirements to
+      disband excess units before changing faction point allocations based on
+      how many quartermasters are controlled by the faction and how they are
+      restricted.
     </p>
     <p>
       Examples:
@@ -5649,11 +5649,11 @@ FORGET Mining
       If the demand for recruits in that region that month is much higher than
       the supply, it may happen that the new unit does not gain all the
       recruits you ordered it to buy, or it may not gain any recruits at all. 
-      If the new units gains at least one recruit, the unit will form
-      possessing any unused silver and all the other items it was given.  If
-      no recruits are gained at all, the empty unit will be dissolved, and the
-      silver and any other items it was given will revert to the first unit
-      you have in that region.
+      If a new unit gains at least one recruit, the unit will form possessing
+      any unused silver and all the other items it was given.  If no recruits
+      are gained at all, the empty unit will be dissolved, and the silver and
+      any other items it was given will revert to the first unit you have in
+      that region.
     </p>
     <p>
       Example:
@@ -5728,7 +5728,7 @@ GIVE NEW 2 2000 silver
       or better.  If the target unit is not a member of your faction, then its
       faction must have declared you Friendly, with a couple of exceptions.
       First, silver may be given to any unit, regardless of factional
-      affiliation. Secondly, men may not be given to units in other factions
+      affiliation. Second, men may not be given to units in other factions
       (you must give the entire unit); the reason for this is to prevent
       highly skilled units from being sabotaged with a <a
       href="#give">GIVE</a> order.
@@ -5944,10 +5944,9 @@ LEAVE
       Attempt to move in the direction(s) specified.  If more than one
       direction is given, the unit will move multiple times, in the order
       specified by the MOVE order, until no more directions are given, or
-      until one of the moves fails.  A move can fail because the units runs
-      out of movement points, because the unit attempts to move into the
-      ocean, or because the units attempts to enter a structure, and is
-      rejected.
+      until one of the moves fails.  A move can fail because the unit runs out
+      of movement points, because the unit attempts to move into the ocean, or
+      because the unit attempts to enter a structure, and is rejected.
     </p>
     <p>
       Valid directions are:
@@ -6809,7 +6808,7 @@ TAKE FROM 4573 10 swords
     </h4>
     <p>
       Attempt to collect taxes from the region. Only War factions may collect
-      taxes, and then only if there are no non-Friendly units on guard. Only
+      taxes, but only if there are no non-Friendly units on guard. Only
       combat-ready units may issue this order. Note that the TAX order and the
       <a href="#pillage">PILLAGE</a> order are mutually exclusive; a unit may
       only attempt to do one in a turn.

--- a/snapshot-tests/rules/havilah.html
+++ b/snapshot-tests/rules/havilah.html
@@ -565,15 +565,15 @@
       character.)
     </p>
     <p>
-      Each faction has a type; this is decided by the player, and determines
+      Each faction has a type which is decided by the player, and determines
       what the faction may do.  The faction has 5 Faction Points, which may be
-      spent on any of the 3 Faction Areas, War, Trade, and Magic.  The faction
-      type may be changed at the beginning of each turn, so a faction can
-      change and adapt to the conditions around it.  Faction Points spent on
-      War determine the number of regions in which factions can obtain income
-      by taxing or pillaging. Faction Points spent on Trade determine the
-      number of regions in which a faction may conduct trade activity. Trade
-      activity includes producing goods and materials, building ships and
+      spent on the Faction Areas of War, Trade, and Magic.  The faction type
+      may be changed at the beginning of each turn, so a faction can change
+      and adapt to the conditions around it.  Faction Points spent on War
+      determine the number of regions in which factions can obtain income by
+      taxing or pillaging. Faction Points spent on Trade determine the number
+      of regions in which a faction may conduct trade activity. Trade activity
+      includes producing goods and materials and constructing ships and
       buildings. Faction Points spent on Magic determine the number of mages
       and acolytes the faction may have (more information on all of the
       faction activities is in further sections of the rules). Here is a chart
@@ -687,8 +687,7 @@
       For example, a well rounded faction might spend 1 point on Magic, 2
       points on Trade, 2 points on War. This faction's type would appear as
       "Magic 1 Trade 2 War 2", and would be able to tax 24 regions, perform
-      trade in 24 regions, and have 1 mage as well as 3 acolytes, as well have
-      3 acolytes.
+      trade in 24 regions, and have 1 mage, as well have 3 acolytes.
     </p>
     <p>
       As another example, a specialized faction might spend all 5 points on
@@ -2960,13 +2959,13 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       If an item requires raw materials, then the specified amount of each
       material is consumed for each item produced. The higher the skill of the
       unit, the more productive each man-month of work will be.  Thus, five
-      men at skill level one are exactly equivalent to one guy at skill level
+      men at skill level one are exactly equivalent to one man at skill level
       5 in terms of base output. Items which require multiple man-months to
-      produce will take still benefit from higher skill level units, just not
-      as quickly.  For example, if a unit of six level one men wanted to
-      produce something which required three man-months per item, that unit
-      could produce two of them in one month.  If their skill level was raised
-      to two, then they could produce four of them in a month. At level three,
+      produce will still benefit from higher skill level units, just not as
+      quickly.  For example, if a unit of six level one men wanted to produce
+      something which required three man-months per item, that unit could
+      produce two of them in one month.  If their skill level was raised to
+      two, then they could produce four of them in a month. At level three,
       they could then produce 6 per month.
     </p>
     <p>
@@ -3025,8 +3024,8 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       on a building requires a unit of the required resource and a man-month
       of work by a character with the appropriate skill and level; higher
       skill levels allow work to proceed faster (still using one unit of the
-      required resource per unit of work done). Again, only Trade factions can
-      issue <a href="#build">BUILD</a> orders. Here is a table of the various
+      required resource per unit of work done). Only Trade factions can issue
+      <a href="#build">BUILD</a> orders. Here is a table of the various
       building types:
     </p>
     <a name="tablebuildings"></a>
@@ -3369,9 +3368,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       move along that road at half cost to a minimum of 1 movement point.
     </p>
     <p>
-      For example: If a unit is moving northwest, then hex it is in must have
-      a northwest road, and the hex it is moving into must have a southeast
-      road.
+      For example: If a unit is moving northwest, then the hex it is in must
+      have a northwest road, and the hex it is moving into must have a
+      southeast road.
     </p>
     <p>
       To gain an economy bonus, a hex must have roads that connect to roads in
@@ -3496,13 +3495,12 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       href="#sail">SAIL</a>s while they have an unfinished ship in their
       possession, the ship will be discarded and lost. Finally, ships are
       never interacted with as objects directly, but when completed are placed
-      in Fleet objects.  Fleets may contain one or more ships, and may be
-      entered like other buildings.
+      in fleets. Fleets may contain one or more ships, and may be entered like
+      other buildings.
     </p>
     <p>
-      Only factions with at least one faction point spent on trade can issue
-      <a href="#build">BUILD</a> orders. Here is a table of the various ship
-      types:
+      Only Trade factions can issue can issue <a href="#build">BUILD</a>
+      orders. Here is a table of the various ship types:
     </p>
     <a name="tableshipinfo"></a>
     <center>
@@ -3603,11 +3601,11 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       the ship to sail.
     </p>
     <p>
-      When a ship is built, if its builder is already the owner of a fleet
-      object, then the ship will be added to that fleet; otherwise a new fleet
-      will be created to hold the ship.  A fleet has the combined capacity and
-      sailor requirement of its constituent vessels, and moves at the speed of
-      its slowest ship. 
+      When a ship is built, if its builder is already the owner of a fleet,
+      then the ship will be added to that fleet; otherwise a new fleet will be
+      created to hold the ship.  A fleet has the combined capacity and sailor
+      requirement of its constituent vessels, and moves at the speed of its
+      slowest ship.
     </p>
     <a name="economy_advanceditems"></a>
     <h3>
@@ -4041,9 +4039,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       orders to drop items (with the <a href="#give">GIVE</a> 0 order) or to
       prevent yourself picking up certain types of spoils (with the <a
       href="#spoils">SPOILS</a> order) in case you win the battle! Also, note
-      that if the winning side took any losses in the battle, any units on
-      this side will not be allowed to move, or attack again for the rest of
-      the turn.
+      that if the winning side took at least 5% casualties in the battle, any
+      units on this side will not be allowed to move, or attack again for the 
+      rest of the turn.
     </p>
     <a name="stealthobs"></a>
     <div class="rule">
@@ -5817,7 +5815,10 @@ EXCHANGE 3453 10 SWOR 10 LBOW
       rid of one of your mages by either giving it to another faction or
       ordering it to <a href="#forget">FORGET</a> all its magic skills. If you
       have too many mages for the number of points you try to assign to MAGIC,
-      the FACTION order will fail.
+      the FACTION order will fail. Factions may have the same requirements to
+      disband excess units before changing faction point allocations based on
+      how many acolytes are controlled by the faction and how they are
+      restricted.
     </p>
     <p>
       Examples:
@@ -5937,11 +5938,11 @@ FORGET Mining
       If the demand for recruits in that region that month is much higher than
       the supply, it may happen that the new unit does not gain all the
       recruits you ordered it to buy, or it may not gain any recruits at all. 
-      If the new units gains at least one recruit, the unit will form
-      possessing any unused silver and all the other items it was given.  If
-      no recruits are gained at all, the empty unit will be dissolved, and the
-      silver and any other items it was given will revert to the first unit
-      you have in that region.
+      If a new unit gains at least one recruit, the unit will form possessing
+      any unused silver and all the other items it was given.  If no recruits
+      are gained at all, the empty unit will be dissolved, and the silver and
+      any other items it was given will revert to the first unit you have in
+      that region.
     </p>
     <p>
       Example:
@@ -6016,7 +6017,7 @@ GIVE NEW 2 2000 silver
       or better.  If the target unit is not a member of your faction, then its
       faction must have declared you Friendly, with a couple of exceptions.
       First, silver may be given to any unit, regardless of factional
-      affiliation. Secondly, men may not be given to units in other factions
+      affiliation. Second, men may not be given to units in other factions
       (you must give the entire unit); the reason for this is to prevent
       highly skilled units from being sabotaged with a <a
       href="#give">GIVE</a> order.
@@ -6232,10 +6233,9 @@ LEAVE
       Attempt to move in the direction(s) specified.  If more than one
       direction is given, the unit will move multiple times, in the order
       specified by the MOVE order, until no more directions are given, or
-      until one of the moves fails.  A move can fail because the units runs
-      out of movement points, because the unit attempts to move into the
-      ocean, or because the units attempts to enter a structure, and is
-      rejected.
+      until one of the moves fails.  A move can fail because the unit runs out
+      of movement points, because the unit attempts to move into the ocean, or
+      because the unit attempts to enter a structure, and is rejected.
     </p>
     <p>
       Valid directions are:
@@ -7138,7 +7138,7 @@ TAKE FROM 4573 10 swords
     </h4>
     <p>
       Attempt to collect taxes from the region. Only War factions may collect
-      taxes, and then only if there are no non-Friendly units on guard. Only
+      taxes, but only if there are no non-Friendly units on guard. Only
       combat-ready units may issue this order. Note that the TAX order and the
       <a href="#pillage">PILLAGE</a> order are mutually exclusive; a unit may
       only attempt to do one in a turn.

--- a/snapshot-tests/rules/kingdoms.html
+++ b/snapshot-tests/rules/kingdoms.html
@@ -538,15 +538,15 @@
       character.)
     </p>
     <p>
-      Each faction has a type; this is decided by the player, and determines
+      Each faction has a type which is decided by the player, and determines
       what the faction may do.  The faction has 5 Faction Points, which may be
-      spent on any of the 3 Faction Areas, War, Trade, and Magic.  The faction
-      type may be changed at the beginning of each turn, so a faction can
-      change and adapt to the conditions around it.  Faction Points spent on
-      War determine the number of regions in which factions can obtain income
-      by taxing or pillaging. Faction Points spent on Trade determine the
-      number of regions in which a faction may conduct trade activity. Trade
-      activity includes producing goods and materials, building ships and
+      spent on the Faction Areas of War, Trade, and Magic.  The faction type
+      may be changed at the beginning of each turn, so a faction can change
+      and adapt to the conditions around it.  Faction Points spent on War
+      determine the number of regions in which factions can obtain income by
+      taxing or pillaging. Faction Points spent on Trade determine the number
+      of regions in which a faction may conduct trade activity. Trade activity
+      includes producing goods and materials and constructing ships and
       buildings. Faction Points spent on Magic determine the number of mages
       the faction may have (more information on all of the faction activities
       is in further sections of the rules). Here is a chart detailing the
@@ -3122,13 +3122,13 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       If an item requires raw materials, then the specified amount of each
       material is consumed for each item produced. The higher the skill of the
       unit, the more productive each man-month of work will be.  Thus, five
-      men at skill level one are exactly equivalent to one guy at skill level
+      men at skill level one are exactly equivalent to one man at skill level
       5 in terms of base output. Items which require multiple man-months to
-      produce will take still benefit from higher skill level units, just not
-      as quickly.  For example, if a unit of six level one men wanted to
-      produce something which required three man-months per item, that unit
-      could produce two of them in one month.  If their skill level was raised
-      to two, then they could produce four of them in a month. At level three,
+      produce will still benefit from higher skill level units, just not as
+      quickly.  For example, if a unit of six level one men wanted to produce
+      something which required three man-months per item, that unit could
+      produce two of them in one month.  If their skill level was raised to
+      two, then they could produce four of them in a month. At level three,
       they could then produce 6 per month.
     </p>
     <p>
@@ -3187,8 +3187,8 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       on a building requires a unit of the required resource and a man-month
       of work by a character with the appropriate skill and level; higher
       skill levels allow work to proceed faster (still using one unit of the
-      required resource per unit of work done). Again, only Trade factions can
-      issue <a href="#build">BUILD</a> orders. Here is a table of the various
+      required resource per unit of work done). Only Trade factions can issue
+      <a href="#build">BUILD</a> orders. Here is a table of the various
       building types:
     </p>
     <a name="tablebuildings"></a>
@@ -3514,9 +3514,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       move along that road at half cost to a minimum of 1 movement point.
     </p>
     <p>
-      For example: If a unit is moving northwest, then hex it is in must have
-      a northwest road, and the hex it is moving into must have a southeast
-      road.
+      For example: If a unit is moving northwest, then the hex it is in must
+      have a northwest road, and the hex it is moving into must have a
+      southeast road.
     </p>
     <p>
       To gain an economy bonus, a hex must have roads that connect to roads in
@@ -3641,13 +3641,12 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       href="#sail">SAIL</a>s while they have an unfinished ship in their
       possession, the ship will be discarded and lost. Finally, ships are
       never interacted with as objects directly, but when completed are placed
-      in Fleet objects.  Fleets may contain one or more ships, and may be
-      entered like other buildings.
+      in fleets. Fleets may contain one or more ships, and may be entered like
+      other buildings.
     </p>
     <p>
-      Only factions with at least one faction point spent on trade can issue
-      <a href="#build">BUILD</a> orders. Here is a table of the various ship
-      types:
+      Only Trade factions can issue can issue <a href="#build">BUILD</a>
+      orders. Here is a table of the various ship types:
     </p>
     <a name="tableshipinfo"></a>
     <center>
@@ -3748,11 +3747,11 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       the ship to sail.
     </p>
     <p>
-      When a ship is built, if its builder is already the owner of a fleet
-      object, then the ship will be added to that fleet; otherwise a new fleet
-      will be created to hold the ship.  A fleet has the combined capacity and
-      sailor requirement of its constituent vessels, and moves at the speed of
-      its slowest ship. 
+      When a ship is built, if its builder is already the owner of a fleet,
+      then the ship will be added to that fleet; otherwise a new fleet will be
+      created to hold the ship.  A fleet has the combined capacity and sailor
+      requirement of its constituent vessels, and moves at the speed of its
+      slowest ship.
     </p>
     <a name="economy_advanceditems"></a>
     <h3>
@@ -4187,9 +4186,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       orders to drop items (with the <a href="#give">GIVE</a> 0 order) or to
       prevent yourself picking up certain types of spoils (with the <a
       href="#spoils">SPOILS</a> order) in case you win the battle! Also, note
-      that if the winning side took any losses in the battle, any units on
-      this side will not be allowed to move, or attack again for the rest of
-      the turn.
+      that if the winning side took at least 5% casualties in the battle, any
+      units on this side will not be allowed to move, or attack again for the 
+      rest of the turn.
     </p>
     <a name="stealthobs"></a>
     <div class="rule">
@@ -6078,11 +6077,11 @@ FORGET Mining
       If the demand for recruits in that region that month is much higher than
       the supply, it may happen that the new unit does not gain all the
       recruits you ordered it to buy, or it may not gain any recruits at all. 
-      If the new units gains at least one recruit, the unit will form
-      possessing any unused silver and all the other items it was given.  If
-      no recruits are gained at all, the empty unit will be dissolved, and the
-      silver and any other items it was given will revert to the first unit
-      you have in that region.
+      If a new unit gains at least one recruit, the unit will form possessing
+      any unused silver and all the other items it was given.  If no recruits
+      are gained at all, the empty unit will be dissolved, and the silver and
+      any other items it was given will revert to the first unit you have in
+      that region.
     </p>
     <p>
       Example:
@@ -6157,7 +6156,7 @@ GIVE NEW 2 2000 silver
       or better.  If the target unit is not a member of your faction, then its
       faction must have declared you Friendly, with a couple of exceptions.
       First, silver may be given to any unit, regardless of factional
-      affiliation. Secondly, men may not be given to units in other factions
+      affiliation. Second, men may not be given to units in other factions
       (you must give the entire unit); the reason for this is to prevent
       highly skilled units from being sabotaged with a <a
       href="#give">GIVE</a> order.
@@ -6373,10 +6372,9 @@ LEAVE
       Attempt to move in the direction(s) specified.  If more than one
       direction is given, the unit will move multiple times, in the order
       specified by the MOVE order, until no more directions are given, or
-      until one of the moves fails.  A move can fail because the units runs
-      out of movement points, because the unit attempts to move into the
-      ocean, or because the units attempts to enter a structure, and is
-      rejected.
+      until one of the moves fails.  A move can fail because the unit runs out
+      of movement points, because the unit attempts to move into the ocean, or
+      because the unit attempts to enter a structure, and is rejected.
     </p>
     <p>
       Valid directions are:
@@ -7246,7 +7244,7 @@ TAKE FROM 4573 10 swords
     </h4>
     <p>
       Attempt to collect taxes from the region. Only War factions may collect
-      taxes, and then only if there are no non-Friendly units on guard. Only
+      taxes, but only if there are no non-Friendly units on guard. Only
       combat-ready units may issue this order. Note that the TAX order and the
       <a href="#pillage">PILLAGE</a> order are mutually exclusive; a unit may
       only attempt to do one in a turn.

--- a/snapshot-tests/rules/neworigins.html
+++ b/snapshot-tests/rules/neworigins.html
@@ -557,16 +557,16 @@
       character.)
     </p>
     <p>
-      Each faction has a type; this is decided by the player, and determines
+      Each faction has a type which is decided by the player, and determines
       what the faction may do.  The faction has 5 Faction Points, which may be
-      spent on any of the 3 Faction Areas, War, Trade, and Magic.  The faction
-      type may be changed at the beginning of each turn, so a faction can
-      change and adapt to the conditions around it.  Faction Points spent on
-      War determine the number of regions in which factions can obtain income
-      by taxing or pillaging. Faction Points spent on Trade determine the
+      spent on the Faction Areas of Martial and Magic.  The faction type may
+      be changed at the beginning of each turn, so a faction can change and
+      adapt to the conditions around it.  Faction Points spent on Martial
+      determine the number of regions in which factions can obtain income by
+      taxing or pillaging. Faction Points spent on Martial also determine the
       number of regions in which a faction may conduct trade activity. Trade
-      activity includes producing goods and materials.Faction points spent on
-      Trade also determine the of quartermaster units a trade faction can
+      activity includes producing goods and materials. Faction points spent on
+      Martial also determine the number of quartermaster units a faction can
       have. Faction Points spent on Magic determine the number of mages and
       apprentices the faction may have (more information on all of the faction
       activities is in further sections of the rules). Here is a chart
@@ -659,8 +659,7 @@
       For example, a well rounded faction might spend 2 points on Magic, 3
       points on Martial. This faction's type would appear as "Magic 2 Martial
       3", and would be able to perform tax and trade in 40 regions, and have 3
-      mages as well as 5 apprentices, as well have 5 apprentices, and 9
-      quartermasters.
+      mages, as well have 5 apprentices, and 9 quartermasters.
     </p>
     <p>
       As another example, a specialized faction might spend all 5 points on
@@ -3004,13 +3003,13 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       If an item requires raw materials, then the specified amount of each
       material is consumed for each item produced. The higher the skill of the
       unit, the more productive each man-month of work will be.  Thus, five
-      men at skill level one are exactly equivalent to one guy at skill level
+      men at skill level one are exactly equivalent to one man at skill level
       5 in terms of base output. Items which require multiple man-months to
-      produce will take still benefit from higher skill level units, just not
-      as quickly.  For example, if a unit of six level one men wanted to
-      produce something which required three man-months per item, that unit
-      could produce two of them in one month.  If their skill level was raised
-      to two, then they could produce four of them in a month. At level three,
+      produce will still benefit from higher skill level units, just not as
+      quickly.  For example, if a unit of six level one men wanted to produce
+      something which required three man-months per item, that unit could
+      produce two of them in one month.  If their skill level was raised to
+      two, then they could produce four of them in a month. At level three,
       they could then produce 6 per month.
     </p>
     <p>
@@ -3019,7 +3018,7 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       will explain their differences in the description of the item.
     </p>
     <p>
-       Only Trade factions can issue <a href="#produce">PRODUCE</a> orders
+       Only Martial factions can issue <a href="#produce">PRODUCE</a> orders
       however, regardless of skill levels.
     </p>
     <p>
@@ -3447,9 +3446,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       move along that road at half cost to a minimum of 1 movement point.
     </p>
     <p>
-      For example: If a unit is moving northwest, then hex it is in must have
-      a northwest road, and the hex it is moving into must have a southeast
-      road.
+      For example: If a unit is moving northwest, then the hex it is in must
+      have a northwest road, and the hex it is moving into must have a
+      southeast road.
     </p>
     <p>
       To gain an economy bonus, a hex must have roads that connect to roads in
@@ -3588,13 +3587,12 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       href="#sail">SAIL</a>s while they have an unfinished ship in their
       possession, the ship will be discarded and lost. Finally, ships are
       never interacted with as objects directly, but when completed are placed
-      in Fleet objects.  Fleets may contain one or more ships, and may be
-      entered like other buildings.
+      in fleets. Fleets may contain one or more ships, and may be entered like
+      other buildings.
     </p>
     <p>
-      Only factions with at least one faction point spent on trade can issue
-      <a href="#build">BUILD</a> orders. Here is a table of the various ship
-      types:
+      Any faction can issue <a href="#build">BUILD</a> orders. Here is a table
+      of the various ship types:
     </p>
     <a name="tableshipinfo"></a>
     <center>
@@ -3695,11 +3693,11 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       the ship to sail.
     </p>
     <p>
-      When a ship is built, if its builder is already the owner of a fleet
-      object, then the ship will be added to that fleet; otherwise a new fleet
-      will be created to hold the ship.  A fleet has the combined capacity and
-      sailor requirement of its constituent vessels, and moves at the speed of
-      its slowest ship. 
+      When a ship is built, if its builder is already the owner of a fleet,
+      then the ship will be added to that fleet; otherwise a new fleet will be
+      created to hold the ship.  A fleet has the combined capacity and sailor
+      requirement of its constituent vessels, and moves at the speed of its
+      slowest ship.
     </p>
     <a name="economy_advanceditems"></a>
     <h3>
@@ -3747,19 +3745,19 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       Taxing/Pillaging:
     </h3>
     <p>
-      War factions may collect taxes in a region.  This is done using the <a
-      href="#tax">TAX</a> order (which is a full month order). The amount of
-      tax money that can be collected each month in a region is shown in the
-      region description. A unit may <a href="#tax">TAX</a> if it has Combat
-      skill of at least level 1, has a weapon and the appropriate skill to use
-      it, has a mount and sufficient skill to ride it in combat or is a mage
-      who knows a spell which damages enemies. Each taxing character can
+      Martial factions may collect taxes in a region.  This is done using the
+      <a href="#tax">TAX</a> order (which is a full month order). The amount
+      of tax money that can be collected each month in a region is shown in
+      the region description. A unit may <a href="#tax">TAX</a> if it has
+      Combat skill of at least level 1, has a weapon and the appropriate skill
+      to use it, has a mount and sufficient skill to ride it in combat or is a
+      mage who knows a spell which damages enemies. Each taxing character can
       collect $50, though if the number of taxers would tax more than the
       available tax income, the tax income is split evenly among all taxers.
     </p>
     <p>
-      War factions may also pillage a region. To do this requires the faction
-      to have enough combat ready men in the region to tax half of the
+      Martial factions may also pillage a region. To do this requires the
+      faction to have enough combat ready men in the region to tax half of the
       available money in the region. The total amount of money that can be
       pillaged will then be shared out between every combat ready unit that
       issues the <a href="#pillage">PILLAGE</a> order. The amount of money
@@ -3787,7 +3785,7 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       Transportation of goods
     </H3>
     <p>
-      Trade factions may train Quartermaster units. A Quartermaster unit may
+      Martial factions may train Quartermaster units. A Quartermaster unit may
       accept <a href="#transport">TRANSPORT</a>ed items from any unit within 2
       hexes distance from the hex containing the quartermaster. Quartermasters
       may also <a href="#transport">TRANSPORT</a> items to any unit within 2
@@ -4174,9 +4172,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       orders to drop items (with the <a href="#give">GIVE</a> 0 order) or to
       prevent yourself picking up certain types of spoils (with the <a
       href="#spoils">SPOILS</a> order) in case you win the battle! Also, note
-      that if the winning side took any losses in the battle, any units on
-      this side will not be allowed to move, or attack again for the rest of
-      the turn.
+      that if the winning side took at least 5% casualties in the battle, any
+      units on this side will not be allowed to move, or attack again for the 
+      rest of the turn.
     </p>
     <a name="stealthobs"></a>
     <div class="rule">
@@ -5937,9 +5935,9 @@ EXCHANGE 3453 10 SWOR 10 LBOW
     </h4>
     <p>
       Attempt to change your faction's type.  In the order, you can specify up
-      to two faction types (MARTIAL, and MAGIC) and the number of faction
+      to two faction types (MARTIAL and MAGIC) and the number of faction
       points to assign to each type; if you are assigning points to only one
-      or two types, you may omit the types that will not have any points.
+      type, you may omit the type that will not have any points.
     </p>
     <p>
       Changing the number of faction points assigned to MAGIC may be tricky.
@@ -5952,9 +5950,10 @@ EXCHANGE 3453 10 SWOR 10 LBOW
       rid of one of your mages by either giving it to another faction or
       ordering it to <a href="#forget">FORGET</a> all its magic skills. If you
       have too many mages for the number of points you try to assign to MAGIC,
-      the FACTION order will fail. Similar problems could occur with
-      TRADE/MARTIAL points and the number of quartermasters controlled by the
-      faction.
+      the FACTION order will fail. Factions may have the same requirements to
+      disband excess units before changing faction point allocations based on
+      how many apprentices or quartermasters are controlled by the faction and
+      how they are restricted.
     </p>
     <p>
       Examples:
@@ -6048,11 +6047,11 @@ FORGET Mining
       If the demand for recruits in that region that month is much higher than
       the supply, it may happen that the new unit does not gain all the
       recruits you ordered it to buy, or it may not gain any recruits at all. 
-      If the new units gains at least one recruit, the unit will form
-      possessing any unused silver and all the other items it was given.  If
-      no recruits are gained at all, the empty unit will be dissolved, and the
-      silver and any other items it was given will revert to the first unit
-      you have in that region.
+      If a new unit gains at least one recruit, the unit will form possessing
+      any unused silver and all the other items it was given.  If no recruits
+      are gained at all, the empty unit will be dissolved, and the silver and
+      any other items it was given will revert to the first unit you have in
+      that region.
     </p>
     <p>
       Example:
@@ -6127,7 +6126,7 @@ GIVE NEW 2 2000 silver
       or better.  If the target unit is not a member of your faction, then its
       faction must have declared you Friendly, with a couple of exceptions.
       First, silver may be given to any unit, regardless of factional
-      affiliation. Secondly, men may not be given to units in other factions
+      affiliation. Second, men may not be given to units in other factions
       (you must give the entire unit); the reason for this is to prevent
       highly skilled units from being sabotaged with a <a
       href="#give">GIVE</a> order.
@@ -6343,10 +6342,9 @@ LEAVE
       Attempt to move in the direction(s) specified.  If more than one
       direction is given, the unit will move multiple times, in the order
       specified by the MOVE order, until no more directions are given, or
-      until one of the moves fails.  A move can fail because the units runs
-      out of movement points, because the unit attempts to move into the
-      ocean, or because the units attempts to enter a structure, and is
-      rejected.
+      until one of the moves fails.  A move can fail because the unit runs out
+      of movement points, because the unit attempts to move into the ocean, or
+      because the unit attempts to enter a structure, and is rejected.
     </p>
     <p>
       Valid directions are:
@@ -7249,11 +7247,11 @@ TAKE FROM 4573 10 swords
       TAX
     </h4>
     <p>
-      Attempt to collect taxes from the region. Only War factions may collect
-      taxes, and then only if there are no non-Friendly units on guard. Only
-      combat-ready units may issue this order. Note that the TAX order and the
-      <a href="#pillage">PILLAGE</a> order are mutually exclusive; a unit may
-      only attempt to do one in a turn.
+      Attempt to collect taxes from the region. Only Martial factions may
+      collect taxes, but only if there are no non-Friendly units on guard.
+      Only combat-ready units may issue this order. Note that the TAX order
+      and the <a href="#pillage">PILLAGE</a> order are mutually exclusive; a
+      unit may only attempt to do one in a turn.
     </p>
     <p>
       Example:

--- a/snapshot-tests/rules/standard.html
+++ b/snapshot-tests/rules/standard.html
@@ -587,15 +587,15 @@
       character.)
     </p>
     <p>
-      Each faction has a type; this is decided by the player, and determines
+      Each faction has a type which is decided by the player, and determines
       what the faction may do.  The faction has 5 Faction Points, which may be
-      spent on any of the 3 Faction Areas, War, Trade, and Magic.  The faction
-      type may be changed at the beginning of each turn, so a faction can
-      change and adapt to the conditions around it.  Faction Points spent on
-      War determine the number of regions in which factions can obtain income
-      by taxing or pillaging. Faction Points spent on Trade determine the
-      number of regions in which a faction may conduct trade activity. Trade
-      activity includes producing goods and materials, building ships and
+      spent on the Faction Areas of War, Trade, and Magic.  The faction type
+      may be changed at the beginning of each turn, so a faction can change
+      and adapt to the conditions around it.  Faction Points spent on War
+      determine the number of regions in which factions can obtain income by
+      taxing or pillaging. Faction Points spent on Trade determine the number
+      of regions in which a faction may conduct trade activity. Trade activity
+      includes producing goods and materials and constructing ships and
       buildings. Faction Points spent on Magic determine the number of mages
       the faction may have (more information on all of the faction activities
       is in further sections of the rules). Here is a chart detailing the
@@ -3075,13 +3075,13 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       If an item requires raw materials, then the specified amount of each
       material is consumed for each item produced. The higher the skill of the
       unit, the more productive each man-month of work will be.  Thus, five
-      men at skill level one are exactly equivalent to one guy at skill level
+      men at skill level one are exactly equivalent to one man at skill level
       5 in terms of base output. Items which require multiple man-months to
-      produce will take still benefit from higher skill level units, just not
-      as quickly.  For example, if a unit of six level one men wanted to
-      produce something which required three man-months per item, that unit
-      could produce two of them in one month.  If their skill level was raised
-      to two, then they could produce four of them in a month. At level three,
+      produce will still benefit from higher skill level units, just not as
+      quickly.  For example, if a unit of six level one men wanted to produce
+      something which required three man-months per item, that unit could
+      produce two of them in one month.  If their skill level was raised to
+      two, then they could produce four of them in a month. At level three,
       they could then produce 6 per month.
     </p>
     <p>
@@ -3140,8 +3140,8 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       on a building requires a unit of the required resource and a man-month
       of work by a character with the appropriate skill and level; higher
       skill levels allow work to proceed faster (still using one unit of the
-      required resource per unit of work done). Again, only Trade factions can
-      issue <a href="#build">BUILD</a> orders. Here is a table of the various
+      required resource per unit of work done). Only Trade factions can issue
+      <a href="#build">BUILD</a> orders. Here is a table of the various
       building types:
     </p>
     <a name="tablebuildings"></a>
@@ -3464,9 +3464,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       move along that road at half cost to a minimum of 1 movement point.
     </p>
     <p>
-      For example: If a unit is moving northwest, then hex it is in must have
-      a northwest road, and the hex it is moving into must have a southeast
-      road.
+      For example: If a unit is moving northwest, then the hex it is in must
+      have a northwest road, and the hex it is moving into must have a
+      southeast road.
     </p>
     <p>
       To gain an economy bonus, a hex must have roads that connect to roads in
@@ -3591,13 +3591,12 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       href="#sail">SAIL</a>s while they have an unfinished ship in their
       possession, the ship will be discarded and lost. Finally, ships are
       never interacted with as objects directly, but when completed are placed
-      in Fleet objects.  Fleets may contain one or more ships, and may be
-      entered like other buildings.
+      in fleets. Fleets may contain one or more ships, and may be entered like
+      other buildings.
     </p>
     <p>
-      Only factions with at least one faction point spent on trade can issue
-      <a href="#build">BUILD</a> orders. Here is a table of the various ship
-      types:
+      Only Trade factions can issue can issue <a href="#build">BUILD</a>
+      orders. Here is a table of the various ship types:
     </p>
     <a name="tableshipinfo"></a>
     <center>
@@ -3698,11 +3697,11 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       the ship to sail.
     </p>
     <p>
-      When a ship is built, if its builder is already the owner of a fleet
-      object, then the ship will be added to that fleet; otherwise a new fleet
-      will be created to hold the ship.  A fleet has the combined capacity and
-      sailor requirement of its constituent vessels, and moves at the speed of
-      its slowest ship. 
+      When a ship is built, if its builder is already the owner of a fleet,
+      then the ship will be added to that fleet; otherwise a new fleet will be
+      created to hold the ship.  A fleet has the combined capacity and sailor
+      requirement of its constituent vessels, and moves at the speed of its
+      slowest ship.
     </p>
     <a name="economy_advanceditems"></a>
     <h3>
@@ -4135,9 +4134,9 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       orders to drop items (with the <a href="#give">GIVE</a> 0 order) or to
       prevent yourself picking up certain types of spoils (with the <a
       href="#spoils">SPOILS</a> order) in case you win the battle! Also, note
-      that if the winning side took any losses in the battle, any units on
-      this side will not be allowed to move, or attack again for the rest of
-      the turn.
+      that if the winning side took at least 5% casualties in the battle, any
+      units on this side will not be allowed to move, or attack again for the 
+      rest of the turn.
     </p>
     <a name="stealthobs"></a>
     <div class="rule">
@@ -5977,11 +5976,11 @@ FORGET Mining
       If the demand for recruits in that region that month is much higher than
       the supply, it may happen that the new unit does not gain all the
       recruits you ordered it to buy, or it may not gain any recruits at all. 
-      If the new units gains at least one recruit, the unit will form
-      possessing any unused silver and all the other items it was given.  If
-      no recruits are gained at all, the empty unit will be dissolved, and the
-      silver and any other items it was given will revert to the first unit
-      you have in that region.
+      If a new unit gains at least one recruit, the unit will form possessing
+      any unused silver and all the other items it was given.  If no recruits
+      are gained at all, the empty unit will be dissolved, and the silver and
+      any other items it was given will revert to the first unit you have in
+      that region.
     </p>
     <p>
       Example:
@@ -6056,7 +6055,7 @@ GIVE NEW 2 2000 silver
       or better.  If the target unit is not a member of your faction, then its
       faction must have declared you Friendly, with a couple of exceptions.
       First, silver may be given to any unit, regardless of factional
-      affiliation. Secondly, men may not be given to units in other factions
+      affiliation. Second, men may not be given to units in other factions
       (you must give the entire unit); the reason for this is to prevent
       highly skilled units from being sabotaged with a <a
       href="#give">GIVE</a> order.
@@ -6272,10 +6271,9 @@ LEAVE
       Attempt to move in the direction(s) specified.  If more than one
       direction is given, the unit will move multiple times, in the order
       specified by the MOVE order, until no more directions are given, or
-      until one of the moves fails.  A move can fail because the units runs
-      out of movement points, because the unit attempts to move into the
-      ocean, or because the units attempts to enter a structure, and is
-      rejected.
+      until one of the moves fails.  A move can fail because the unit runs out
+      of movement points, because the unit attempts to move into the ocean, or
+      because the unit attempts to enter a structure, and is rejected.
     </p>
     <p>
       Valid directions are:
@@ -7145,7 +7143,7 @@ TAKE FROM 4573 10 swords
     </h4>
     <p>
       Attempt to collect taxes from the region. Only War factions may collect
-      taxes, and then only if there are no non-Friendly units on guard. Only
+      taxes, but only if there are no non-Friendly units on guard. Only
       combat-ready units may issue this order. Note that the TAX order and the
       <a href="#pillage">PILLAGE</a> order are mutually exclusive; a unit may
       only attempt to do one in a turn.

--- a/standard/rules.cpp
+++ b/standard/rules.cpp
@@ -252,6 +252,7 @@ static GameDefs g = {
 	34,	// MAX_DESTROY_PERCENT
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT, // REPORT_FORMAT
+	5, // BATTLE_STOP_MOVE_PERCENT
 };
 
 GameDefs *Globals = &g;

--- a/standard/world.cpp
+++ b/standard/world.cpp
@@ -2226,7 +2226,7 @@ void Game::CreateWorld()
 
 	regions.TownStatistics();
 
-	regions.ResoucesStatistics();
+	regions.ResourcesStatistics();
 }
 
 int ARegionList::GetRegType( ARegion *pReg )

--- a/unittest/rules.cpp
+++ b/unittest/rules.cpp
@@ -252,6 +252,7 @@ static GameDefs g = {
 	33,	// MAX_DESTROY_PERCENT
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT | GameDefs::REPORT_FORMAT_JSON, // REPORT_FORMAT
+	5, // BATTLE_STOP_MOVE_PERCENT
 };
 
 GameDefs *Globals = &g;


### PR DESCRIPTION
* Most of these came from PRs attached to Issue #106 but closed
  * Much of those PRs had been already applied, but not all.
  * Updated many instances of War/Trade to be aware of Martial
  * Fixed a long standing bug where apprentice count was duplicated.
* Updated rules to reflect the combat loss movement changes.
  * This was actually the subject of the issue and had not been fixes.
* Made the percent of loss which stops movement configurable but defaulted it in all rule sets to what it current was globally (5%)
* Update rules snapshots to reflect all the changes.