### PR TITLE
Remove 2 more uses of ALists

### DIFF
--- a/army.cpp
+++ b/army.cpp
@@ -702,7 +702,7 @@ Army::Army(Unit * ldr,AList * locs,int regtype,int ass)
 	// If TACTICS_NEEDS_WAR is enabled, we don't want to push leaders 
 	// from tact-4 to tact-5! Also check that we have skills, otherwise
 	// we get a nasty core dump ;)
-	if (Globals->TACTICS_NEEDS_WAR && (tactician->skills.Num() != 0)) {
+	if (Globals->TACTICS_NEEDS_WAR && (tactician->skills.size() != 0)) {
 		int currskill = tactician->skills.GetDays(S_TACTICS)/tactician->GetMen();
 		if (currskill < 450 - Globals->SKILL_PRACTICE_AMOUNT) {
 			tactician->PracticeAttribute("tactics");

--- a/astring.h
+++ b/astring.h
@@ -28,11 +28,10 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include "alist.h"
 
 using namespace std;
 
-class AString : public AListElem {
+class AString {
 	friend ostream & operator <<(ostream &os, const AString &);
 	friend istream & operator >>(istream &is, AString &);
 

--- a/game.cpp
+++ b/game.cpp
@@ -1060,7 +1060,7 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 										"for faction "+pFac->num);
 							} else {
 								if (getatsign) {
-									u->oldorders.Add(new AString(saveorder));
+									u->oldorders.push_back(string(saveorder.const_str()));
 								}
 								ProcessOrder(o, u, pLine, NULL);
 							}
@@ -1080,8 +1080,8 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 
 void Game::WriteNewFac(Faction *pFac)
 {
-	AString *strFac = new AString(AString("Adding ") + *(pFac->address) + ".");
-	newfactions.Add(strFac);
+	string strFac = string("Adding ") + pFac->address->const_str() + ".";
+	newfactions.push_back(strFac);
 }
 
 int Game::DoOrdersCheck(const AString &strOrders, const AString &strCheck)

--- a/game.h
+++ b/game.h
@@ -289,7 +289,7 @@ private:
 	void ModifyHealing(int level, int patients, int success);
 
 	AList factions;
-	AList newfactions; /* List of strings */
+	std::vector<std::string> newfactions; /* List of strings */
 	vector<Battle *> battles;
 	ARegionList regions;
 	int factionseq;

--- a/havilah/world.cpp
+++ b/havilah/world.cpp
@@ -201,7 +201,7 @@ int syllprob[] = { 0, 60, 40, 0 };
 // world generation
 //
 
-static AList regionnames;
+static std::vector<std::string> regionnames;
 static int nnames;
 static int ntowns;
 static int nregions;
@@ -233,8 +233,8 @@ void CountNames()
 	// them easily (to check for randomly generated rude words,
 	// for example)
 	ofstream names("names.out", ios::out|ios::ate);
-	forlist(&regionnames) {
-		names << ((AString *) elem)->const_str() << '\n';
+	for(auto name: regionnames) {
+		names << name << '\n';
 	}
 }
 
@@ -243,7 +243,6 @@ int AGetName(int town, ARegion *reg)
 	int unique, rnd, syllables, i, trail, port, similar;
 	unsigned int u;
 	char temp[80];
-	AString *name;
 
 	port = 0;
 	if (town) {
@@ -333,9 +332,8 @@ int AGetName(int town, ARegion *reg)
 		}
 		temp[0] = toupper(temp[0]);
 		unique = 1;
-		forlist(&regionnames) {
-			name = (AString *) elem;
-			if (*name == temp) {
+		for(auto name: regionnames) {
+			if (name == temp) {
 				unique = 0;
 				break;
 			}
@@ -350,26 +348,16 @@ int AGetName(int town, ARegion *reg)
 	else
 		nregions++;
 
-	name = new AString(temp);
-	regionnames.Add(name);
+	regionnames.push_back(temp);
 
-	return regionnames.Num();
+	return regionnames.size();
 }
 
 const char *AGetNameString(int name)
 {
-	AString *str;
-
-	forlist(&regionnames) {
-		name--;
-		if (!name) {
-			str = (AString *) elem;
-			return str->Str();
-		}
-	}
-
-	// This should never happen
-	return "Error";
+	if (name <= 0 || name > (int) regionnames.size())
+		return "Error";
+	return regionnames[name-1].c_str();
 }
 
 void Game::CreateWorld()

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -189,7 +189,7 @@ void Game::RunMovementOrders()
 							else if (d->dir == MOVE_PAUSE) *tOrder += "P";
 							else *tOrder += d->dir - MOVE_ENTER;
 						}
-						u->oldorders.Insert(tOrder);
+						u->oldorders.push_front(tOrder->const_str());
 					}
 				}
 			}
@@ -209,7 +209,7 @@ void Game::RunMovementOrders()
 						else
 							*tOrder += DirectionAbrs[d->dir];
 					}
