### PR TITLE
Fix treasury off-by-one error

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -2186,18 +2186,17 @@ void Game::WriteTimesArticle(AString article)
 
 void Game::CountItems(size_t ** citems)
 {
-	int i = 0;
 	forlist (&factions)
 	{
 		Faction * fac = (Faction *) elem;
 		if (!fac->is_npc)
 		{
+			int i = fac->num - 1; // faction numbers are 1-based
 			for (int j = 0; j < NITEMS; j++)
 			{
 				citems[i][j] = CountItem (fac, j);
 			}
 		}
-		i++;
 	}
 }
 


### PR DESCRIPTION
When I redid the treasury handling during the update to json reports, I made count the items once up front rather than doing it each time
through for each faction.   However this led to an untoward bug where
the index into citems was not using the faction id, but the code in the
reports assumed that a factions items would always be at their row in
the output.

The citems array was large enough and accounts for deleted factions already, but it was filling it wrong in CountItems.  This fixes that and fills the row which actually matches the faction being counted.