### PR TITLE
Uniquely name barren water in terrain

### DIFF
--- a/gamedata.cpp
+++ b/gamedata.cpp
@@ -4978,7 +4978,7 @@ static TerrainType td[] = {
 	 {-1,-1,-1},
 	 0,-1,-1,-1,
 	 0,{-1,-1,-1,-1,-1,-1}},
-	{"ocean", "ocean", "barrenocean", '-', R_OCEAN,
+	{"deadwater", "deadwater", "barrenocean", '-', R_OCEAN,
 	 TerrainType::BARREN | TerrainType::FLYINGMOUNTS | TerrainType::ANNIHILATED,
 	 0,0,0,1,
 	 {{-1,0,0},{-1,0,0},{-1,0,0},{-1,0,0},

--- a/text_report_generator.cpp
+++ b/text_report_generator.cpp
@@ -133,6 +133,10 @@ const map<const string, const array<string, 2>> TextReportGenerator::terrain_fil
     { "barren", {
         "  * * ",
         " * *  " }
+    },
+    { "deadwater", {
+        "  ~ ~ ",
+        " ~ ~  " }
     }
 };
 


### PR DESCRIPTION
This will allow players to see what land has been annhilated more easily.