### PR TITLE
An iterator for AList

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+[package.json]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/alist.cpp
+++ b/alist.cpp
@@ -165,3 +165,13 @@ int AList::NextLive(AListElem **copy, int size, int pos)
 	}
 	return pos;
 }
+
+AList::iterator AList::begin() const
+{
+    return AList::iterator(this->list);
+}
+
+AList::iterator AList::end() const
+{
+    return AList::iterator();
+}


### PR DESCRIPTION
The `forlist` macro comes from when there were no iterators. `AList` is a custom container that needs to be replaced with std containers, but the amount of work is immense. Therefore I have added iterator interface (begin and end) methods so that modern `for (var item : iterator)` syntax can be used in the code. It will allow the removal of the `forlist` macro from the codebase over time.

## New API
`AList::begin` - iterator for the beginning of the list
`AList::end` - iterator for the end of the list
`AList::iter<T>` - allows for strongly typed iteration over the `AList`

## Improvements

1. Will allow the use of modern C++ `for` loop syntax.
2. All iterator-based APIs from `std` namespace will work on `AList` instances.