### PR TITLE
Require the form alias to be strictly numeric

### DIFF
--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -2724,10 +2724,14 @@ Unit *Game::ProcessFormOrder(Unit *former, AString *o, OrdersCheck *pCheck, int 
 		return 0;
 	}
 
-	int an = t->value();
+	int an = t->strict_value();
 	delete t;
 	if (!an) {
 		parse_error(pCheck, former, 0, "Must give alias in FORM order.");
+		return 0;
+	}
+	if (an == -1) {
+		parse_error(pCheck, former, 0, "Invalid alias in FORM order.");
 		return 0;
 	}
 	if (pCheck) {


### PR DESCRIPTION
Currently if you do
FORM 1a
END
FORM 1b
END

The checker accepts it but it doesn't work correctly as you end up with errors about multiply defined aliases during the run.