### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: make all-clean && make all
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}
           path: |
@@ -43,7 +43,7 @@ jobs:
     needs: compile
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ubuntu
       - run: ./run-snapshots.sh


### PR DESCRIPTION
The @v3 versions are deprecated.  The @v4 versions are the right ones to use now.