### PR TITLE
Add ruleset specific move rules/fix start location handling

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -2588,6 +2588,54 @@ ARegion *ARegionArray::GetRegion(int xx, int yy)
 	return(regions[xx / 2 + yy * x / 2]);
 }
 
+std::vector<ARegion *> ARegionArray::get_starting_region_candidates(int terrain) {
+	ARegionGraph graph = ARegionGraph(this);
+	graph.setInclusion([](ARegion *current, ARegion *next) { return next->type != R_OCEAN; });
+
+	std::vector<ARegion *> candidates;
+	for (int x2 = 0; x2 < x; x2++) {
+		for (int y2 = 0; y2 < y; y2++) {
+			ARegion *reg = GetRegion(x2, y2);
+			if (!reg) continue;
+			if (reg->type != terrain) continue;
+
+			graphs::Location2D loc = { reg->xloc, reg->yloc };
+			auto result = graphs::breadthFirstSearch(graph, loc, 2);
+			// if hex is part of a landmass smaller than 10 hexes within 2 moves, skip it
+			if (result.size() < 10) continue;
+			// Now, check for the required items
+			std::map<int, bool> requiredItems = {
+				{I_WOOD, false},
+				{I_IRON, false},
+				{I_STONE, false},
+				{I_GRAIN, false},
+				{I_LIVESTOCK, false},
+				{I_HORSE, false},
+				{I_CAMEL, false}
+			};
+			for (auto &kv : result) {
+				ARegion *tReg = graph.get(kv.first);
+				if (tReg->produces_item(I_WOOD)) requiredItems[I_WOOD] = true;
+				if (tReg->produces_item(I_IRON)) requiredItems[I_IRON] = true;
+				if (tReg->produces_item(I_STONE)) requiredItems[I_STONE] = true;
+				if (tReg->produces_item(I_GRAIN)) requiredItems[I_GRAIN] = true;
+				if (tReg->produces_item(I_LIVESTOCK)) requiredItems[I_LIVESTOCK] = true;
+				if (tReg->produces_item(I_HORSE)) requiredItems[I_HORSE] = true;
+				if (tReg->produces_item(I_CAMEL)) requiredItems[I_CAMEL] = true;
+			}
+			if (requiredItems[I_WOOD] == false) continue;
+			if (requiredItems[I_IRON] == false) continue;
+			if (requiredItems[I_STONE] == false) continue;
+			if (requiredItems[I_GRAIN] == false && requiredItems[I_LIVESTOCK] == false) continue;
+			if (requiredItems[I_HORSE] == false && requiredItems[I_CAMEL] == false) continue;
+
+			candidates.push_back(reg);
+		}
+	}
+
+	return candidates;
+}
+
 void ARegionArray::SetName(char const *name)
 {
 	if (name) {

--- a/aregion.h
+++ b/aregion.h
@@ -297,6 +297,9 @@ class ARegion : public AListElem
 		AString WagesForReport();
 		int Population();
 
+		// ruleset specific movment checks
+		bool movement_forbidden_by_ruleset(Unit *unit, ARegion *origin);
+
 		AString *name;
 		int num;
 		int type;
@@ -392,6 +395,8 @@ class ARegionArray
 		void SetRegion(int, int, ARegion *);
 		ARegion *GetRegion(int, int);
 		void SetName(char const *name);
+
+		std::vector<ARegion *> get_starting_region_candidates(int terrain);
 
 		int x;
 		int y;

--- a/basic/extra.cpp
+++ b/basic/extra.cpp
@@ -186,3 +186,4 @@ void Game::ModifyTablesPerRuleset(void)
 	return;
 }
 
+bool ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin) { return false; }

--- a/fracas/extra.cpp
+++ b/fracas/extra.cpp
@@ -569,3 +569,5 @@ void Game::ModifyTablesPerRuleset(void)
 
 	return;
 }
+
+bool ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin) { return false; }

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -1195,3 +1195,5 @@ void Game::ModifyTablesPerRuleset(void)
 	}
 	return;
 }
+
+bool ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin) { return false; }

--- a/kingdoms/extra.cpp
+++ b/kingdoms/extra.cpp
@@ -191,3 +191,5 @@ void Game::ModifyTablesPerRuleset(void)
 	ModifyItemProductionBooster(I_AXE, I_HAMMER, 1);
 	return;
 }