-					u->oldorders.Insert(tOrder);
+					u->oldorders.push_front(tOrder->const_str());
 				}
 			}
 		}
@@ -1188,7 +1188,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 		order += o->target;
 		order += " ";
 		order += ItemDefs[o->item].abr;
-		tOrder->turnOrders.Add(new AString(order));
+		tOrder->turnOrders.push_back(order.const_str());
 		u->turnorders.Insert(tOrder);
 	}
 	delete u->monthorders;
@@ -1328,7 +1328,7 @@ void Game::RunAProduction(ARegion * r, Production * p)
 				order += po->target;
 				order += " ";
 				order += ItemDefs[po->item].abr;
-				tOrder->turnOrders.Add(new AString(order));
+				tOrder->turnOrders.push_back(order.const_str());
 				u->turnorders.Insert(tOrder);
 			}
 
@@ -1576,7 +1576,7 @@ void Game::Do1StudyOrder(Unit *u,Object *obj)
 				AString order;
 				tOrder->repeating = 0;
 				order = AString("STUDY ") + SkillDefs[sk].abbr + " " + o->level;
-				tOrder->turnOrders.Add(new AString(order));
+				tOrder->turnOrders.push_back(order.const_str());
 				u->turnorders.Insert(tOrder);
 			} else {
 				string msg = "Completes study to level " + to_string(o->level) + " in " + SkillDefs[sk].name + ".";

--- a/neworigins/world.cpp
+++ b/neworigins/world.cpp
@@ -202,7 +202,7 @@ int syllprob[] = { 0, 60, 40, 0 };
 // world generation
 //
 
-static AList regionnames;
+static std::vector<std::string> regionnames;
 static int nnames;
 static int ntowns;
 static int nregions;
@@ -234,8 +234,8 @@ void CountNames()
 	// them easily (to check for randomly generated rude words,
 	// for example)
 	ofstream names("names.out", ios::out|ios::ate);
-	forlist(&regionnames) {
-		names << ((AString *) elem)->const_str() << '\n';
+	for(auto name: regionnames) {
+		names << name << '\n';
 	}
 }
 
@@ -244,7 +244,6 @@ int AGetName(int town, ARegion *reg)
 	int unique, rnd, syllables, i, trail, port, similar;
 	unsigned int u;
 	char temp[80];
-	AString *name;
 
 	port = 0;
 	if (town) {
@@ -334,9 +333,8 @@ int AGetName(int town, ARegion *reg)
 		}
 		temp[0] = toupper(temp[0]);
 		unique = 1;
-		forlist(&regionnames) {
-			name = (AString *) elem;
-			if (*name == temp) {
+		for(auto name: regionnames) {
+			if (name == temp) {
 				unique = 0;
 				break;
 			}
@@ -351,26 +349,16 @@ int AGetName(int town, ARegion *reg)
 	else
 		nregions++;
 
-	name = new AString(temp);
-	regionnames.Add(name);
+	regionnames.push_back(temp);
 
-	return regionnames.Num();
+	return regionnames.size();
 }
 
 const char *AGetNameString(int name)
 {
-	AString *str;
-
-	forlist(&regionnames) {
-		name--;
-		if (!name) {
-			str = (AString *) elem;
-			return str->Str();
-		}
-	}
-
-	// This should never happen
-	return "Error";
+	if (name <= 0 || name > (int) regionnames.size())
+		return "Error";
+	return regionnames[name-1].c_str();
 }
 
 void Game::CreateWorld()

--- a/orders.h
+++ b/orders.h
@@ -323,7 +323,7 @@ class TurnOrder : public Order {
 		TurnOrder();
 		~TurnOrder();
 		int repeating;
-		AList turnOrders;
+		std::vector<std::string> turnOrders;
 };
 
 class CastOrder : public Order {

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -348,7 +348,7 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 						else {
 							unit = ProcessFormOrder(unit, &order, pCheck, getatsign);
 							if (!pCheck && unit && unit->former && unit->former->format)
-								unit->former->oldorders.Add(new AString(saveorder));
+								unit->former->oldorders.push_back(saveorder.const_str());
 							if (!pCheck) {
 								if (unit) unit->ClearOrders();
 							}
@@ -368,7 +368,7 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 							parse_error(pCheck, unit, fac, "TURN: without ENDTURN");
 
 						if (!pCheck && unit->former && unit->former->format)
-							unit->former->oldorders.Add(new AString(saveorder));
+							unit->former->oldorders.push_back(saveorder.const_str());
 
 						if (pCheck && former) delete unit;
 						unit = former;
@@ -387,7 +387,7 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 					if (faction != 0) {
 						AString *retval;
 						if (!pCheck && unit->former && unit->former->format)
-							unit->former->oldorders.Add(new AString(saveorder));
+							unit->former->oldorders.push_back(saveorder.const_str());
 						retval = ProcessTurnOrder(unit, f, pCheck, getatsign);
 						if (retval) {
 							order = *retval;
@@ -411,7 +411,7 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 					unit->presentTaxing = 0;
 					unit->inTurnBlock = 0;
 					if (!pCheck && unit->former && unit->former->format)
-						unit->former->oldorders.Add(new AString(saveorder));
+						unit->former->oldorders.push_back(saveorder.const_str());
 				} else
 					parse_error(pCheck, unit, fac, "ENDTURN: without TURN.");
 				break;
@@ -419,9 +419,9 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 				if (fac) {
 					if (unit) {
 						if (!pCheck && getatsign)
-							unit->oldorders.Add(new AString(saveorder));
+							unit->oldorders.push_back(saveorder.const_str());
 						if (!pCheck && unit->former && unit->former->format)
-							unit->former->oldorders.Add(new AString(saveorder));
+							unit->former->oldorders.push_back(saveorder.const_str());
 
 						ProcessOrder(code, unit, &order, pCheck);
 					} else {
@@ -435,7 +435,7 @@ void Game::ParseOrders(int faction, istream& f, OrdersCheck *pCheck)
 			code = NORDERS;
 			if (!pCheck) {
 				if (getatsign && fac && unit)
-					unit->oldorders.Add(new AString(saveorder));
+					unit->oldorders.push_back(saveorder.const_str());
 			}
 		}
 
@@ -1328,9 +1328,8 @@ void Game::ProcessRestartOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 			pFac->SetAddress(*(u->faction->address));
 			AString *pass = new AString(*(u->faction->password));
 			pFac->password = pass;
-			AString *facstr = new AString(AString("Restarting ")
-					+ *(pFac->address) + ".");
-			newfactions.Add(facstr);
+			string facstr = string("Restarting ") + pFac->address->const_str() + ".";
+			newfactions.push_back(facstr);
 		}
 	}
 }
@@ -2011,7 +2010,7 @@ AString *Game::ProcessTurnOrder(Unit *unit, istream& f, OrdersCheck *pCheck, int
 						break;
 					}
 					turnDepth++;
-					tOrder->turnOrders.Add(new AString(saveorder));
+					tOrder->turnOrders.push_back(saveorder.const_str());
 					turnLast = 1;
 					break;
 				case O_FORM:
@@ -2021,7 +2020,7 @@ AString *Game::ProcessTurnOrder(Unit *unit, istream& f, OrdersCheck *pCheck, int
 					}
 					turnLast = 0;
 					formDepth++;
-					tOrder->turnOrders.Add(new AString(saveorder));
+					tOrder->turnOrders.push_back(saveorder.const_str());
 					break;
 				case O_ENDFORM:
 					if (turnLast) {
@@ -2037,7 +2036,7 @@ AString *Game::ProcessTurnOrder(Unit *unit, istream& f, OrdersCheck *pCheck, int
 						}
 					}
 					formDepth--;
-					tOrder->turnOrders.Add(new AString(saveorder));
+					tOrder->turnOrders.push_back(saveorder.const_str());
 					turnLast = 1;
 					break;
 				case O_UNIT:
@@ -2057,16 +2056,16 @@ AString *Game::ProcessTurnOrder(Unit *unit, istream& f, OrdersCheck *pCheck, int
 						parse_error(pCheck, unit, 0, "ENDTURN: without TURN.");
 					} else {
 						if (--turnDepth) 
-							tOrder->turnOrders.Add(new AString(saveorder));
+							tOrder->turnOrders.push_back(saveorder.const_str());
 						turnLast = 0;
 					}
 					break;
 				default:
-					tOrder->turnOrders.Add(new AString(saveorder));
+					tOrder->turnOrders.push_back(saveorder.const_str());
 					break;
 			}
 			if (!pCheck && unit->former && unit->former->format)
-				unit->former->oldorders.Add(new AString(saveorder));
+				unit->former->oldorders.push_back(saveorder.const_str());
 			delete token;
 		}
 	}

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -2401,7 +2401,6 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 	Item *it, *sh;
 	Unit *t, *s;
 	Object *fleet;
-	Skill *skill;
 	SkillList *skills;
 
 	string ord = (o->type == O_TAKE) ? "TAKE" : "GIVE";
@@ -2822,8 +2821,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		}
 
 		/* Check if any new skill reports have to be shown */
