### PR TITLE
Fix Form alias parsing misbehavior

### DIFF
--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -2724,10 +2724,14 @@ Unit *Game::ProcessFormOrder(Unit *former, AString *o, OrdersCheck *pCheck, int 
 		return 0;
 	}
 
-	int an = t->value();
+	int an = t->strict_value();
 	delete t;
 	if (!an) {
 		parse_error(pCheck, former, 0, "Must give alias in FORM order.");
+		return 0;
+	}
+	if (an == -1) {
+		parse_error(pCheck, former, 0, "Invalid alias in FORM order.");
 		return 0;
 	}
 	if (pCheck) {


### PR DESCRIPTION
In the current game, when checking the orders, it merely checks that the alias *starts* with a number, but forms like the following

FORM 1a
FORM 1b

etc

would be allowed and would not error during the checker but would
during the run.   This makes them error during the checker phase as
well.