+
+bool ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin) { return false; }

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -1312,3 +1312,8 @@ void Game::ModifyTablesPerRuleset(void)
 
 	return;
 }
+
+
+bool ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin) {
+	return false;
+}

--- a/neworigins/map.cpp
+++ b/neworigins/map.cpp
@@ -2961,50 +2961,9 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 
 				// First, we need to find the candidates
 				ARegionArray *to = GetRegionArray(levelTo);
-				ARegionGraph graph = ARegionGraph(to);
-				graph.setInclusion([](ARegion *current, ARegion *next) { return next->type != R_OCEAN; });
-
 				std::map<int, std::vector<ARegion *> > candidates;
 				for (int type = R_PLAIN; type <= R_TUNDRA; type++) {
-					for (int x2 = 0; x2 < maxX; x2++) {
-						for (int y2 = 0; y2 < maxY; y2++) {
-							ARegion *reg = to->GetRegion(x2, y2);
-							if (!reg) continue;
-							if (reg->type == type) {
-								graphs::Location2D loc = { reg->xloc, reg->yloc };
-								auto result = graphs::breadthFirstSearch(graph, loc, 2);
-								// if hex is part of a landmass smaller than 10 hexes within 3 moves, skip it
-								if (result.size() < 10) continue;
-								// Now, check for the required items
-								std::map<int, bool> requiredItems = {
-									{I_WOOD, false},
-									{I_IRON, false},
-									{I_STONE, false},
-									{I_GRAIN, false},
-									{I_LIVESTOCK, false},
-									{I_HORSE, false},
-									{I_CAMEL, false}
-								};
-								for (auto &kv : result) {
-									ARegion *tReg = graph.get(kv.first);
-									if (tReg->produces_item(I_WOOD)) requiredItems[I_WOOD] = true;
-									if (tReg->produces_item(I_IRON)) requiredItems[I_IRON] = true;
-									if (tReg->produces_item(I_STONE)) requiredItems[I_STONE] = true;
-									if (tReg->produces_item(I_GRAIN)) requiredItems[I_GRAIN] = true;
-									if (tReg->produces_item(I_LIVESTOCK)) requiredItems[I_LIVESTOCK] = true;
-									if (tReg->produces_item(I_HORSE)) requiredItems[I_HORSE] = true;
-									if (tReg->produces_item(I_CAMEL)) requiredItems[I_CAMEL] = true;
-								}
-								if (requiredItems[I_WOOD] == false) continue;
-								if (requiredItems[I_IRON] == false) continue;
-								if (requiredItems[I_STONE] == false) continue;
-								if (requiredItems[I_GRAIN] == false && requiredItems[I_LIVESTOCK] == false) continue;
-								if (requiredItems[I_HORSE] == false && requiredItems[I_CAMEL] == false) continue;
-
-								candidates[type].push_back(reg);
-							}
-						}
-					}
+					candidates[type] = to->get_starting_region_candidates(type);
 				}
 				// Now for each type, choose a random candidate
 				std::mt19937 gen{std::random_device{}()}; // generates random numbers

--- a/standard/extra.cpp
+++ b/standard/extra.cpp
@@ -226,3 +226,5 @@ void Game::ModifyTablesPerRuleset(void)
 	ModifyItemProductionBooster(I_AXE, I_HAMMER, 1);
 	return;
 }
+
+bool ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin) { return false; }

--- a/unittest/extra.cpp
+++ b/unittest/extra.cpp
@@ -73,3 +73,5 @@ void Game::ModifyTablesPerRuleset(void) {
 		EnableObject(O_CARAVANSERAI);
 	}
 }
+
+bool ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin) { return false; }


### PR DESCRIPTION
This commit does 2 things
* It adds a ruleset specific move function so that a ruleset can deny a specific move (this will be used as part of NO7 victory condition/prelim checking)
* It makes the nexus gateways utilize the same logic for making sure a candidate location is 'viable'. The nexus setup code still spreads the portal 'targets' across the world even though that's not needed. The move code for nexus will now pick candidates which are close enough to resources and the continues to use the same filtering of cities, guarded cities, cities with others, empty hexes, any hexes and then chooses randomly among those.