-		forlist(&(u->skills)) {
-			skill = (Skill *) elem;
+		for(auto skill: u->skills) {
 			newlvl = u->GetRealSkill(skill->type);
 			oldlvl = u->faction->skills.GetDays(skill->type);
 			if (newlvl > oldlvl) {
@@ -2836,7 +2834,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 
 		// Okay, now for each item that the unit has, tell the new faction
 		// about it in case they don't know about it yet.
-		forlist_reuse(&u->items) {
+		forlist(&u->items) {
 			it = (Item *)elem;
 			u->faction->DiscoverItem(it->type, 0, 1);
 		}

--- a/skills.h
+++ b/skills.h
@@ -37,7 +37,7 @@ class SkillList;
 
 #include "astring.h"
 #include "gamedefs.h"
-#include "alist.h"
+#include <list>
 
 /* For dependencies:
   A value of depend == -1 indicates no more dependencies.
@@ -120,30 +120,39 @@ struct ShowSkill {
 	AString * Report(Faction *) const;
 };
 
-class Skill : public AListElem {
-	public:
-		void Readin(istream& f);
-		void Writeout(ostream &f);
+class Skill {
+public:
+	void Readin(istream& f);
+	void Writeout(ostream &f);
+	Skill *Split(int total, int split);
 
-		Skill * Split(int,int); /* total num, num leaving */
-
-		int type;
-		unsigned int days;
-		unsigned int exp;
+	int type;
+	unsigned int days;
+	unsigned int exp;
 };
 
-class SkillList : public AList {
-	public:
-		int GetDays(int); /* Skill */
-		int GetExp(int); /* Skill */
-		void SetDays(int,int); /* Skill, days */
-		void SetExp(int,int); /* Skill, exp */
-		void Combine(SkillList *);
-		int GetStudyRate(int, int); /* Skill, num of men */
-		SkillList * Split(int,int); /* total men, num to split */
-		AString Report(int); /* Number of men */
-		void Readin(istream& f);
-		void Writeout(ostream& f);
+class SkillList {
+	std::list<Skill *> skills;
+
+public:
+	using iterator = typename std::list<Skill *>::iterator;
+
+	int GetDays(int sk);
+	int GetExp(int sk);
+	void SetDays(int sk, int days);
+	void SetExp(int sk,int exp);
+	void Combine(SkillList *skl);
+	int GetStudyRate(int sk, int men);
+	SkillList *Split(int total, int split);
+	AString Report(int men);
+	void Readin(istream& f);
+	void Writeout(ostream& f);
+	inline int size() { return skills.size(); }
+	inline Skill *front() { return skills.front(); }
+
+	inline iterator begin(){ return skills.begin(); }
+	inline iterator end(){ return skills.end(); }
+	inline size_t erase(Skill *s) { return std::erase(skills, s); }
 };
 
 class HealType {

--- a/unit.cpp
+++ b/unit.cpp
@@ -442,8 +442,7 @@ json Unit::write_json_orders()
 
 	bool has_continuing_month_order = false;
 
-	forlist(&(oldorders)) {
-		string order = ((AString *)elem)->const_str();
+	for(auto order: oldorders) {
 		AString temp = order;
 		temp.getat();
 		AString *token = temp.gettoken();
@@ -491,8 +490,7 @@ json Unit::write_json_orders()
 				parent_stack.push(container);
 				container = json::array();
 			}
-			forlist(&tOrder->turnOrders) {
-				string order = ((AString *)elem)->const_str();
+			for(auto order: tOrder->turnOrders) {
 				AString temp = order;
 				temp.getat();
 				AString *token = temp.gettoken();
@@ -528,8 +526,7 @@ json Unit::write_json_orders()
 			container.push_back( { { "order", "@TURN" } } );
 			parent_stack.push(container);
 			container = json::array();
-			forlist(&tOrder->turnOrders) {
-				string order = ((AString *)elem)->const_str();
+			for(auto order: tOrder->turnOrders) {
 				AString temp = order;
 				temp.getat();
 				AString *token = temp.gettoken();

--- a/unit.h
+++ b/unit.h
@@ -252,7 +252,7 @@ class Unit
 		int readyItem;
 		int readyWeapon[MAX_READY];
 		int readyArmor[MAX_READY];
-		AList oldorders;
+		std::list<std::string> oldorders;
 		int needed; /* For assessing maintenance */
 		int hunger;
 		int stomach_space;


### PR DESCRIPTION
This removes the use of ALists of strings (in oldorders and turnorders), as well as the use of ALists for Skills and SkillList.
SkillList was reimplemented as a class containing a private std::list container and exposing the iterators and the needed
functions.