### PR TITLE
Clean up all uses of AList from lists of Units

### DIFF
--- a/aregion.h
+++ b/aregion.h
@@ -50,6 +50,7 @@ using json = nlohmann::json;
 
 #include <map>
 #include <vector>
+#include <list>
 #include <functional>
 
 /* Weather Types */
@@ -209,8 +210,8 @@ class ARegion : public AListElem
 
 		Unit *GetUnit(int);
 		Unit *GetUnitAlias(int, int); /* alias, faction number */
-		Unit *GetUnitId(UnitId *, int);
-		void DeduplicateUnitList(AList *, int);
+		Unit *get_unit_id(UnitId unitid, int faction);
+		void deduplicate_unit_list(std::list<UnitId>& list, int);
 		Location *GetLocation(UnitId *, int);
 
 		void SetLoc(int, int, int);
@@ -345,7 +346,7 @@ class ARegion : public AListElem
 		AList objects;
 		map<int,int> newfleets;
 		int fleetalias;
-		AList hell; /* Where dead units go */
+		std::vector<Unit *>hell; /* Where dead units go */
 		AList farsees;
 		// List of units which passed through the region
 		AList passers;

--- a/battle.cpp
+++ b/battle.cpp
@@ -760,8 +760,7 @@ void Game::GetDFacs(ARegion * r,Unit * t,AList & facs)
 		// units aren't set to noaid
 		forlist((&r->objects)) {
 			Object * obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit * u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (u->IsAlive()) {
 					if (u->faction == t->faction &&
 						(u->GetFlag(FLAG_NOAID) == 0)) {
@@ -779,8 +778,7 @@ void Game::GetDFacs(ARegion * r,Unit * t,AList & facs)
 	
 	forlist((&r->objects)) {
 		Object * obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit * u = (Unit *) elem;
+		for(auto u: obj->units) {
 			if (u->IsAlive()) {
 				if (u->faction == t->faction ||
 					(AlliesIncluded == 1 && 
@@ -803,8 +801,7 @@ void Game::GetAFacs(ARegion *r, Unit *att, Unit *tar, AList &dfacs,
 {
 	forlist((&r->objects)) {
 		Object * obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit * u = (Unit *) elem;
+		for(auto u: obj->units) {
 			if (u->canattack && u->IsAlive()) {
 				int add = 0;
 				if ((u->faction == att->faction ||
@@ -817,13 +814,11 @@ void Game::GetAFacs(ARegion *r, Unit *att, Unit *tar, AList &dfacs,
 						add = 1;
 					} else {
 						if (u->attackorders) {
-							forlist(&(u->attackorders->targets)) {
-								UnitId * id = (UnitId *) elem;
-								Unit *t = r->GetUnitId(id, u->faction->num);
+							for (auto id = u->attackorders->targets.begin(); id != u->attackorders->targets.end();) {
+								Unit *t = r->get_unit_id(*id, u->faction->num);
 								if (!t) continue;
 								if (t == tar) {
-									u->attackorders->targets.Remove(id);
-									delete id;
+									id = u->attackorders->targets.erase(id);
 								}
 								if (t->faction == tar->faction) add = 1;
 							}
@@ -926,8 +921,7 @@ void Game::GetSides(ARegion *r, AList &afacs, AList &dfacs, AList &atts,
 
 		forlist (&r2->objects) {
 			Object * o = (Object *) elem;
-			forlist (&o->units) {
-				Unit * u = (Unit *) elem;
+			for(auto u: o->units) {
 				int add = 0;
 
 #define ADD_ATTACK 1

--- a/economy.cpp
+++ b/economy.cpp
@@ -821,10 +821,9 @@ void ARegion::AddTown(int size, AString * name)
 	forlist(&objects) {
 		Object *obj = (Object *) elem;
 		if (obj->type == O_DUMMY) continue;
-		if ((ObjectDefs[obj->type].monster != -1)
-			&& (!(ObjectDefs[obj->type].flags & ObjectType::CANENTER))) {
-				obj->units.Empty();
-				objects.Remove(obj);
+		if ((ObjectDefs[obj->type].monster != -1) && (!(ObjectDefs[obj->type].flags & ObjectType::CANENTER))) {
+			obj->units.clear();
+			objects.Remove(obj);
 		}
 	}
 }
@@ -1602,8 +1601,7 @@ void ARegion::PostTurn(ARegionList *pRegs)
 
 	forlist(&objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			u->PostTurn(this);
 		}
 	}

--- a/faction.cpp
+++ b/faction.cpp
@@ -642,8 +642,7 @@ int Faction::CanCatch(ARegion *r, Unit *t)
 
 	forlist(&r->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u == t && o->type != O_DUMMY) return 1;
 			if (u->faction == this && u->GetAttackRiding() >= def) return 1;
 		}
@@ -670,8 +669,7 @@ int Faction::CanSee(ARegion* r, Unit* u, int practice)
 		Object* obj = (Object *) elem;
 		int dummy = 0;
 		if (obj->type == O_DUMMY) dummy = 1;
-		forlist((&obj->units)) {
-			Unit* temp = (Unit *) elem;
+		for(auto temp: obj->units) {
 			if (u == temp && dummy == 0) retval = 1;
 
 			// penalty of 2 to stealth if assassinating and 1 if stealing

--- a/game.cpp
+++ b/game.cpp
@@ -91,8 +91,7 @@ void Game::DefaultWorkOrder()
 		if (r->type == R_NEXUS) continue;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->monthorders || u->faction->is_npc ||
 						(Globals->TAX_PILLAGE_MONTH_LONG &&
 						 u->taxing != TAX_NONE))
@@ -126,7 +125,7 @@ AString Game::GetXtraMap(ARegion *reg,int type)
 			forlist(&reg->objects) {
 				Object *o = (Object *) elem;
 				if (!(ObjectDefs[o->type].flags & ObjectType::CANENTER)) {
-					if (o->units.First()) {
+					if (o->units.size() > 0) {
 						return "*";
 					} else {
 						return ".";
@@ -779,8 +778,7 @@ Unit *Game::ParseGMUnit(AString *tag, Faction *pFac)
 			ARegion *reg = (ARegion *)elem;
 			forlist(&reg->objects) {
 				Object *obj = (Object *)elem;
-				forlist(&obj->units) {
-					Unit *u = (Unit *)elem;
+				for(auto u: obj->units) {
 					if (u->faction->num == pFac->num && u->gm_alias == gma) {
 						return u;
 					}
@@ -1193,8 +1191,7 @@ void Game::ClearOrders(Faction *f)
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->faction == f) {
 					u->ClearOrders();
 				}
@@ -1244,8 +1241,7 @@ void Game::MakeFactionReportLists()
 			forlist(&reg->objects) {
 				Object *obj = (Object *) elem;
 
-				forlist(&obj->units) {
-					Unit *unit = (Unit *) elem;
+				for(auto unit: obj->units) {
 					facs[unit->faction->num] = unit->faction;
 				}
 			}
@@ -1370,8 +1366,7 @@ void Game::SetupUnitSeq()
 		ARegion *r = (ARegion *)elem;
 		forlist(&r->objects) {
 			Object *o = (Object *)elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *)elem;
+			for(auto u: o->units) {
 				if (u && u->num > max) max = u->num;
 			}
 		}
@@ -1396,8 +1391,7 @@ void Game::SetupUnitNums()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				i = u->num;
 				if ((i > 0) && (i < maxppunits)) {
 					if (!ppUnits[i])
@@ -1469,8 +1463,7 @@ void Game::CountAllSpecialists()
 			ARegion *r = (ARegion *) elem;
 			forlist(&r->objects) {
 				Object *o = (Object *) elem;
-				forlist(&o->units) {
-					Unit *u = (Unit *) elem;
+				for(auto u: o->units) {
 					if (u->type == U_MAGE) u->faction->nummages++;
 					if (u->GetSkill(S_QUARTERMASTER))
 						u->faction->numqms++;
@@ -1554,8 +1547,7 @@ int Game::CountMages(Faction *pFac)
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->faction == pFac && u->type == U_MAGE) i++;
 			}
 		}
@@ -1570,8 +1562,7 @@ int Game::CountQuarterMasters(Faction *pFac)
 		ARegion *r = (ARegion *)elem;
 		forlist(&r->objects) {
 			Object *o = (Object *)elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *)elem;
+			for(auto u: o->units) {
 				if (u->faction == pFac && u->GetSkill(S_QUARTERMASTER)) i++;
 			}
 		}
@@ -1586,8 +1577,7 @@ int Game::CountTacticians(Faction *pFac)
 		ARegion *r = (ARegion *)elem;
 		forlist(&r->objects) {
 			Object *o = (Object *)elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *)elem;
+			for(auto u: o->units) {
 				if (u->faction == pFac && u->GetSkill(S_TACTICS) == 5) i++;
 			}
 		}
@@ -1602,8 +1592,7 @@ int Game::CountApprentices(Faction *pFac)
 		ARegion *r = (ARegion *)elem;
 		forlist(&r->objects) {
 			Object *o = (Object *)elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *)elem;
+			for(auto u: o->units) {
 				if (u->faction == pFac && u->type == U_APPRENTICE) i++;
 			}
 		}
@@ -2049,8 +2038,7 @@ void Game::AdjustCityMons(ARegion *r)
 	int needmage = 1;
 	forlist(&r->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->type == U_GUARD || u->type == U_GUARDMAGE) {
 				AdjustCityMon(r, u);
 				/* Don't create new city guards if we have some */
@@ -2208,8 +2196,7 @@ int Game::CountItem (Faction * fac, int item)
 	for (const auto& r : fac->present_regions) {
 		forlist(&r->objects) {
 			Object * obj = (Object *) elem;
-			forlist(&obj->units) {
-				Unit * unit = (Unit *) elem;
+			for(auto unit: obj->units) {
 				if (unit->faction == fac)
 					all += unit->items.GetNum (item);
 			}

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -113,7 +113,6 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 	int d, count, temple, i, j, clash;
 	ARegion *r;
 	Object *o;
-	Unit *u;
 	AString rname;
 	map <string, int> temples;
 	map <string, int>::iterator it;
@@ -143,8 +142,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				continue;
 			forlist(&r->objects) {
 				o = (Object *) elem;
-				forlist(&o->units) {
-					u = (Unit *) elem;
+				for(auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						count++;
 					}
@@ -163,8 +161,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				continue;
 			forlist(&r->objects) {
 				o = (Object *) elem;
-				forlist(&o->units) {
-					u = (Unit *) elem;
+				for(auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						if (!d--) {
 							q->target = u->num;
@@ -357,7 +354,6 @@ Faction *Game::CheckVictory()
 	Item *item;
 	ARegion *r, *start;
 	Object *o;
-	Unit *u;
 	Faction *f;
 	Skill *s;
 	Location *l;
@@ -394,8 +390,7 @@ Faction *Game::CheckVictory()
 		}
 		forlist(&r->objects) {
 			o = (Object *) elem;
-			forlist(&o->units) {
-				u = (Unit *) elem;
+			for(auto u: o->units) {
 				intersection.clear();
 				set_intersection(u->visited.begin(),
 					u->visited.end(),
@@ -598,8 +593,7 @@ Faction *Game::CheckVictory()
 			r = (ARegion *) elem;
 			forlist(&r->objects) {
 				o = (Object *) elem;
-				forlist(&o->units) {
-					u = (Unit *) elem;
+				for(auto u: o->units) {
 					if (u->faction == f) {
 						reliccount += u->items.GetNum(I_RELICOFGRACE);
 					}
@@ -621,8 +615,7 @@ Faction *Game::CheckVictory()
 				r = (ARegion *) elem;
 				forlist(&r->objects) {
 					o = (Object *) elem;
-					forlist(&o->units) {
-						u = (Unit *) elem;
+					for(auto u: o->units) {
 						if (u->faction == f) {
 							units++;
 							forlist(&u->items) {
@@ -651,7 +644,7 @@ Faction *Game::CheckVictory()
 							// but given that the appropriate place for that function is
 							// r->hell, this doesn't seem right given what's happened.
 							// In this case, I'm willing to leak memory :-)
-							o->units.Remove(u);
+							std::erase(o->units, u);
 						}
 					}
 				}

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -148,7 +148,6 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 	int d, count, temple, i, j, clash, reward_count;
 	ARegion *r;
 	Object *o;
-	Unit *u;
 	AString rname;
 	map <string, int> temples;
 	map <string, int>::iterator it;
@@ -221,8 +220,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				continue;
 			forlist(&r->objects) {
 				o = (Object *) elem;
-				forlist(&o->units) {
-					u = (Unit *) elem;
+				for(auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						count++;
 					}
@@ -242,8 +240,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				continue;
 			forlist(&r->objects) {
 				o = (Object *) elem;
-				forlist(&o->units) {
-					u = (Unit *) elem;
+				for(auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						if (!d--) {
 							q->target = u->num;
@@ -455,8 +452,7 @@ int count_entities(ARegionList *regions) {
 			if (o->type == O_EMPOWERED_ALTAR) {
 				count++;
 			}
-			forlist(&o->units) {
-				Unit *u = (Unit *)elem;
+			for(auto u: o->units) {
 				if (u->items.GetNum(I_IMPRISONED_ENTITY) > 0) {
 					count += u->items.GetNum(I_IMPRISONED_ENTITY);
 				}
@@ -475,7 +471,6 @@ Faction *Game::CheckVictory()
 	Quest *q;
 	ARegion *r, *start;
 	Object *o;
-	Unit *u;
 	Location *l;
 	AString message, times, temp;
 	map <string, int> vRegions, uvRegions;
@@ -510,8 +505,7 @@ Faction *Game::CheckVictory()
 		}
 		forlist(&r->objects) {
 			o = (Object *) elem;
-			forlist(&o->units) {
-				u = (Unit *) elem;
+			for(auto u: o->units) {
 				intersection.clear();
 				set_intersection(u->visited.begin(),
 					u->visited.end(),

--- a/npc.cpp
+++ b/npc.cpp
@@ -149,7 +149,7 @@ void Game::GrowLMons(int rate)
 		
 		forlist(&r->objects) {
 			Object *obj = (Object *) elem;
-			if (obj->units.Num()) continue;
+			if (obj->units.size()) continue;
 			int montype = ObjectDefs[obj->type].monster;
 			int grow=!(ObjectDefs[obj->type].flags&ObjectType::NOMONSTERGROWTH);
 			if ((montype != -1) && grow) {

--- a/object.h
+++ b/object.h
@@ -120,7 +120,7 @@ class Object : public AListElem
 
 		Unit *GetUnit(int);
 		Unit *GetUnitAlias(int, int); /* alias, faction number */
-		Unit *GetUnitId(UnitId *, int);
+		Unit *get_unit_id(UnitId *unitid, int);
 
 		// AS
 		int IsRoad();
@@ -166,7 +166,7 @@ class Object : public AListElem
 		int shipno;
 		int movepoints;
 		int destroyed;	// how much points was destroyed so far this turn
-		AList units;
+		std::vector<Unit *> units;
 		AList ships;
 };
 

--- a/orders.h
+++ b/orders.h
@@ -56,6 +56,7 @@ class SacrificeOrder;
 #include "gamedefs.h"
 #include "astring.h"
 #include "alist.h"
+#include <list>
 
 enum {
 	O_ATLANTIS,
@@ -210,7 +211,7 @@ class TeachOrder : public Order {
 		TeachOrder();
 		~TeachOrder();
 
-		AList targets;
+		std::list<UnitId> targets;
 };
 
 class ProduceOrder : public Order {
@@ -247,7 +248,7 @@ class AttackOrder : public Order {
 		AttackOrder();
 		~AttackOrder();
 
-		AList targets;
+		std::list<UnitId> targets;
 };
 
 class BuildOrder : public Order {
@@ -255,7 +256,7 @@ class BuildOrder : public Order {
 		BuildOrder();
 		~BuildOrder();
 
-		UnitId * target;
+		UnitId *target;
 		int new_building;
 		int needtocomplete;
 };
@@ -356,7 +357,7 @@ class TeleportOrder : public CastRegionOrder {
 		~TeleportOrder();
 
 		int gate;
-		AList units;
+		std::list<UnitId> units;
 };
 
 class CastIntOrder : public CastOrder {
@@ -372,7 +373,7 @@ class CastUnitsOrder : public CastOrder {
 		CastUnitsOrder();
 		~CastUnitsOrder();
 
-		AList units;
+		std::list<UnitId> units;
 };
 
 class CastTransmuteOrder : public CastOrder {
@@ -389,7 +390,7 @@ class EvictOrder : public Order {
 		EvictOrder();
 		~EvictOrder();
 
-		AList targets;
+		std::list<UnitId> targets;
 };
 
 class IdleOrder : public Order {

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -1642,7 +1642,8 @@ void Game::ProcessAttackOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	while (id && id->unitnum != -1) {
 		if (!pCheck) {
 			if (!u->attackorders) u->attackorders = new AttackOrder;
-			u->attackorders->targets.Add(id);
+			u->attackorders->targets.push_back(*id);
+			delete id;
 		}
 		id = ParseUnit(o);
 	}
@@ -1812,7 +1813,8 @@ void Game::ProcessTeachOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	while (id && id->unitnum != -1) {
 		students++;
 		if (order) {
-			order->targets.Add(id);
+			order->targets.push_back(*id);
+			delete id;
 		}
 		id = ParseUnit(o);
 	}
@@ -2889,7 +2891,8 @@ void Game::ProcessEvictOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 	while (id && id->unitnum != -1) {
 		if (!pCheck) {
 			if (!u->evictorders) u->evictorders = new EvictOrder;
-			u->evictorders->targets.Add(id);
+			u->evictorders->targets.push_back(*id);
+			delete id;
 		}
 		id = ParseUnit(o);
 	}

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -140,8 +140,7 @@ void Game::ClearCastEffects()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				u->SetFlag(FLAG_INVIS, 0);
 			}
 		}
@@ -154,8 +153,7 @@ void Game::RunCastOrders()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->castorders) {
 					RunACastOrder(r, o, u);
 					delete u->castorders;
@@ -230,8 +228,7 @@ void Game::RunStealOrders()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist_safe(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->stealorders) {
 					if (u->stealorders->type == O_STEAL) {
 						Do1Steal(r, o, u);
@@ -265,7 +262,7 @@ AList *Game::CanSeeSteal(ARegion *r, Unit *u)
 void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 {
 	AssassinateOrder *so = (AssassinateOrder *) u->stealorders;
-	Unit *tar = r->GetUnitId(so->target, u->faction->num);
+	Unit *tar = r->get_unit_id(*(so->target), u->faction->num);
 
 	if (!tar) {
 		u->error("ASSASSINATE: Invalid unit given.");
@@ -342,7 +339,7 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
 void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 {
 	StealOrder *so = (StealOrder *) u->stealorders;
-	Unit *tar = r->GetUnitId(so->target, u->faction->num);
+	Unit *tar = r->get_unit_id(*so->target, u->faction->num);
 
 	if (!tar) {
 		u->error("STEAL: Invalid unit given.");
@@ -446,8 +443,7 @@ void Game::DrownUnits()
 			forlist(&r->objects) {
 				Object *o = (Object *) elem;
 				if (o->type != O_DUMMY) continue;
-				forlist(&o->units) {
-					Unit *u = (Unit *)elem;
+				for(auto u: o->units) {
 					int drown = 0;
 					switch(Globals->FLIGHT_OVER_WATER) {
 						case GameDefs::WFLIGHT_UNLIMITED:
@@ -487,8 +483,7 @@ void Game::RunForgetOrders()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				forlist(&u->forgetorders) {
 					ForgetOrder *fo = (ForgetOrder *) elem;
 					u->ForgetSkill(fo->skill);
@@ -515,8 +510,7 @@ void Game::Do1Quit(Faction *f)
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->faction == f) {
 					r->Kill(u);
 				}
@@ -537,8 +531,7 @@ void Game::RunDestroyOrders()
 					Do1Destroy(r, o, u);
 					continue;
 				} else {
-					forlist(&o->units)
-						((Unit *) elem)->destroy = 0;
+					for(auto u: o->units) u->destroy = 0;
 				}
 			}
 		}
@@ -550,16 +543,14 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 
 	if (TerrainDefs[r->type].similar_type == R_OCEAN) {
 		u->error("DESTROY: Can't destroy a ship while at sea.");
-		forlist(&o->units) {
-			((Unit *) elem)->destroy = 0;
-		}
+		for(auto u1: o->units) u1->destroy = 0;
 		return;
 	}
 
 	if (!u->GetMen()) {
 		u->error("DESTROY: Empty units cannot destroy structures.");
-		forlist(&o->units) {
-			((Unit *) elem)->destroy = 0;
+		for(auto u1: o->units) {
+			u1->destroy = 0;
 		}
 		return;
 	}
@@ -593,8 +584,8 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 		willDestroy = std::min(destroyablePoints, destroyPower);
 		if (willDestroy == 0) {
 			u->error(string("Can't destroy ") + o->name->const_str() + " more.");
-			forlist(&o->units) {
-				((Unit *) elem)->destroy = 0;
+			for(auto u1: o->units) {
+				u1->destroy = 0;
 			}
 
 			return;
@@ -612,8 +603,7 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 			u->event("Destroys " + string(o->name->const_str()) + ".", "destroy");
 	
 			Object *dest = r->GetDummy();
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				u->destroy = 0;
 				u->MoveUnit(dest);
 			}
@@ -627,8 +617,8 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 		}
 	} else {
 		u->error("DESTROY: Can't destroy that.");
-		forlist(&o->units) {
-			((Unit *) elem)->destroy = 0;
+		for(auto u1: o->units) {
+			u1->destroy = 0;
 		}
 	}
 }
@@ -639,8 +629,7 @@ void Game::RunFindOrders()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				RunFindUnit(u);
 			}
 		}
@@ -688,8 +677,7 @@ int Game::FortTaxBonus(Object *o, Unit *u)
 {
 	int protect = ObjectDefs[o->type].protect;
 	int fortbonus = 0;
-	forlist(&o->units) {
-		Unit *unit = (Unit *) elem;
+	for(auto unit: o->units) {
 		int men = unit->GetMen();
 		if (unit->num == u->num) {
 			if (unit->taxing == TAX_TAX) {
@@ -713,8 +701,7 @@ int Game::CountTaxes(ARegion *reg)
 	forlist(&reg->objects) {
 		Object *o = (Object *) elem;
 		int protect = ObjectDefs[o->type].protect;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->GetFlag(FLAG_AUTOTAX) && !Globals->TAX_PILLAGE_MONTH_LONG)
 				u->taxing = TAX_TAX;
 			if (u->taxing == TAX_AUTO) u->taxing = TAX_TAX;
@@ -758,8 +745,7 @@ void Game::RunTaxRegion(ARegion *reg)
 
 	forlist(&reg->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->taxing == TAX_TAX) {
 				int t = u->Taxers(0);
 				t += FortTaxBonus(o, u);
@@ -789,8 +775,7 @@ int Game::CountPillagers(ARegion *reg)
 	int p = 0;
 	forlist(&reg->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->taxing == TAX_PILLAGE) {
 				if (!reg->CanPillage(u)) {
 					u->error("PILLAGE: A unit is on guard.");
@@ -819,8 +804,7 @@ void Game::ClearPillagers(ARegion *reg)
 {
 	forlist(&reg->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->taxing == TAX_PILLAGE) {
 				u->error("PILLAGE: Not enough men to pillage.");
 				u->taxing = TAX_NONE;
@@ -847,8 +831,7 @@ void Game::RunPillageRegion(ARegion *reg)
 	int amt = reg->wealth * 2;
 	forlist(&reg->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->taxing == TAX_PILLAGE) {
 				u->taxing = TAX_NONE;
 				int num = u->Taxers(1);
@@ -919,8 +902,7 @@ void Game::RunPromoteOrders()
 			r = (ARegion *) elem;
 			forlist(&r->objects) {
 				o = (Object *) elem;
-				forlist(&o->units) {
-					u = (Unit *) elem;
+				for(auto u: o->units) {
 					if (u->promote) {
 						if (o->type != O_DUMMY) {
 							u->error("PROMOTE: Must be owner");
@@ -951,13 +933,13 @@ void Game::RunPromoteOrders()
 
 void Game::Do1PromoteOrder(Object *obj, Unit *u)
 {
-	Unit *tar = obj->GetUnitId(u->promote, u->faction->num);
+	Unit *tar = obj->get_unit_id(u->promote, u->faction->num);
 	if (!tar) {
 		u->error("PROMOTE: Can't find target.");
 		return;
 	}
-	obj->units.Remove(tar);
-	obj->units.Insert(tar);
+	std::erase(obj->units, tar);
+	obj->units.insert(obj->units.begin(), tar);
 	ObjectType& ob = ObjectDefs[obj->type];
 	if (ob.flags & ObjectType::GRANTSKILL) {
 		if (tar->faction->skills.GetDays(ob.granted_skill) < ob.granted_level) {
@@ -976,12 +958,10 @@ void Game::Do1EvictOrder(Object *obj, Unit *u)
 		return;
 	}
 
-	obj->region->DeduplicateUnitList(&ord->targets, u->faction->num);
-	while (ord && ord->targets.Num()) {
-		UnitId *id = (UnitId *)ord->targets.First();
-		ord->targets.Remove(id);
-		Unit *tar = obj->GetUnitId(id, u->faction->num);
-		delete id;
+	obj->region->deduplicate_unit_list(ord->targets, u->faction->num);
+
+	for(auto id: ord->targets) {
+		Unit *tar = obj->get_unit_id(&id, u->faction->num);
 		if (!tar) continue;
 		if (obj->IsFleet() &&
 			(TerrainDefs[obj->region->type].similar_type == R_OCEAN) &&
@@ -994,6 +974,7 @@ void Game::Do1EvictOrder(Object *obj, Unit *u)
 		tar->event("Evicted from " + string(obj->name->const_str()) + " by " + u->name->const_str(), "evict");
 		u->event("Evicted " + string(tar->name->const_str()) + " from " + obj->name->const_str(), "evict");
 	}
+	ord->targets.clear();
 }
 
 /* RunEnterOrders is performed in TWO phases: one in the
@@ -1006,8 +987,7 @@ void Game::RunEnterOrders(int phase)
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				// normal enter phase or ENTER NEW / JOIN phase?
 				if (phase == 0) {
 					if (u->enter > 0 || u->enter == -1)
@@ -1055,12 +1035,12 @@ void Game::Do1EnterOrder(ARegion *r, Object *in, Unit *u)
 void Game::Do1JoinOrder(ARegion *r, Object *in, Unit *u)
 {
 	JoinOrder *jo;
-	Unit *tar, *pass;
+	Unit *tar;
 	Object *to, *from;
 	Item *item;
 
 	jo = (JoinOrder *) u->joinorders;
-	tar = r->GetUnitId(jo->target, u->faction->num);
+	tar = r->get_unit_id(*jo->target, u->faction->num);
 
 	if (!tar) {
 		u->error("JOIN: No such unit.");
@@ -1088,15 +1068,14 @@ void Game::Do1JoinOrder(ARegion *r, Object *in, Unit *u)
 			u->error("JOIN MERGE: Target unit is not in a fleet.");
 			return;
 		}
-		forlist(&u->object->units) {
-			pass = (Unit *) elem;
+		for(auto pass: u->object->units) {
 			if (to->ForbiddenBy(r, pass)) {
 				u->error("JOIN MERGE: A unit would be refused entry.");
 				return;
 			}
 		}
 		from = u->object;
-		forlist_reuse(&from->ships) {
+		forlist(&from->ships) {
 			item = (Item *) elem;
 			GiveOrder go;
 			UnitId id;
@@ -1112,8 +1091,7 @@ void Game::Do1JoinOrder(ARegion *r, Object *in, Unit *u)
 			DoGiveOrder(r, u, &go);
 			go.target = NULL;
 		}
-		forlist_reuse(&u->object->units) {
-			pass = (Unit *) elem;
+		for(auto pass: u->object->units) {
 			pass->MoveUnit(to);
 		}
 
@@ -1155,8 +1133,7 @@ void Game::RemoveEmptyObjects()
 				(TerrainDefs[r->type].similar_type != R_OCEAN)) continue;
 			if (ObjectDefs[o->type].cost &&
 					o->incomplete >= ObjectDefs[o->type].cost) {
-				forlist(&o->units) {
-					Unit *u = (Unit *) elem;
+				for(auto u: o->units) {
 					u->MoveUnit(r->GetDummy());
 				}
 				r->objects.Remove(o);
@@ -1209,8 +1186,7 @@ void Game::MidProcessTurn()
 		// r->MidTurn(); // Not yet implemented
 		forlist(&r->objects) {
 			Object *o = (Object *)elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *)elem;
+			for(auto u: o->units) {
 				MidProcessUnit(r, u);
 			}
 		}
@@ -1286,8 +1262,7 @@ void Game::PostProcessTurn()
 
 		forlist (&r->objects) {
 			Object *o = (Object *) elem;
-			forlist (&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				PostProcessUnit(r, u);
 			}
 		}
@@ -1306,8 +1281,7 @@ void Game::DoAutoAttacks()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->canattack && u->IsAlive())
 					DoAutoAttack(r, u);
 			}
@@ -1318,13 +1292,11 @@ void Game::DoAutoAttacks()
 void Game::DoMovementAttacks(AList *locs)
 {
 	Location *l;
-	Unit *u;
 
 	forlist(locs) {
 		l = (Location *) elem;
 		if (l->obj) {
-			forlist(&l->obj->units) {
-				u = (Unit *) elem;
+			for(auto u: l->obj->units) {
 				DoMovementAttack(l->region, u);
 			}
 		} else {
@@ -1357,8 +1329,7 @@ void Game::DoAutoAttackOn(ARegion *r, Unit *t)
 {
 	forlist(&r->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->guard != GUARD_AVOID &&
 					(u->GetAttitude(r, t) == A_HOSTILE) && u->IsAlive() &&
 					u->canattack)
@@ -1381,8 +1352,7 @@ void Game::DoAutoAttack(ARegion *r, Unit *u) {
 		return;
 	forlist(&r->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *t = (Unit *) elem;
+		for(auto t: o->units) {
 			if (u->GetAttitude(r, t) == A_HOSTILE) {
 				AttemptAttack(r, u, t, 1);
 			}
@@ -1396,8 +1366,7 @@ int Game::CountWMonTars(ARegion *r, Unit *mon) {
 	int retval = 0;
 	forlist(&r->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->type == U_NORMAL || u->type == U_MAGE ||
 					u->type == U_APPRENTICE) {
 				if (mon->CanSee(r, u) && mon->CanCatch(r, u)) {
@@ -1412,8 +1381,7 @@ int Game::CountWMonTars(ARegion *r, Unit *mon) {
 Unit *Game::GetWMonTar(ARegion *r, int tarnum, Unit *mon) {
 	forlist(&r->objects) {
 		Object *o = (Object *) elem;
-		forlist(&o->units) {
-			Unit *u = (Unit *) elem;
+		for(auto u: o->units) {
 			if (u->type == U_NORMAL || u->type == U_MAGE ||
 					u->type == U_APPRENTICE) {
 				if (mon->CanSee(r, u) && mon->CanCatch(r, u)) {
@@ -1445,8 +1413,7 @@ void Game::DoAttackOrders()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
+			for(auto u: o->units) {
 				if (u->type == U_WMON) {
 					if (u->canattack && u->IsAlive()) {
 						CheckWMonAttack(r, u);
@@ -1454,12 +1421,9 @@ void Game::DoAttackOrders()
 				} else {
 					if (u->attackorders && u->IsAlive()) {
 						AttackOrder *ord = u->attackorders;
-						r->DeduplicateUnitList(&ord->targets, u->faction->num);
-						while (ord->targets.Num()) {
-							UnitId *id = (UnitId *) ord->targets.First();
-							ord->targets.Remove(id);
-							Unit *t = r->GetUnitId(id, u->faction->num);
-							delete id;
+						r->deduplicate_unit_list(ord->targets, u->faction->num);
+						for (auto id: ord->targets) {
+							Unit *t = r->get_unit_id(id, u->faction->num);
 							if (u->canattack && u->IsAlive()) {
 								if (t) {
 									AttemptAttack(r, u, t, 0);
@@ -1517,8 +1481,7 @@ void Game::RunSellOrders()
 		}
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				forlist((&u->sellorders)) {
 					u->error("SELL: Can't sell that.");
 				}
@@ -1533,8 +1496,7 @@ int Game::GetSellAmount(ARegion *r, Market *m)
 	int num = 0;
 	forlist((&r->objects)) {
 		Object *obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit *u = (Unit *) elem;
+		for(auto u: obj->units) {
 			forlist ((&u->sellorders)) {
 				SellOrder *o = (SellOrder *) elem;
 				if (o->item == m->item) {
@@ -1564,8 +1526,7 @@ void Game::DoSell(ARegion *r, Market *m)
 	int oldamount = m->amount;
 	forlist((&r->objects)) {
 		Object *obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit *u = (Unit *) elem;
+		for(auto u: obj->units) {
 			forlist((&u->sellorders)) {
 				SellOrder *o = (SellOrder *) elem;
 				if (o->item == m->item) {
@@ -1603,8 +1564,7 @@ void Game::RunBuyOrders()
 		}	
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				forlist((&u->buyorders)) {
 					u->error("BUY: Can't buy that.");
 				}
@@ -1619,8 +1579,7 @@ int Game::GetBuyAmount(ARegion *r, Market *m)
 	int num = 0;
 	forlist((&r->objects)) {
 		Object *obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit *u = (Unit *) elem;
+		for(auto u: obj->units) {
 			forlist ((&u->buyorders)) {
 				BuyOrder *o = (BuyOrder *) elem;
 				if (o->item == m->item) {
@@ -1689,8 +1648,7 @@ void Game::DoBuy(ARegion *r, Market *m)
 	int oldamount = m->amount;
 	forlist((&r->objects)) {
 		Object *obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit *u = (Unit *) elem;
+		for(auto u: obj->units) {
 			forlist((&u->buyorders)) {
 				BuyOrder *o = (BuyOrder *) elem;
 				if (o->item == m->item) {
@@ -1751,8 +1709,7 @@ void Game::CheckUnitMaintenanceItem(int item, int value, int consume)
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (u->needed > 0 &&
 					((!consume) || (u->GetFlag(FLAG_CONSUMING_UNIT) || u->GetFlag(FLAG_CONSUMING_FACTION)))) {
 					int amount = u->items.GetNum(item);
@@ -1790,15 +1747,12 @@ void Game::CheckFactionMaintenanceItem(int item, int value, int consume)
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (u->needed > 0 && ((!consume) || u->GetFlag(FLAG_CONSUMING_FACTION))) {
 					/* Go through all units again */
 					forlist((&r->objects)) {
 						Object *obj2 = (Object *) elem;
-						forlist((&obj2->units)) {
-							Unit *u2 = (Unit *) elem;
-
+						for(auto u2: obj2->units) {
 							if (u->faction == u2->faction && u != u2) {
 								int amount = u2->items.GetNum(item);
 								if (amount) {
@@ -1843,14 +1797,12 @@ void Game::CheckAllyMaintenanceItem(int item, int value)
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (u->needed > 0) {
 					/* Go through all units again */
 					forlist((&r->objects)) {
 						Object *obj2 = (Object *) elem;
-						forlist((&obj2->units)) {
-							Unit *u2 = (Unit *) elem;
+						for(auto u2: obj2->units) {
 							if (u->faction != u2->faction && u2->GetAttitude(r, u) == A_ALLY) {
 								int amount = u2->items.GetNum(item);
 								if (amount) {
@@ -1894,8 +1846,7 @@ void Game::CheckUnitHungerItem(int item, int value)
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (u->hunger > 0) {
 					int amount = u->items.GetNum(item);
 					if (amount) {
@@ -1925,15 +1876,12 @@ void Game::CheckFactionHungerItem(int item, int value)
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (u->hunger > 0) {
 					/* Go through all units again */
 					forlist((&r->objects)) {
 						Object *obj2 = (Object *) elem;
-						forlist((&obj2->units)) {
-							Unit *u2 = (Unit *) elem;
-
+						for(auto u2: obj2->units) {
 							if (u->faction == u2->faction && u != u2) {
 								int amount = u2->items.GetNum(item);
 								if (amount) {
@@ -1971,14 +1919,12 @@ void Game::CheckAllyHungerItem(int item, int value)
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (u->hunger > 0) {
 					/* Go through all units again */
 					forlist((&r->objects)) {
 						Object *obj2 = (Object *) elem;
-						forlist((&obj2->units)) {
-							Unit *u2 = (Unit *) elem;
+						for(auto u2: obj2->units) {
 							if (u->faction != u2->faction &&
 								u2->GetAttitude(r, u) == A_ALLY) {
 								int amount = u2->items.GetNum(item);
@@ -2020,8 +1966,7 @@ void Game::AssessMaintenance()
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				if (!(u->faction->is_npc)) {
 					r->visited = 1;
 					if (quests.CheckQuestVisitTarget(r, u, &quest_rewards)) {
@@ -2060,8 +2005,7 @@ void Game::AssessMaintenance()
 					ARegion *r = (ARegion *) elem;
 					forlist((&r->objects)) {
 						Object *obj = (Object *) elem;
-						forlist((&obj->units)) {
-							Unit *u = (Unit *) elem;
+						for(auto u: obj->units) {
 							if (u->hunger > 0 && u->faction->unclaimed > cost) {
 								int value = Globals->UPKEEP_FOOD_VALUE;
 								int eat = (u->hunger + value - 1) / value;
@@ -2127,8 +2071,7 @@ void Game::AssessMaintenance()
 			ARegion *r = (ARegion *) elem;
 			forlist((&r->objects)) {
 				Object *obj = (Object *) elem;
-				forlist((&obj->units)) {
-					Unit *u = (Unit *) elem;
+				for(auto u: obj->units) {
 					if (u->needed > 0 && u->faction->unclaimed) {
 						/* Now see if faction has money */
 						if (u->faction->unclaimed >= u->needed) {
@@ -2167,8 +2110,7 @@ void Game::AssessMaintenance()
 			ARegion *r = (ARegion *) elem;
 			forlist((&r->objects)) {
 				Object *obj = (Object *) elem;
-				forlist((&obj->units)) {
-					Unit *u = (Unit *) elem;
+				for(auto u: obj->units) {
 					if (u->needed > 0 || u->hunger > 0)
 						u->Short(u->needed, u->hunger);
 				}
@@ -2183,8 +2125,7 @@ void Game::DoWithdrawOrders()
 		ARegion *r = (ARegion *)elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *)elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				forlist((&u->withdraworders)) {
 					WithdrawOrder *o = (WithdrawOrder *)elem;
 					if (DoWithdrawOrder(r, u, o)) break;
@@ -2236,8 +2177,7 @@ void Game::DoGiveOrders()
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				forlist((&u->giveorders)) {
 					GiveOrder *o = (GiveOrder *)elem;
 					if (o->item < 0) {
@@ -2246,7 +2186,7 @@ void Game::DoGiveOrders()
 							DoGiveOrder(r, u, o);
 						} else if (o->amount == -2) {
 							if (o->type == O_TAKE) {
-								s = r->GetUnitId(o->target, u->faction->num);
+								s = r->get_unit_id(*o->target, u->faction->num);
 								if (!s || !u->CanSee(r, s)) {
 									u->error("TAKE: Nonexistant target (" +	o->target->Print() + ").");
 									continue;
@@ -2326,8 +2266,7 @@ void Game::DoExchangeOrders()
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				forlist((&u->exchangeorders)) {
 					Order *o = (Order *) elem;
 					DoExchangeOrder(r, u, (ExchangeOrder *) o);
@@ -2340,7 +2279,7 @@ void Game::DoExchangeOrders()
 void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
 {
 	// Check if the destination unit exists
-	Unit *t = r->GetUnitId(o->target, u->faction->num);
+	Unit *t = r->get_unit_id(*o->target, u->faction->num);
 	if (!t) {
 		u->error("EXCHANGE: Nonexistant target (" + o->target->Print() + ").");
 		u->exchangeorders.Remove(o);
@@ -2391,7 +2330,7 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
 	// Check if other unit has a reciprocal exchange order
 	forlist ((&t->exchangeorders)) {
 		ExchangeOrder *tOrder = (ExchangeOrder *) elem;
-		Unit *ptrUnitTemp = r->GetUnitId(tOrder->target, t->faction->num);
+		Unit *ptrUnitTemp = r->get_unit_id(*tOrder->target, t->faction->num);
 		if (ptrUnitTemp == u) {
 			if (tOrder->expectItem == o->giveItem) {
 				if (tOrder->giveItem == o->expectItem) {
@@ -2460,7 +2399,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 	int hasitem, ship, num, shipcount, amt, newfleet, cur;
 	int notallied, newlvl, oldlvl;
 	Item *it, *sh;
-	Unit *p, *t, *s;
+	Unit *t, *s;
 	Object *fleet;
 	Skill *skill;
 	SkillList *skills;
@@ -2515,8 +2454,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 					shipcount += sh->num;
 				}
 				if (shipcount <= o->amount) {
-					forlist(&(u->object->units)) {
-						p = (Unit *) elem;
+					for(auto p: u->object->units) {
 						if ((!p->CanSwim() || p->GetFlag(FLAG_NOCROSS_WATER))) {
 							u->error(ord + ": Can't abandon our last ship in the ocean.");
 							return 0;
@@ -2529,8 +2467,8 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 			u->event("Abandons " + ItemString(o->item, num - o->amount) + ".", event_type);
 			return 0;
 		}
-		// GIVE to unit:	
-		t = r->GetUnitId(o->target, u->faction->num);
+		// GIVE to unit:
+		t = r->get_unit_id(*o->target, u->faction->num);
 		if (!t) {
 			u->error(ord + ": Nonexistant target (" + o->target->Print() + ").");
 			return 0;
@@ -2637,8 +2575,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 					shipcount += sh->num;
 				}
 				if (shipcount <= amt) {
-					forlist(&(s->object->units)) {
-						p = (Unit *) elem;
+					for(auto p: s->object->units) {
 						if ((!p->CanSwim() || p->GetFlag(FLAG_NOCROSS_WATER))) {
 							u->error(ord + ": Can't give away our last ship in the ocean.");
 							return 0;
@@ -2763,7 +2700,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 	}
 
 	amt = o->amount;
-	t = r->GetUnitId(o->target, u->faction->num);
+	t = r->get_unit_id(*o->target, u->faction->num);
 	if (!t) {
 		u->error(ord + ": Nonexistant target (" + o->target->Print() + ").");
 		return 0;
@@ -2990,9 +2927,7 @@ void Game::DoGuard1Orders()
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
-
+			for(auto u: obj->units) {
 				if (!Globals->OCEAN_GUARD &&
 					(u->guard == GUARD_SET || u->guard == GUARD_GUARD) &&
 					TerrainDefs[r->type].similar_type == R_OCEAN) {
@@ -3046,8 +2981,7 @@ void Game::DeleteEmptyInRegion(ARegion *region)
 {
 	forlist(&region->objects) {
 		Object *obj = (Object *) elem;
-		forlist (&obj->units) {
-			Unit *unit = (Unit *) elem;
+		for(auto unit: obj->units) {
 			if (unit->IsAlive() == 0) {
 				region->Kill(unit);
 			}
@@ -3064,8 +2998,7 @@ void Game::CheckTransportOrders()
 		ARegion *r = (ARegion *)elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *)elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *)elem;
+			for(auto u: obj->units) {
 				forlist ((&u->transportorders)) {
 					// make sure target exists
 					TransportOrder *o = (TransportOrder *)elem;
@@ -3186,8 +3119,7 @@ void Game::CollectInterQMTransportItems() {
 		ARegion *r = (ARegion *)elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *)elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *)elem;
+			for(auto u: obj->units) {
 				// Move the items from the transport_items list to the unit's items list
 				forlist((&u->transport_items)) {
 					Item *it = (Item *)elem;
@@ -3208,8 +3140,7 @@ void Game::RunTransportOrders() {
 		ARegion *r = (ARegion *)elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *)elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *)elem;
+			for(auto u: obj->units) {
 				u->transport_items.Empty();
 			}
 		}
@@ -3229,8 +3160,7 @@ void Game::RunTransportOrders() {
 		ARegion *r = (ARegion *)elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *)elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *)elem;
+			for(auto u: obj->units) {
 				u->transportorders.DeleteAll();
 			}
 		}
@@ -3244,8 +3174,7 @@ void Game::RunTransportPhase(TransportOrder::TransportPhase phase) {
 		ARegion *r = (ARegion *)elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *)elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *)elem;
+			for(auto u: obj->units) {
 				forlist ((&u->transportorders)) {
 					TransportOrder *t = (TransportOrder *)elem;
 					if (t->type != O_TRANSPORT) continue;
@@ -3336,8 +3265,7 @@ void Game::RunSacrificeOrders() {
 		std::vector<Object *> destroyed_objects;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				SacrificeOrder *o = u->sacrificeorders;
 				if (o == nullptr) continue;
 
@@ -3389,8 +3317,7 @@ void Game::RunSacrificeOrders() {
 							bool done = false;
 							forlist((&r->objects)) {
 								Object *ob = (Object *)elem;
-								forlist((&ob->units)) {
-									Unit *recip = (Unit *)elem;
+								for(auto recip: ob->units) {
 									if (recip->faction == u->faction && recip->GetMen() != 0) {
 										done = true;
 										recip->items.SetNum(reward_item, recip->items.GetNum(reward_item) + reward_amt);
@@ -3429,8 +3356,7 @@ void Game::RunSacrificeOrders() {
 		// destroy any pending objects in this region.
 		for (auto obj: destroyed_objects) {
 			// This shouldn't happen, as the sacrifice objects are not enterable, but.. just in case.
-			forlist((&obj->units)) {
-				Unit *u = (Unit *)elem;
+			for(auto u: obj->units) {
 				u->MoveUnit(r->GetDummy());
 				u->event("Moved out of a sacrificed structure.", "sacrifice");
 			}
@@ -3467,8 +3393,7 @@ void Game::Do1Annihilate(ARegion *reg) {
 	std::vector<Object *> destroyed_objects;
 	forlist_reuse(&reg->objects) {
 		Object *obj = (Object *)elem;
-		forlist(&obj->units) {
-			Unit *u = (Unit *)elem;
+		for(auto u: obj->units) {
 			u->items.DeleteAll(); // throw away all the items
 			u->event("Is annihilated.", "annihilate");
 			reg->Kill(u);
@@ -3509,8 +3434,7 @@ void Game::RunAnnihilateOrders() {
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
-			forlist((&obj->units)) {
-				Unit *u = (Unit *) elem;
+			for(auto u: obj->units) {
 				AnnihilateOrder *o = u->annihilateorders;
 				if (o == nullptr) continue;
 

--- a/standard/extra.cpp
+++ b/standard/extra.cpp
@@ -104,14 +104,13 @@ Faction *Game::CheckVictory()
 			if (obj->type != O_BKEEP){
 				continue;
 			}
-			if (obj->units.Num()){
+			if (obj->units.size()){
 				return NULL;
 			}
 			// Now see find the first faction guarding the region
 			forlist(&region->objects) {
 				Object *o = region->GetDummy();
-				forlist(&o->units) {
-					Unit *u = (Unit *)elem;
+				for(auto u: o->units) {
 					if (u->guard == GUARD_GUARD){
 						return u->faction;
 					}

--- a/standard/monsters.cpp
+++ b/standard/monsters.cpp
@@ -56,8 +56,7 @@ void Game::GrowVMons()
 		forlist(&r->objects) {
 			Object *obj = (Object *)elem;
 			if (obj->type != O_BKEEP) continue;
-			forlist(&obj->units) {
-				Unit *u = (Unit *)elem;
+			for(auto u: obj->units) {
 				int men = u->GetMen(I_BALROG) + 2;
 				if (men > 200) men = 200;
 				u->items.SetNum(I_BALROG, men);

--- a/unit.cpp
+++ b/unit.cpp
@@ -53,15 +53,6 @@ string UnitId::Print()
 	}
 }
 
-UnitPtr *GetUnitList(AList *list, Unit *u)
-{
-	forlist (list) {
-		UnitPtr *p = (UnitPtr *) elem;
-		if (p->ptr == u) return p;
-	}
-	return 0;
-}
-
 Unit::Unit()
 {
 	name = 0;
@@ -1117,8 +1108,7 @@ int Unit::GetSharedNum(int item)
 
 	forlist((&object->region->objects)) {
 		Object *obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit *u = (Unit *) elem;
+		for(auto u: obj->units) {
 			if ((u->num == num) || 
 			(u->faction == faction && u->GetFlag(FLAG_SHARING)))
 				count += u->items.GetNum(item);
@@ -1141,8 +1131,7 @@ void Unit::ConsumeShared(int item, int needed)
 	// We still need more, so look for whomever is able to share with us
 	forlist((&object->region->objects)) {
 		Object *obj = (Object *) elem;
-		forlist((&obj->units)) {
-			Unit *u = (Unit *) elem;
+		for(auto u: obj->units) {
 			if (u->faction == faction && u->GetFlag(FLAG_SHARING)) {
 				amount = u->items.GetNum(item);
 				if (amount < 1) continue;
@@ -2591,10 +2580,10 @@ int Unit::GetWeapon(AString &itm, int riding, int ridingBonus,
 
 void Unit::MoveUnit(Object *toobj)
 {
-	if (object) object->units.Remove(this);
+	if (object) std::erase(object->units, this);
 	object = toobj;
 	if (object) {
-		object->units.Add(this);
+		object->units.push_back(this);
 		ObjectType& ob = ObjectDefs[object->type];
 		if (object->GetOwner() == this  && ob.flags & ObjectType::GRANTSKILL) {
 			if (faction->skills.GetDays(ob.granted_skill) < ob.granted_level) {

--- a/unit.h
+++ b/unit.h
@@ -101,7 +101,7 @@ enum {
 #define FLAG_SWIMSPOILS			0x2000
 #define FLAG_SAILSPOILS			0x4000
 
-class UnitId : public AListElem {
+class UnitId {
 	public:
 		UnitId();
 		~UnitId();
@@ -112,13 +112,7 @@ class UnitId : public AListElem {
 		int faction;
 };
 
-class UnitPtr : public AListElem {
-	public:
-		Unit * ptr;
-};
-UnitPtr *GetUnitList(AList *, Unit *);
-
-class Unit : public AListElem
+class Unit
 {
 	public:
 		Unit();


### PR DESCRIPTION
This makes units (one of the largest things which used alists) no longer use them.. This is one step on the road toward more modern stl containers and patterns being the way this code works.