### PR TITLE
Some various bug fixes from old issues

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -174,8 +174,8 @@ Production *ARegion::get_production_for_skill(int item, int skill) {
 int ARegion::IsNativeRace(int item)
 {
 	TerrainType *typer = &(TerrainDefs[type]);
-	int coastal = sizeof(typer->coastal_races)/sizeof(int);
-	int noncoastal = sizeof(typer->races)/sizeof(int);
+	int coastal = sizeof(typer->coastal_races)/sizeof(typer->coastal_races[0]);
+	int noncoastal = sizeof(typer->races)/sizeof(typer->races[0]);
 	if (IsCoastal()) {
 		for (int i=0; i<coastal; i++) {
 			if (item == typer->coastal_races[i]) return 1;
@@ -229,7 +229,7 @@ std::vector<int> ARegion::GetPossibleLairs() {
 	std::vector<int> lairs;
 	TerrainType *tt = &TerrainDefs[type];
 
-	const int sz = sizeof(tt->lairs) / sizeof(int);
+	const int sz = sizeof(tt->lairs) / sizeof(tt->lairs[0]);
 
 	for (int i = 0; i < sz; i++) {
 		int index = tt->lairs[i];
@@ -1639,7 +1639,7 @@ int ARegion::NotifySpell(Unit *caster, char const *spell, ARegionList *pRegs)
 
 	if (!(pS->flags & SkillType::NOTIFY)) {
 		// Okay, we aren't notifyable, check our prerequisites
-		for (i = 0; i < sizeof(pS->depends)/sizeof(SkillDepend); i++) {
+		for (i = 0; i < sizeof(pS->depends)/sizeof(pS->depends[0]); i++) {
 			if (pS->depends[i].skill == NULL) break;
 			if (NotifySpell(caster, pS->depends[i].skill, pRegs)) return 1;
 		}

--- a/basic/map.cpp
+++ b/basic/map.cpp
@@ -909,8 +909,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			ARegion *reg = pArr->GetRegion(xoff, y);
 			if (!reg) continue;
 			
-			if ((reg->type == R_LAKE) && (!Globals->LAKESIDE_IS_COASTAL))
-				continue;
+			if ((reg->type == R_LAKE) && (!Globals->LAKESIDE_IS_COASTAL)) continue;
 			if (TerrainDefs[reg->type].flags & TerrainType::BARREN) continue;
 			
 			reg->race = -1;
@@ -924,14 +923,11 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				if (!nreg) continue;
 				while((ctr++ < 20) && (reg->race == -1)) {
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
-						int rnum =
-							sizeof(TerrainDefs[nreg->type].coastal_races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
+							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
 						
-						while ( reg->race == -1 || 
-								(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
-							reg->race = 
-								TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
+						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
 						}
 					} else {
@@ -943,7 +939,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				}
 			} else {
 				// setup noncoastal race here
-				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(int);
+				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
 				
 				while ( reg->race == -1 || 
 						(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
@@ -986,16 +982,13 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 					if ((!nreg) || (nreg->race != -1)) continue;
 					int iscoastal = 0;
 					int cnum = sizeof(TerrainDefs[reg->type].coastal_races) /
-						sizeof(int);
-					for (int i=0; i<cnum; i++) {
-						if (reg->race ==
-								TerrainDefs[reg->type].coastal_races[i])
+						sizeof(TerrainDefs[reg->type].coastal_races[0]);
+					for (int i = 0; i < cnum; i++) {
+						if (reg->race == TerrainDefs[reg->type].coastal_races[i])
 							iscoastal = 1;
 					}
 					// Only coastal races may pass from sea to land
-					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) &&
-							(!iscoastal))
-						continue;
+					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) && (!iscoastal)) continue;
 
 					int ch = getrandom(5);
 					if (iscoastal) {
@@ -1005,8 +998,7 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 						ManType *mt = FindRace(ItemDefs[reg->race].abr);
 						if (mt->terrain==TerrainDefs[nreg->type].similar_type)
 							ch += 2;
-						int rnum = sizeof(TerrainDefs[nreg->type].races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].races) / sizeof(TerrainDefs[nreg->type].races[0]);
 						for (int i=0; i<rnum; i++) {
 							if (TerrainDefs[nreg->type].races[i] == reg->race)
 								ch++;

--- a/economy.cpp
+++ b/economy.cpp
@@ -1105,11 +1105,11 @@ int ARegion::TownHabitat()
 	forlist(&objects) {
 		Object *obj = (Object *) elem;
 		if (ObjectDefs[obj->type].protect > fort) fort = ObjectDefs[obj->type].protect;
-		if (ItemDefs[ObjectDefs[obj->type].productionAided].flags & IT_FOOD) farm++;
+		if (ItemDefs[ObjectDefs[obj->type].productionAided].type & IT_FOOD) farm++;
 		if (ObjectDefs[obj->type].productionAided == I_SILVER) inn++;
 		if (ObjectDefs[obj->type].productionAided == I_HERBS) temple++;
 		if ((ObjectDefs[obj->type].flags & ObjectType::TRANSPORT)
-			&& (ItemDefs[ObjectDefs[obj->type].productionAided].flags & IT_MOUNT)) caravan++;
+			&& (ItemDefs[ObjectDefs[obj->type].productionAided].type & IT_MOUNT)) caravan++;
 	}
 	int hab = 2;
 	int step = 0;

--- a/economy.cpp
+++ b/economy.cpp
@@ -111,9 +111,9 @@ void ARegion::SetupHabitat(TerrainType* terrain) {
 	// Only select race here if it hasn't been set during Race Growth
 	// in the World Creation process.
 	if ((race == -1) || (!Globals->GROW_RACES)) {
-		int noncoastalraces = sizeof(terrain->races) / sizeof(int);
+		int noncoastalraces = sizeof(terrain->races) / sizeof(terrain->races[0]);
 		int allraces =
-			noncoastalraces + sizeof(terrain->coastal_races) / sizeof(int);
+			noncoastalraces + sizeof(terrain->coastal_races) / sizeof(terrain->coastal_races[0]);
 
 		race = -1;
 		while (race == -1 || (ItemDefs[race].flags & ItemType::DISABLED)) {
@@ -417,7 +417,7 @@ void ARegion::SetupCityMarket()
 		// Raw goods
 		if (ItemDefs[i].pInput[0].item == -1) {
 			for (unsigned int c = 0;
-				c<(sizeof(TerrainDefs[type].prods)/sizeof(Product));
+				c<(sizeof(TerrainDefs[type].prods)/sizeof(TerrainDefs[type].prods[0]));
 				c++) {
 				int resource = TerrainDefs[type].prods[c].product;
 				if (i == resource) {
@@ -430,12 +430,12 @@ void ARegion::SetupCityMarket()
 		else {
 			canProduceHere = 1;
 			for (unsigned int c = 0;
-				c<(sizeof(ItemDefs[i].pInput)/sizeof(Materials));
+				c<(sizeof(ItemDefs[i].pInput)/sizeof(ItemDefs[i].pInput[0]));
 				c++) {
 				int match = 0;
 				int need = ItemDefs[i].pInput[c].item;
 				for (unsigned int r=0;
-					r<(sizeof(TerrainDefs[type].prods)/sizeof(Product));
+					r<(sizeof(TerrainDefs[type].prods)/sizeof(TerrainDefs[type].prods[0]));
 					r++) {
 					if (TerrainDefs[type].prods[r].product == need)
 						match = 1;
@@ -772,7 +772,7 @@ void ARegion::SetupProds(double weight)
 		}
 	}
 
-	for (unsigned int c= 0; c < (sizeof(typer->prods)/sizeof(Product)); c++) {
+	for (unsigned int c= 0; c < (sizeof(typer->prods)/sizeof(typer->prods[0])); c++) {
 		int item = typer->prods[c].product;
 		int chance = typer->prods[c].chance * weight;
 		int amt = typer->prods[c].amount;
@@ -947,9 +947,9 @@ void ARegion::SetupEditRegion()
 	// Only select race here if it hasn't been set during Race Growth
 	// in the World Creation process.
 	if ((race == -1) || (!Globals->GROW_RACES)) {
-		int noncoastalraces = sizeof(typer->races)/sizeof(int);
+		int noncoastalraces = sizeof(typer->races)/sizeof(typer->races[0]);
 		int allraces =
-			noncoastalraces + sizeof(typer->coastal_races)/sizeof(int);
+			noncoastalraces + sizeof(typer->coastal_races)/sizeof(typer->coastal_races[0]);
 
 		race = -1;
 		while (race == -1 || (ItemDefs[race].flags & ItemType::DISABLED)) {

--- a/fracas/map.cpp
+++ b/fracas/map.cpp
@@ -924,14 +924,11 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				if (!nreg) continue;
 				while((ctr++ < 20) && (reg->race == -1)) {
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
-						int rnum =
-							sizeof(TerrainDefs[nreg->type].coastal_races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
+								sizeof(TerrainDefs[nreg->type].coastal_races[0]);
 						
-						while ( reg->race == -1 || 
-								(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
-							reg->race = 
-								TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
+						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
 						}
 					} else {
@@ -943,10 +940,9 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				}
 			} else {
 				// setup noncoastal race here
-				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(int);
+				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
 				
-				while ( reg->race == -1 || 
-						(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
@@ -986,16 +982,13 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 					if ((!nreg) || (nreg->race != -1)) continue;
 					int iscoastal = 0;
 					int cnum = sizeof(TerrainDefs[reg->type].coastal_races) /
-						sizeof(int);
+						sizeof(TerrainDefs[reg->type].coastal_races[0]);
 					for (int i=0; i<cnum; i++) {
-						if (reg->race ==
-								TerrainDefs[reg->type].coastal_races[i])
+						if (reg->race == TerrainDefs[reg->type].coastal_races[i])
 							iscoastal = 1;
 					}
 					// Only coastal races may pass from sea to land
-					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) &&
-							(!iscoastal))
-						continue;
+					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) && (!iscoastal)) continue;
 
 					int ch = getrandom(5);
 					if (iscoastal) {
@@ -1005,8 +998,7 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 						ManType *mt = FindRace(ItemDefs[reg->race].abr);
 						if (mt->terrain==TerrainDefs[nreg->type].similar_type)
 							ch += 2;
-						int rnum = sizeof(TerrainDefs[nreg->type].races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].races) / sizeof(TerrainDefs[nreg->type].races[0]);
 						for (int i=0; i<rnum; i++) {
 							if (TerrainDefs[nreg->type].races[i] == reg->race)
 								ch++;

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -1178,7 +1178,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		f << enclose("tr", true);
 		f << enclose("td colspan=\"2\"", true) << TerrainDefs[i].name << '\n' << enclose("td", false);
 		f << enclose("td colspan=\"4\"", true);
-		for (unsigned int c = 0; c < sizeof(TerrainDefs[i].prods)/sizeof(Product); c++) {
+		for (unsigned int c = 0; c < sizeof(TerrainDefs[i].prods)/sizeof(TerrainDefs[i].prods[0]); c++) {
 			if (TerrainDefs[i].prods[c].product == -1) continue;
 			if (!first) {
 				f << ", ";
@@ -1392,8 +1392,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		pS = FindSkill(ItemDefs[i].pSkill);
 		if (pS && (pS->flags & SkillType::DISABLED)) continue;
 		int last = 0;
-		for (int j = 0; j < (int) (sizeof(ItemDefs->pInput) /
-				sizeof(ItemDefs->pInput[0])); j++) {
+		for (int j = 0; j < (int) (sizeof(ItemDefs->pInput) / sizeof(ItemDefs->pInput[0])); j++) {
 			int k = ItemDefs[i].pInput[j].item;
 			if (k != -1 && (ItemDefs[k].flags & ItemType::DISABLED))
 				last = 1;
@@ -1564,7 +1563,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			if (ItemDefs[i].flags & ItemType::DISABLED) continue;
 			if (!(ItemDefs[i].type & IT_SHIP)) continue;
 			int pub = 1;
-			for (int c = 0; c < (int) sizeof(ItemDefs->pInput)/(int) sizeof(Materials); c++) {
+			for (int c = 0; c < (int) sizeof(ItemDefs->pInput)/(int) sizeof(ItemDefs->pInput[0]); c++) {
 				int m = ItemDefs[i].pInput[c].item;
 				if (m != -1) {
 					if (ItemDefs[m].flags & ItemType::DISABLED) pub = 0;
@@ -2190,8 +2189,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		pS = FindSkill(ItemDefs[i].pSkill);
 		if (pS && (pS->flags & SkillType::DISABLED)) continue;
 		last = 0;
-		for (int j = 0; j < (int) (sizeof(ItemDefs->pInput) /
-						sizeof(ItemDefs->pInput[0])); j++) {
+		for (int j = 0; j < (int) (sizeof(ItemDefs->pInput) / sizeof(ItemDefs->pInput[0])); j++) {
 			int k = ItemDefs[i].pInput[j].item;
 			if (k != -1 &&
 					!(ItemDefs[k].flags & ItemType::DISABLED) &&
@@ -2289,8 +2287,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 				pS = FindSkill(ItemDefs[j].pSkill);
 				if (!pS || (pS->flags & SkillType::DISABLED)) continue;
 				last = 0;
-				for (int k = 0; k < (int) (sizeof(ItemDefs->pInput) /
-						sizeof(ItemDefs->pInput[0])); k++) {
+				for (int k = 0; k < (int) (sizeof(ItemDefs->pInput) / sizeof(ItemDefs->pInput[0])); k++) {
 					int l = ItemDefs[j].pInput[k].item;
 					if (l != -1 &&
 							!(ItemDefs[l].flags & ItemType::DISABLED) &&
@@ -2624,7 +2621,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			if (ItemDefs[i].flags & ItemType::DISABLED) continue;
 			if (!(ItemDefs[i].type & IT_SHIP)) continue;
 			int pub = 1;
-			for (int c = 0; c < (int) sizeof(ItemDefs->pInput)/(int) sizeof(Materials); c++) {
+			for (int c = 0; c < (int) sizeof(ItemDefs->pInput)/(int) sizeof(ItemDefs->pInput[0]); c++) {
 				int m = ItemDefs[i].pInput[c].item;
 				if (m != -1) {
 					if (ItemDefs[m].flags & ItemType::DISABLED) pub = 0;

--- a/havilah/map.cpp
+++ b/havilah/map.cpp
@@ -932,14 +932,11 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				if (!nreg) continue;
 				while((ctr++ < 20) && (reg->race == -1)) {
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
-						int rnum =
-							sizeof(TerrainDefs[nreg->type].coastal_races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
+							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
 						
-						while ( reg->race == -1 || 
-								(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
-							reg->race = 
-								TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
+						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
 						}
 					} else {
@@ -951,10 +948,9 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				}
 			} else {
 				// setup noncoastal race here
-				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(int);
+				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
 				
-				while ( reg->race == -1 || 
-						(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
@@ -994,16 +990,13 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 					if ((!nreg) || (nreg->race != -1)) continue;
 					int iscoastal = 0;
 					int cnum = sizeof(TerrainDefs[reg->type].coastal_races) /
-						sizeof(int);
+						sizeof(TerrainDefs[reg->type].coastal_races[0]);
 					for (int i=0; i<cnum; i++) {
-						if (reg->race ==
-								TerrainDefs[reg->type].coastal_races[i])
+						if (reg->race == TerrainDefs[reg->type].coastal_races[i])
 							iscoastal = 1;
 					}
 					// Only coastal races may pass from sea to land
-					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) &&
-							(!iscoastal))
-						continue;
+					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) && (!iscoastal)) continue;
 
 					int ch = getrandom(5);
 					if (iscoastal) {
@@ -1013,8 +1006,7 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 						ManType *mt = FindRace(ItemDefs[reg->race].abr);
 						if (mt->terrain==TerrainDefs[nreg->type].similar_type)
 							ch += 2;
-						int rnum = sizeof(TerrainDefs[nreg->type].races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].races) / sizeof(TerrainDefs[nreg->type].races[0]);
 						for (int i=0; i<rnum; i++) {
 							if (TerrainDefs[nreg->type].races[i] == reg->race)
 								ch++;

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -1387,9 +1387,8 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				if (!nreg) continue;
 				while((ctr++ < 20) && (reg->race == -1)) {
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
-						int rnum =
-							sizeof(TerrainDefs[nreg->type].coastal_races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
+							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
 						reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 					} else {
 						int dir = getrandom(NDIRS);
@@ -1400,7 +1399,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				}
 			} else {
 				// setup noncoastal race here
-				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(int);
+				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
 				reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 			}
 		}
@@ -1422,16 +1421,13 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 					if ((!nreg) || (nreg->race != -1)) continue;
 					int iscoastal = 0;
 					int cnum = sizeof(TerrainDefs[reg->type].coastal_races) /
-						sizeof(int);
+						sizeof(TerrainDefs[reg->type].coastal_races[0]);
 					for (int i=0; i<cnum; i++) {
-						if (reg->race ==
-								TerrainDefs[reg->type].coastal_races[i])
+						if (reg->race == TerrainDefs[reg->type].coastal_races[i])
 							iscoastal = 1;
 					}
 					// Only coastal races may pass from sea to land
-					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) &&
-							(!iscoastal))
-						continue;
+					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) && (!iscoastal)) continue;
 
 					int ch = getrandom(5);
 					if (iscoastal) {
@@ -1441,8 +1437,7 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 						ManType *mt = FindRace(ItemDefs[reg->race].abr);
 						if (mt->terrain==TerrainDefs[nreg->type].similar_type)
 							ch += 2;
-						int rnum = sizeof(TerrainDefs[nreg->type].races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].races) / sizeof(TerrainDefs[nreg->type].races[0]);
 						for (int i=0; i<rnum; i++) {
 							if (TerrainDefs[nreg->type].races[i] == reg->race)
 								ch++;

--- a/modify.cpp
+++ b/modify.cpp
@@ -45,8 +45,7 @@ void Game::DisableSkill(int sk)
 void Game::ModifySkillDependancy(int sk, int i, char const *dep, int lev)
 {
 	if (sk < 0 || sk > (NSKILLS-1)) return;
-	if (i < 0 || i >= (int)(sizeof(SkillDefs[sk].depends)/sizeof(SkillDefs[sk].depends[0])))
-		return;
+	if (i < 0 || i >= (int)(sizeof(SkillDefs[sk].depends)/sizeof(SkillDefs[sk].depends[0]))) return;
 	if (dep && (FindSkill(dep) == NULL)) return;
 	if (lev < 0) return;
 	SkillDefs[sk].depends[i].skill = dep;
@@ -182,8 +181,7 @@ void Game::ModifyItemProductionOutput(int it, int months, int count)
 void Game::ModifyItemProductionInput(int it, int i, int input, int amount)
 {
 	if (it < 0 || it > (NITEMS-1)) return;
-	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].pInput)/sizeof(ItemDefs[it].pInput[0])))
-		return;
+	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].pInput)/sizeof(ItemDefs[it].pInput[0]))) return;
 	if (input < -1 || input > (NITEMS-1)) return;
 	if (amount < 0) amount = 0;
 	ItemDefs[it].pInput[i].item = input;
@@ -208,8 +206,7 @@ void Game::ModifyItemMagicOutput(int it, int count)
 void Game::ModifyItemMagicInput(int it, int i, int input, int amount)
 {
 	if (it < 0 || it > (NITEMS-1)) return;
-	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].mInput)/sizeof(ItemDefs[it].mInput[0])))
-		return;
+	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].mInput)/sizeof(ItemDefs[it].mInput[0]))) return;
 	if (input < -1 || input > (NITEMS-1)) return;
 	if (amount < 0) amount = 0;
 	ItemDefs[it].mInput[i].item = input;
@@ -358,7 +355,7 @@ void Game::ModifyWeaponBonusMalus(char const *weap, int index, char *weaponAbbr,
 {
 	WeaponType *pw = FindWeapon(weap);
 	if (pw == NULL) return;
-
+	if (index < 0 || index >= (int)(sizeof(pw->bonusMalus)/sizeof(pw->bonusMalus[0]))) return;
 	if (pw->bonusMalus[index].weaponAbbr) {
 		delete pw->bonusMalus[index].weaponAbbr;
 	}
@@ -468,8 +465,7 @@ void Game::ModifyObjectMonster(int ob, int monster)
 void Game::ModifyObjectConstruction(int ob, int it, int num, char const *sk, int lev)
 {
 	if (ob < 0 || ob > (NOBJECTS-1)) return;
-	if ((it < -1 && it != I_WOOD_OR_STONE) || it > (NITEMS -1))
-		return;
+	if ((it < -1 && it != I_WOOD_OR_STONE) || it > (NITEMS -1)) return;
 	if (num < 0) return;
 	if (sk && FindSkill(sk) == NULL) return;
 	if (lev < 0) return;
@@ -535,8 +531,7 @@ void Game::ModifyTerrainRace(int t, int i, int r)
 void Game::ModifyTerrainCoastRace(int t, int i, int r)
 {
 	if (t < 0 || t > (R_NUM -1)) return;
-	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].coastal_races)/sizeof(TerrainDefs[t].coastal_races[0])))
-		return;
+	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].coastal_races)/sizeof(TerrainDefs[t].coastal_races[0]))) return;
 	if (r < -1 || r > NITEMS-1) r = -1;
 	if (r != -1 && !(ItemDefs[r].type & IT_MAN)) r = -1;
 	TerrainDefs[t].coastal_races[i] = r;
@@ -546,9 +541,7 @@ void Game::ClearTerrainItems(int terrain)
 {
 	if (terrain < 0 || terrain > R_NUM-1) return;
 
-	for (unsigned int c = 0;
-			c < sizeof(TerrainDefs[terrain].prods)/sizeof(TerrainDefs[terrain].prods[0]);
-			c++) {
+	for (unsigned int c = 0; c < sizeof(TerrainDefs[terrain].prods)/sizeof(TerrainDefs[terrain].prods[0]); c++) {
 		TerrainDefs[terrain].prods[c].product = -1;
 		TerrainDefs[terrain].prods[c].chance = 0;
 		TerrainDefs[terrain].prods[c].amount = 0;
@@ -558,8 +551,7 @@ void Game::ClearTerrainItems(int terrain)
 void Game::ModifyTerrainItems(int terrain, int i, int p, int c, int a)
 {
 	if (terrain < 0 || terrain > (R_NUM -1)) return;
-	if (i < 0 || i >= (int)(sizeof(TerrainDefs[terrain].prods)/sizeof(TerrainDefs[terrain].prods[0])))
-		return;
+	if (i < 0 || i >= (int)(sizeof(TerrainDefs[terrain].prods)/sizeof(TerrainDefs[terrain].prods[0]))) return;
 	if (p < -1 || p > NITEMS-1) p = -1;
 	if (c < 0 || c > 100) c = 0;
 	if (a < 0) a = 0;
@@ -644,7 +636,7 @@ void Game::ModifySpecialTargetObjects(char const *special, int index, int obj)
 {
 	SpecialType *sp = FindSpecial(special);
 	if (sp == NULL) return;
-	if (index < 0 || index > 3) return;
+	if (index < 0 || index >= (int)(sizeof(sp->buildings) / sizeof(sp->buildings[0]))) return;
 	if ((obj != -1 && obj < 1) || (obj > (NOBJECTS-1))) return;
 	sp->buildings[index] = obj;
 }
@@ -653,7 +645,7 @@ void Game::ModifySpecialTargetItems(char const *special, int index, int item)
 {
 	SpecialType *sp = FindSpecial(special);
 	if (sp == NULL) return;
-	if (index < 0 || index > 7) return;
+	if (index < 0 || index >= (int)(sizeof(sp->targets) / sizeof(sp->targets[0]))) return;
 	if (item < -1 || item > (NITEMS-1)) return;
 	sp->targets[index] = item;
 }
@@ -662,7 +654,7 @@ void Game::ModifySpecialTargetEffects(char const *special, int index, char const
 {
 	SpecialType *sp = FindSpecial(special);
 	if (sp == NULL) return;
-	if (index < 0 || index > 3) return;
+	if (index < 0 || index >= (int)(sizeof(sp->effects) / sizeof(sp->effects[0]))) return;
 	if (effect && (FindEffect(effect) == NULL)) return;
 	sp->effects[index] = effect;
 }
@@ -678,7 +670,7 @@ void Game::ModifySpecialShields(char const *special, int index, int type)
 {
 	SpecialType *sp = FindSpecial(special);
 	if (sp == NULL) return;
-	if (index < 0 || index > 4) return;
+	if (index < 0 || index >= (int)(sizeof(sp->shield) / sizeof(sp->shield[0]))) return;
 	if (type < -1 || type > (NUM_ATTACK_TYPES)) return;
 	sp->shield[index] = type;
 }
@@ -687,7 +679,7 @@ void Game::ModifySpecialDefenseMods(char const *special, int index, int type, in
 {
 	SpecialType *sp = FindSpecial(special);
 	if (sp == NULL) return;
-	if (index < 0 || index > 4) return;
+	if (index < 0 || index >= (int)(sizeof(sp->defs) / sizeof(sp->defs[0]))) return;
 	if (type < -1 || type > (NUM_ATTACK_TYPES)) return;
 	sp->defs[index].type = type;
 	sp->defs[index].val = val;
@@ -698,7 +690,7 @@ void Game::ModifySpecialDamage(char const *special, int index, int type, int min
 {
 	SpecialType *sp = FindSpecial(special);
 	if (sp == NULL) return;
-	if (index < 0 || index > 4) return;
+	if (index < 0 || index >= (int)(sizeof(sp->damage) / sizeof(sp->damage[0]))) return;
 	if (effect && (FindEffect(effect) == NULL)) return;
 	if (type < -1 || type > NUM_ATTACK_TYPES) return;
 	if (cls < -1 || cls > (NUM_WEAPON_CLASSES-1)) return;
@@ -731,7 +723,7 @@ void Game::ModifyEffectDefenseMod(char const *effect, int index, int type, int v
 	EffectType *ep = FindEffect(effect);
 	if (ep == NULL) return;
 	if (type < 0 || type > NUM_ATTACK_TYPES) return;
-	if (index < 0 || index > 4) return;
+	if (index < 0 || index >= (int)(sizeof(ep->defMods) / sizeof(ep->defMods[0]))) return;
 	ep->defMods[index].type = type;
 	ep->defMods[index].val = val;
 }
@@ -775,12 +767,11 @@ void Game::ModifyRangeLevelPenalty(char const *range, int pen)
 	rp->crossLevelPenalty = pen;
 }
 
-void Game::ModifyAttribMod(char const *mod, int index, int flags, char const *ident,
-		int type, int val)
+void Game::ModifyAttribMod(char const *mod, int index, int flags, char const *ident, int type, int val)
 {
 	AttribModType *mp = FindAttrib(mod);
 	if (mp == NULL) return;
-	if (index < 0 || index > 5) return;
+	if (index < 0 || index >= (int)(sizeof(mp->mods) / sizeof(mp->mods[0]))) return;
 	if (!ident) return;
 	if (type < 0 || type > AttribModItem::NUMMODTYPE-1) return;
 

--- a/modify.cpp
+++ b/modify.cpp
@@ -45,7 +45,7 @@ void Game::DisableSkill(int sk)
 void Game::ModifySkillDependancy(int sk, int i, char const *dep, int lev)
 {
 	if (sk < 0 || sk > (NSKILLS-1)) return;
-	if (i < 0 || i >= (int)(sizeof(SkillDefs[sk].depends)/sizeof(SkillDepend)))
+	if (i < 0 || i >= (int)(sizeof(SkillDefs[sk].depends)/sizeof(SkillDefs[sk].depends[0])))
 		return;
 	if (dep && (FindSkill(dep) == NULL)) return;
 	if (lev < 0) return;
@@ -182,7 +182,7 @@ void Game::ModifyItemProductionOutput(int it, int months, int count)
 void Game::ModifyItemProductionInput(int it, int i, int input, int amount)
 {
 	if (it < 0 || it > (NITEMS-1)) return;
-	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].pInput)/sizeof(Materials)))
+	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].pInput)/sizeof(ItemDefs[it].pInput[0])))
 		return;
 	if (input < -1 || input > (NITEMS-1)) return;
 	if (amount < 0) amount = 0;
@@ -208,7 +208,7 @@ void Game::ModifyItemMagicOutput(int it, int count)
 void Game::ModifyItemMagicInput(int it, int i, int input, int amount)
 {
 	if (it < 0 || it > (NITEMS-1)) return;
-	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].mInput)/sizeof(Materials)))
+	if (i < 0 || i >= (int)(sizeof(ItemDefs[it].mInput)/sizeof(ItemDefs[it].mInput[0])))
 		return;
 	if (input < -1 || input > (NITEMS-1)) return;
 	if (amount < 0) amount = 0;
@@ -515,10 +515,10 @@ void Game::ClearTerrainRaces(int t)
 {
 	if (t < 0 || t > R_NUM-1) return;
 	unsigned int c;
-	for (c = 0; c < sizeof(TerrainDefs[t].races)/sizeof(int); c++) {
+	for (c = 0; c < sizeof(TerrainDefs[t].races)/sizeof(TerrainDefs[t].races[0]); c++) {
 		TerrainDefs[t].races[c] = -1;
 	}
-	for (c = 0; c < sizeof(TerrainDefs[t].coastal_races)/sizeof(int); c++) {
+	for (c = 0; c < sizeof(TerrainDefs[t].coastal_races)/sizeof(TerrainDefs[t].coastal_races[0]); c++) {
 		TerrainDefs[t].coastal_races[c] = -1;
 	}
 }
@@ -526,7 +526,7 @@ void Game::ClearTerrainRaces(int t)
 void Game::ModifyTerrainRace(int t, int i, int r)
 {
 	if (t < 0 || t > (R_NUM -1)) return;
-	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].races)/sizeof(int))) return;
+	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].races)/sizeof(TerrainDefs[t].races[0]))) return;
 	if (r < -1 || r > NITEMS-1) r = -1;
 	if (r != -1 && !(ItemDefs[r].type & IT_MAN)) r = -1;
 	TerrainDefs[t].races[i] = r;
@@ -535,7 +535,7 @@ void Game::ModifyTerrainRace(int t, int i, int r)
 void Game::ModifyTerrainCoastRace(int t, int i, int r)
 {
 	if (t < 0 || t > (R_NUM -1)) return;
-	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].coastal_races)/sizeof(int)))
+	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].coastal_races)/sizeof(TerrainDefs[t].coastal_races[0])))
 		return;
 	if (r < -1 || r > NITEMS-1) r = -1;
 	if (r != -1 && !(ItemDefs[r].type & IT_MAN)) r = -1;
@@ -547,7 +547,7 @@ void Game::ClearTerrainItems(int terrain)
 	if (terrain < 0 || terrain > R_NUM-1) return;
 
 	for (unsigned int c = 0;
-			c < sizeof(TerrainDefs[terrain].prods)/sizeof(Product);
+			c < sizeof(TerrainDefs[terrain].prods)/sizeof(TerrainDefs[terrain].prods[0]);
 			c++) {
 		TerrainDefs[terrain].prods[c].product = -1;
 		TerrainDefs[terrain].prods[c].chance = 0;
@@ -558,7 +558,7 @@ void Game::ClearTerrainItems(int terrain)
 void Game::ModifyTerrainItems(int terrain, int i, int p, int c, int a)
 {
 	if (terrain < 0 || terrain > (R_NUM -1)) return;
-	if (i < 0 || i >= (int)(sizeof(TerrainDefs[terrain].prods)/sizeof(Product)))
+	if (i < 0 || i >= (int)(sizeof(TerrainDefs[terrain].prods)/sizeof(TerrainDefs[terrain].prods[0])))
 		return;
 	if (p < -1 || p > NITEMS-1) p = -1;
 	if (c < 0 || c > 100) c = 0;
@@ -592,7 +592,7 @@ void Game::ModifyTerrainLairChance(int t, int chance)
 void Game::ModifyTerrainLair(int t, int i, int l)
 {
 	if (t < 0 || t > (R_NUM -1)) return;
-	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].lairs)/sizeof(int))) return;
+	if (i < 0 || i >= (int)(sizeof(TerrainDefs[t].lairs)/sizeof(TerrainDefs[t].lairs[0]))) return;
 	if (l < -1 || l > NOBJECTS-1) l = -1;
 	TerrainDefs[t].lairs[i] = l;
 }

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -945,7 +945,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 		// Figure out the max we can produce based on the inputs
 		int count = 0;
 		unsigned int c;
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[ship].pInput[c].item;
 			if (i != -1)
 				count += u->GetSharedNum(i) / ItemDefs[ship].pInput[c].amt;
@@ -966,7 +966,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 		r->improvement += count;
 
 		// Deduct the items spent
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[ship].pInput[c].item;
 			int a = ItemDefs[ship].pInput[c].amt;
 			if (i != -1) {
@@ -984,7 +984,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 	else {
 		// Figure out the max we can produce based on the inputs
 		unsigned int c;
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[ship].pInput[c].item;
 			if (i != -1) {
 				int amt = u->GetSharedNum(i);
@@ -1006,7 +1006,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 		r->improvement += maxproduced;
 		
 		// Deduct the items spent
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[ship].pInput[c].item;
 			int a = ItemDefs[ship].pInput[c].amt;
 			if (i != -1) {
@@ -1105,7 +1105,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 		// Figure out the max we can produce based on the inputs
 		int count = 0;
 		unsigned int c;
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[o->item].pInput[c].item;
 			if (i != -1)
 				count += u->GetSharedNum(i) / ItemDefs[o->item].pInput[c].amt;
@@ -1118,7 +1118,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 		r->improvement += count;
 
 		// Deduct the items spent
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[o->item].pInput[c].item;
 			int a = ItemDefs[o->item].pInput[c].amt;
 			if (i != -1) {
@@ -1136,7 +1136,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 	else {
 		// Figure out the max we can produce based on the inputs
 		unsigned int c;
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[o->item].pInput[c].item;
 			if (i != -1) {
 				int amt = u->GetSharedNum(i);
@@ -1150,7 +1150,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 		r->improvement += maxproduced;
 		
 		// Deduct the items spent
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(Materials); c++) {
+		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[o->item].pInput[c].item;
 			int a = ItemDefs[o->item].pInput[c].amt;
 			if (i != -1) {

--- a/neworigins/map.cpp
+++ b/neworigins/map.cpp
@@ -2588,14 +2588,11 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				if (!nreg) continue;
 				while((ctr++ < 20) && (reg->race == -1)) {
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
-						int rnum =
-							sizeof(TerrainDefs[nreg->type].coastal_races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
+							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
 						
-						while ( reg->race == -1 || 
-								(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
-							reg->race = 
-								TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
+						while (reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
 						}
 					} else {
@@ -2607,10 +2604,9 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				}
 			} else {
 				// setup noncoastal race here
-				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(int);
+				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
 				
-				while ( reg->race == -1 || 
-						(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
@@ -2650,16 +2646,13 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 					if ((!nreg) || (nreg->race != -1)) continue;
 					int iscoastal = 0;
 					int cnum = sizeof(TerrainDefs[reg->type].coastal_races) /
-						sizeof(int);
+						sizeof(TerrainDefs[reg->type].coastal_races[0]);
 					for (int i=0; i<cnum; i++) {
-						if (reg->race ==
-								TerrainDefs[reg->type].coastal_races[i])
+						if (reg->race == TerrainDefs[reg->type].coastal_races[i])
 							iscoastal = 1;
 					}
 					// Only coastal races may pass from sea to land
-					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) &&
-							(!iscoastal))
-						continue;
+					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) && (!iscoastal)) continue;
 
 					int ch = getrandom(5);
 					if (iscoastal) {
@@ -2669,8 +2662,7 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 						ManType *mt = FindRace(ItemDefs[reg->race].abr);
 						if (mt->terrain==TerrainDefs[nreg->type].similar_type)
 							ch += 2;
-						int rnum = sizeof(TerrainDefs[nreg->type].races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].races) / sizeof(TerrainDefs[nreg->type].races[0]);
 						for (int i=0; i<rnum; i++) {
 							if (TerrainDefs[nreg->type].races[i] == reg->race)
 								ch++;

--- a/npc.cpp
+++ b/npc.cpp
@@ -322,16 +322,14 @@ Unit *Game::MakeManUnit(Faction *fac, int mantype, int num, int level, int weapo
 	int scomb = men->defaultlevel;
 	int sxbow = men->defaultlevel;
 	int slbow = men->defaultlevel;
-	for (unsigned int i=0;
-		i<(sizeof(men->skills)/sizeof(men->skills[0]));
-			i++) {
-				if (men->skills[i] == NULL) continue;
-				if (FindSkill(men->skills[i]) == FindSkill("COMB"))
-					scomb = men->speciallevel;
-				if (FindSkill(men->skills[i]) == FindSkill("XBOW"))
-					sxbow = men->speciallevel;
-				if (FindSkill(men->skills[i]) == FindSkill("LBOW"))
-					slbow = men->speciallevel;
+	for (unsigned int i=0; i<(sizeof(men->skills)/sizeof(men->skills[0])); i++) {
+		if (men->skills[i] == NULL) continue;
+		if (FindSkill(men->skills[i]) == FindSkill("COMB"))
+			scomb = men->speciallevel;
+		if (FindSkill(men->skills[i]) == FindSkill("XBOW"))
+			sxbow = men->speciallevel;
+		if (FindSkill(men->skills[i]) == FindSkill("LBOW"))
+			slbow = men->speciallevel;
 	}
 	int combat = scomb;
 	AString *s = new AString("COMB");
@@ -435,9 +433,7 @@ Unit *Game::MakeManUnit(Faction *fac, int mantype, int num, int level, int weapo
 		sk = LookupSkill(ws1);
 	int maxskill = men->defaultlevel;
 	int special = 0;
-	for (unsigned int i=0;
-		i<(sizeof(men->skills)/sizeof(men->skills[0]));
-		i++) {
+	for (unsigned int i=0; i<(sizeof(men->skills)/sizeof(men->skills[0])); i++) {
 		if (FindSkill(men->skills[i]) == FindSkill(SkillDefs[sk].abbr)) {
 			special = 1;
 		}		

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -277,7 +277,8 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 		return;
 	}
 
-	AList *seers = CanSeeSteal(r, u);
+	// Make sure we dispose of the allocated AList properly until we get rid of ALists entirely
+	std::unique_ptr<AList> seers(CanSeeSteal(r, u));
 	int succ = 1;
 	forlist(seers) {
 		Faction *f = ((FactionPtr *) elem)->ptr;
@@ -350,7 +351,8 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 		return;
 	}
 
-	AList *seers = CanSeeSteal(r, u);
+	// Make sure we dispose of the allocated AList properly until we get rid of alists entirely.
+	std::unique_ptr<AList> seers(CanSeeSteal(r, u)); 
 	int succ = 1;
 	forlist(seers) {
 		Faction *f = ((FactionPtr *) elem)->ptr;

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -1696,8 +1696,7 @@ void Game::DoBuy(ARegion *r, Market *m)
 							int exp = mt->speciallevel - mt->defaultlevel;
 							if (exp > 0) {
 								exp = exp * temp * GetDaysByLevel(1);
-								for (int ms = 0; ms < ((int) sizeof(mt->skills))/((int) sizeof(int)); ms++)
-								{
+								for (int ms = 0; ms < (int)(sizeof(mt->skills)/sizeof(mt->skills[0])); ms++) {
 									AString sname = mt->skills[ms];
 									int skill = LookupSkill(&sname);
 									if (skill == -1) continue;

--- a/skillshows.cpp
+++ b/skillshows.cpp
@@ -1501,7 +1501,7 @@ AString *ShowSkill::Report(Faction *f) const
 		if (sk1 == sk2 && ItemDefs[i].pLevel == level) {
 			int canmake = 1;
 			int resource = 1;
-			for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(Materials); c++) {
+			for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(ItemDefs[i].pInput[0]); c++) {
 				if (ItemDefs[i].pInput[c].item == -1) continue;
 				resource = 0;
 				if (ITEM_DISABLED(ItemDefs[i].pInput[c].item)) {
@@ -1523,7 +1523,7 @@ AString *ShowSkill::Report(Faction *f) const
 		sk2 = FindSkill(ItemDefs[i].mSkill);
 		if (sk1 == sk2 && ItemDefs[i].mLevel == level) {
 			int canmagic = 1;
-			for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(Materials); c++) {
+			for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(ItemDefs[i].mInput[0]); c++) {
 				if (ItemDefs[i].mInput[c].item == -1) continue;
 				if (ITEM_DISABLED(ItemDefs[i].mInput[c].item)) {
 					canmagic = 0;
@@ -1572,7 +1572,7 @@ AString *ShowSkill::Report(Faction *f) const
 				temp2 += ItemDefs[i].abr;
 				temp2 += "] via magic";
 				count = 0;
-				for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(Materials); c++) {
+				for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(ItemDefs[i].mInput[0]); c++) {
 					if (ItemDefs[i].mInput[c].item == -1) continue;	
 					count++;
 				}
@@ -1580,7 +1580,7 @@ AString *ShowSkill::Report(Faction *f) const
 					temp2 += " at a cost of ";
 					temp4 = "";
 					count = 0;
-					for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(Materials); c++) {
+					for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(ItemDefs[i].mInput[0]); c++) {
 						if (ItemDefs[i].mInput[c].item == -1) continue;	
 						if (!(temp4 == "")) {
 							if (count > 0)
@@ -1588,8 +1588,7 @@ AString *ShowSkill::Report(Faction *f) const
 							temp2 += temp4;
 							count++;
 						}
-						temp4 = ItemString(ItemDefs[i].mInput[c].item,
-								ItemDefs[i].mInput[c].amt);
+						temp4 = ItemString(ItemDefs[i].mInput[c].item, ItemDefs[i].mInput[c].amt);
 					}
 					if (count > 0)
 						temp2 += " and ";
@@ -1604,7 +1603,7 @@ AString *ShowSkill::Report(Faction *f) const
 		if (sk1 == sk2 && ItemDefs[i].pLevel == level) {
 			int canmake = 1;
 			int resource = 1;
-			for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(Materials); c++) {
+			for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(ItemDefs[i].pInput[0]); c++) {
 				if (ItemDefs[i].pInput[c].item == -1) continue;
 				resource = 0;
 				if (ITEM_DISABLED(ItemDefs[i].pInput[c].item)) {
@@ -1648,7 +1647,7 @@ AString *ShowSkill::Report(Faction *f) const
 						temp1 += "any of ";
 					temp4 = "";
 					count = 0;
-					for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(Materials); c++) {
+					for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(ItemDefs[i].pInput[0]); c++) {
 						if (ItemDefs[i].pInput[c].item == -1) continue;	
 						if (!(temp4 == "")) {
 							if (count > 0)
@@ -1814,7 +1813,7 @@ AString *ShowSkill::Report(Faction *f) const
 		comma = 0;
 		int found = 0;
 		temp = "This skill requires ";
-		for (c=0; c<sizeof(SkillDefs[skill].depends)/sizeof(SkillDepend); c++) {
+		for (c=0; c<sizeof(SkillDefs[skill].depends)/sizeof(SkillDefs[skill].depends[0]); c++) {
 			SkillType *pS = FindSkill(SkillDefs[skill].depends[c].skill);
 			if (!pS || (pS->flags & SkillType::DISABLED)) continue;
 			found = 1;

--- a/spells.cpp
+++ b/spells.cpp
@@ -958,7 +958,7 @@ int Game::RunEnchant(ARegion *r,Unit *u, int skill, int item)
 	num = max;
 
 	// Figure out how many we can make based on available resources
-	for (c=0; c<sizeof(ItemDefs[item].mInput)/sizeof(Materials); c++) {
+	for (c=0; c<sizeof(ItemDefs[item].mInput)/sizeof(ItemDefs[item].mInput[0]); c++) {
 		if (ItemDefs[item].mInput[c].item == -1)
 			continue;
 		i = ItemDefs[item].mInput[c].item;
@@ -969,7 +969,7 @@ int Game::RunEnchant(ARegion *r,Unit *u, int skill, int item)
 	}
 
 	// collect all the materials
-	for (c=0; c<sizeof(ItemDefs[item].mInput)/sizeof(Materials); c++) {
+	for (c=0; c<sizeof(ItemDefs[item].mInput)/sizeof(ItemDefs[item].mInput[0]); c++) {
 		if (ItemDefs[item].mInput[c].item == -1)
 			continue;
 		i = ItemDefs[item].mInput[c].item;
@@ -1171,7 +1171,7 @@ int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
 		return 0;
 	}
 	unsigned int c;
-	for (c = 0; c < sizeof(ItemDefs[item].mInput)/sizeof(Materials); c++) {
+	for (c = 0; c < sizeof(ItemDefs[item].mInput)/sizeof(ItemDefs[item].mInput[0]); c++) {
 		if (ItemDefs[item].mInput[c].item == -1) continue;
 		int amt = u->GetSharedNum(ItemDefs[item].mInput[c].item);
 		int cost = ItemDefs[item].mInput[c].amt;
@@ -1182,7 +1182,7 @@ int Game::RunCreateArtifact(ARegion *r,Unit *u,int skill,int item)
 	}
 
 	// Deduct the costs
-	for (c = 0; c < sizeof(ItemDefs[item].mInput)/sizeof(Materials); c++) {
+	for (c = 0; c < sizeof(ItemDefs[item].mInput)/sizeof(ItemDefs[item].mInput[0]); c++) {
 		if (ItemDefs[item].mInput[c].item == -1) continue;
 		int cost = ItemDefs[item].mInput[c].amt;
 		u->ConsumeShared(ItemDefs[item].mInput[c].item, cost);

--- a/standard/map.cpp
+++ b/standard/map.cpp
@@ -911,14 +911,11 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				if (!nreg) continue;
 				while((ctr++ < 20) && (reg->race == -1)) {
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
-						int rnum =
-							sizeof(TerrainDefs[nreg->type].coastal_races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
+							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
 						
-						while ( reg->race == -1 || 
-								(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
-							reg->race = 
-								TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
+						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
 						}
 					} else {
@@ -930,10 +927,9 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				}
 			} else {
 				// setup noncoastal race here
-				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(int);
+				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
 				
-				while ( reg->race == -1 || 
-						(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
+				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
@@ -973,16 +969,13 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 					if ((!nreg) || (nreg->race != -1)) continue;
 					int iscoastal = 0;
 					int cnum = sizeof(TerrainDefs[reg->type].coastal_races) /
-						sizeof(int);
+						sizeof(TerrainDefs[reg->type].coastal_races[0]);
 					for (int i=0; i<cnum; i++) {
-						if (reg->race ==
-								TerrainDefs[reg->type].coastal_races[i])
+						if (reg->race == TerrainDefs[reg->type].coastal_races[i])
 							iscoastal = 1;
 					}
 					// Only coastal races may pass from sea to land
-					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) &&
-							(!iscoastal))
-						continue;
+					if ((TerrainDefs[nreg->type].similar_type == R_OCEAN) && (!iscoastal)) continue;
 
 					int ch = getrandom(5);
 					if (iscoastal) {
@@ -992,8 +985,7 @@ void ARegionList::GrowRaces(ARegionArray *pArr)
 						ManType *mt = FindRace(ItemDefs[reg->race].abr);
 						if (mt->terrain==TerrainDefs[nreg->type].similar_type)
 							ch += 2;
-						int rnum = sizeof(TerrainDefs[nreg->type].races) /
-							sizeof(int);
+						int rnum = sizeof(TerrainDefs[nreg->type].races) / sizeof(TerrainDefs[nreg->type].races[0]);
 						for (int i=0; i<rnum; i++) {
 							if (TerrainDefs[nreg->type].races[i] == reg->race)
 								ch++;

--- a/unit.cpp
+++ b/unit.cpp
@@ -1318,8 +1318,7 @@ int Unit::GetAvailSkill(int sk)
 		str = ItemDefs[i->type].grantSkill;
 		if (ItemDefs[i->type].grantSkill && LookupSkill(&str) == sk) {
 			int grant = 0;
-			for (unsigned j = 0; j < sizeof(ItemDefs[0].fromSkills)
-								 / sizeof(ItemDefs[0].fromSkills[0]); j++) {
+			for (unsigned j = 0; j < sizeof(ItemDefs[0].fromSkills) / sizeof(ItemDefs[0].fromSkills[0]); j++) {
 				if (ItemDefs[i->type].fromSkills[j]) {
 					int fromSkill;
 
@@ -1411,7 +1410,7 @@ int Unit::CanStudy(int sk)
 	if (SkillDefs[sk].flags & SkillType::DISABLED) return 0;
 
 	unsigned int c;
-	for (c = 0; c < sizeof(SkillDefs[sk].depends)/sizeof(SkillDepend); c++) {
+	for (c = 0; c < sizeof(SkillDefs[sk].depends)/sizeof(SkillDefs[sk].depends[0]); c++) {
 		if (SkillDefs[sk].depends[c].skill == NULL) return 1;
 		SkillType *pS = FindSkill(SkillDefs[sk].depends[c].skill);
 		if (pS && (pS->flags & SkillType::DISABLED)) continue;
@@ -1520,8 +1519,7 @@ int Unit::Practice(int sk)
 				continue;
 			str = ItemDefs[it->type].grantSkill;
 			if (ItemDefs[it->type].grantSkill && LookupSkill(&str) == sk) {
-				for (unsigned j = 0; j < sizeof(ItemDefs[0].fromSkills)
-									 / sizeof(ItemDefs[0].fromSkills[0]); j++) {
+				for (unsigned j = 0; j < sizeof(ItemDefs[0].fromSkills) / sizeof(ItemDefs[0].fromSkills[0]); j++) {
 					if (ItemDefs[it->type].fromSkills[j]) {
 						int fromSkill;
 
@@ -1551,7 +1549,7 @@ int Unit::Practice(int sk)
 	curlev = GetRealSkill(sk);
 	if (curlev >= max) return 0;
 
-	for (i = 0; i < sizeof(SkillDefs[sk].depends)/sizeof(SkillDepend); i++) {
+	for (i = 0; i < sizeof(SkillDefs[sk].depends)/sizeof(SkillDefs[sk].depends[0]); i++) {
 		AString skname = SkillDefs[sk].depends[i].skill;
 		reqsk = LookupSkill(&skname);
 		if (reqsk == -1) break;
@@ -2746,7 +2744,7 @@ void Unit::SkillStarvation()
 			Skill *sj = GetSkillObject(j);
 			int dependancy_level = 0;
 			unsigned int c;
-			for (c=0;c < sizeof(SkillDefs[i].depends)/sizeof(SkillDepend);c++) {
+			for (c=0;c < sizeof(SkillDefs[i].depends)/sizeof(SkillDefs[i].depends[0]);c++) {
 				AString skname = SkillDefs[i].depends[c].skill;
 				if (skname == SkillDefs[j].abbr) {
 					dependancy_level = SkillDefs[i].depends[c].level;


### PR DESCRIPTION
* Fix a memory leak in Do1Assinate and Do1Steal
   * Identified by @ennorehling in Issue #22
*  Fix iterations on static arrays
   * Identified by @ennorehling in Issue #21
   * A lot of the code iterated over fixed static arrays in classes by assuming the type of the element.  If the element changed (as likely happened at some point from int to a char * for ManType.skills) we could end up doing bad things.  The one notably problematic case was fortunately under a global which is rarely enabled so it never caused crashed.  I changed/audited all instances of sizeof(somearray)/sizeof(...) to make sure it was always dividing by the sizeof the first element of the arrary.  This guarantees correctness even if a type changes to a promotable type. (non-promotable types would be caught by the compiler)
* Fix a number of bad array bounds checks
   * Identified by @ennorehling  in Issues #18, #19 and #20
   * Many of the functions in modify.cpp had checks which were just wrong and could lead to writes to random  memory or crashes.  Modified all functions to compare to the >= actual size of array being indexed.
* Fix a bogus comparison in TownHabitate
   * Found by @danextpope in Issue #10 
   * While the function in question (to add a town/habitat) was only called during setup, the code was still wrong.  It was comparing ItemDefs.flags to a value from the ItemDefs.type field.  If we ever modify something so that towns can form later in the game this would have broken.
