### PR TITLE
Clean up usage of namepace std

### DIFF
--- a/aregion.h
+++ b/aregion.h
@@ -155,8 +155,8 @@ class TownInfo
 		TownInfo();
 		~TownInfo();
 
-		void Readin(istream& f);
-		void Writeout(ostream& f);
+		void Readin(std::istream& f);
+		void Writeout(std::ostream& f);
 		int TownType();
 
 		AString *name;
@@ -187,15 +187,15 @@ class ARegion : public AListElem
 		ARegion();
 		//ARegion(int, int);
 		~ARegion();
-		
+
 		void Setup();
 		void ManualSetup(const RegionSetup& settings);
 
 		void ZeroNeighbors();
 		void SetName(char const *);
 
-		void Writeout(ostream& f);
-		void Readin(istream& f, AList *);
+		void Writeout(std::ostream& f);
+		void Readin(std::istream& f, AList *);
 
 		int CanMakeAdv(Faction *, int);
 		int HasItem(Faction *, int);
@@ -318,7 +318,7 @@ class ARegion : public AListElem
 		int wages;
 		int maxwages;
 		int wealth;
-		
+
 		/* Economy */
 		int habitat;
 		int development;
@@ -336,7 +336,7 @@ class ARegion : public AListElem
 		int emigrants;
 		// economic improvement
 		int improvement;
-		
+
 		/* Potential bonuses to economy */
 		int clearskies;
 		int earthlore;
@@ -344,7 +344,7 @@ class ARegion : public AListElem
 
 		ARegion *neighbors[NDIRS];
 		AList objects;
-		map<int,int> newfleets;
+		std::map<int,int> newfleets;
 		int fleetalias;
 		std::vector<Unit *>hell; /* Where dead units go */
 		AList farsees;
@@ -447,10 +447,10 @@ class GeoMap
 		int GetVegetation(int, int);
 		int GetCulture(int, int);
 		void ApplyGeography(ARegionArray *pArr);
-		
+
 		int size, xscale, yscale, xoff, yoff;
-		map<long int,Geography> geomap;
-		
+		std::map<long int, Geography> geomap;
+
 };
 
 class ARegionList : public AList
@@ -461,8 +461,8 @@ class ARegionList : public AList
 
 		ARegion *GetRegion(int);
 		ARegion *GetRegion(int, int, int);
-		int ReadRegions(istream &f, AList *);
-		void WriteRegions(ostream&  f);
+		int ReadRegions(std::istream &f, AList *);
+		void WriteRegions(std::ostream&  f);
 		Location *FindUnit(int);
 		Location *GetUnitId(UnitId *id, int faction, ARegion *cur);
 
@@ -516,7 +516,7 @@ class ARegionList : public AList
 		void UnsetRace(ARegionArray *pRegs);
 		void RaceAnchors(ARegionArray *pRegs);
 		void GrowRaces(ARegionArray *pRegs);
-		
+
 		void TownStatistics();
 		void ResourcesStatistics();
 

--- a/army.cpp
+++ b/army.cpp
@@ -26,7 +26,7 @@
 #include "gameio.h"
 #include "gamedata.h"
 
-#include <assert.h> 
+#include <assert.h>
 
 void unit_stat_control::Clear(UnitStat& us) {
 	us.attackStats.clear();
@@ -249,8 +249,8 @@ Soldier::Soldier(Unit * u,Object * o,int regtype,int r,int ass)
 				dskill[i] += ObjectDefs[o->type].defenceArray[i];
 		}
 		if (o->runes) {
-			dskill[ATTACK_ENERGY] = max(dskill[ATTACK_ENERGY], o->runes);
-			dskill[ATTACK_SPIRIT] = max(dskill[ATTACK_SPIRIT], o->runes);
+			dskill[ATTACK_ENERGY] = std::max(dskill[ATTACK_ENERGY], o->runes);
+			dskill[ATTACK_SPIRIT] = std::max(dskill[ATTACK_SPIRIT], o->runes);
 		}
 		o->capacity--;
 	}
@@ -699,7 +699,7 @@ Army::Army(Unit * ldr,AList * locs,int regtype,int ass)
 			}
 		}
 	}
-	// If TACTICS_NEEDS_WAR is enabled, we don't want to push leaders 
+	// If TACTICS_NEEDS_WAR is enabled, we don't want to push leaders
 	// from tact-4 to tact-5! Also check that we have skills, otherwise
 	// we get a nasty core dump ;)
 	if (Globals->TACTICS_NEEDS_WAR && (tactician->skills.size() != 0)) {
@@ -1352,8 +1352,10 @@ int Army::DoAnAttack(Battle * b, char const *special, int numAttacks, int attack
 	}
 
 	if (canShield) {
-    	auto correctShield = [&attackType](shared_ptr<Shield> sh) { return sh->shieldtype == attackType; };
-    	auto compareShield = [](shared_ptr<Shield> s1, shared_ptr<Shield> s2) { return s1->shieldskill < s2->shieldskill; };
+    	auto correctShield = [&attackType](std::shared_ptr<Shield> sh) { return sh->shieldtype == attackType; };
+    	auto compareShield = [](std::shared_ptr<Shield> s1, std::shared_ptr<Shield> s2) {
+			return s1->shieldskill < s2->shieldskill;
+		};
     	auto validShields = shields | std::views::filter(correctShield);
     	auto maxShield = std::max_element(validShields.begin(), validShields.end(), compareShield);
 
@@ -1506,9 +1508,9 @@ void Army::Kill(int killed, int damage)
 	if (Globals->ARMY_ROUT == GameDefs::ARMY_ROUT_HITS_INDIVIDUAL)
 		hitsalive--;
 
-	temp->damage += min(temp->hits, damage);
-	temp->hits = max(0, temp->hits - damage);
-	
+	temp->damage += std::min(temp->hits, damage);
+	temp->hits = std::max(0, temp->hits - damage);
+
 	if (temp->hits > 0) return;
 
 	temp->unit->losses++;

--- a/army.h
+++ b/army.h
@@ -28,7 +28,6 @@
 #include <functional>
 #include <map>
 #include <vector>
-using namespace std;
 
 class Soldier;
 class Army;
@@ -154,7 +153,7 @@ class Soldier {
 		int amuletofi;
 
 		/* Effects */
-		map< char const *, int > effects;
+		std::map<char const *, int> effects;
 };
 
 typedef Soldier * SoldierPtr;
@@ -208,7 +207,7 @@ class Army
 
 		SoldierPtr * soldiers;
 		Unit * leader;
-		std::vector<shared_ptr<Shield>> shields;
+		std::vector<std::shared_ptr<Shield>> shields;
 		int round;
 		int tac;
 		int canfront;

--- a/astring.cpp
+++ b/astring.cpp
@@ -406,16 +406,16 @@ int AString::strict_value() //this cannot handle negative numbers!
 	return ret;
 }
 
-ostream& operator<<(ostream &os,const AString &s)
+std::ostream& operator<<(std::ostream &os,const AString &s)
 {
 	os << s.str;
 	return os;
 }
 
-istream& operator>>(istream &is,AString &s)
+std::istream& operator>>(std::istream &is,AString &s)
 {
 	// We expect to read a line at a time from the file, not a string at a time since we do tokenization internally.
-	string buf;
+	std::string buf;
 	getline(is, buf);
 	s.len = strlen(buf.c_str());
 	s.str = new char[s.len + 1];
@@ -423,7 +423,7 @@ istream& operator>>(istream &is,AString &s)
 	return is;
 }
 
-const string plural(int count, const std::string &one, const std::string &many) {
+const std::string plural(int count, const std::string &one, const std::string &many) {
 	return count != 1 ? many : one;
 }
 

--- a/astring.h
+++ b/astring.h
@@ -29,11 +29,9 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
 class AString {
-	friend ostream & operator <<(ostream &os, const AString &);
-	friend istream & operator >>(istream &is, AString &);
+	friend std::ostream & operator <<(std::ostream &os, const AString &);
+	friend std::istream & operator >>(std::istream &is, AString &);
 
 public:
 

--- a/basic/map.cpp
+++ b/basic/map.cpp
@@ -155,21 +155,21 @@ void ARegionList::CreateSurfaceLevel(int level, int xSize, int ySize, char const
 	int sea = Globals->OCEAN;
 	if (Globals->SEA_LIMIT)
 		sea = sea * (100 + 2 * Globals->SEA_LIMIT) / 100;
-			
+
 	MakeLand(pRegionArrays[level], sea, Globals->CONTINENT_SIZE);
-	
+
 	CleanUpWater(pRegionArrays[level]);
 
 	SetupAnchors(pRegionArrays[level]);
-	
+
 	GrowTerrain(pRegionArrays[level], 0);
-	
+
 	AssignTypes(pRegionArrays[level]);
 
 	SeverLandBridges(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -281,8 +281,8 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1;  
-				reg->wages = -1; 
+				reg->race = -1;
+				reg->wages = -1;
 
 				reg->level = arr;
 				Add(reg);
@@ -376,7 +376,7 @@ void ARegionList::MakeIcosahedralRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1; // 
+				reg->race = -1; //
 				reg->wages = -1; // initially store: name
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
@@ -431,7 +431,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 		if (!reg) continue;
 		ARegion *newreg = reg;
 		ARegion *seareg = reg;
-		
+
 		// Archipelago or Continent?
 		if (getrandom(100) < Globals->ARCHIPELAGO) {
 			// Make an Archipelago:
@@ -511,7 +511,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
-					&& (getrandom(4) < 3)) continue;				
+					&& (getrandom(4) < 3)) continue;
 				ARegion *newreg = reg->neighbors[dir];
 				if (!newreg) break;
 				int polecheck = 0;
@@ -774,7 +774,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 				if (!reg) continue;
 				if ((j > 0) && (j < 21) && (getrandom(3) < 2)) continue;
 				if (reg->type == R_NUM) {
-				
+
 					// Check for Lakes
 					if (Globals->LAKES &&
 						(getrandom(100) < (Globals->LAKES/10 + 1))) {
@@ -788,7 +788,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 							reg->wages = AGetName(0, reg);
 						break;
 					}
-					
+
 
 					int init = getrandom(6);
 					for (int i=0; i<NDIRS; i++) {
@@ -920,13 +920,13 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			int xoff = x + 2 - getrandom(3) - getrandom(3);
 			ARegion *reg = pArr->GetRegion(xoff, y);
 			if (!reg) continue;
-			
+
 			if ((reg->type == R_LAKE) && (!Globals->LAKESIDE_IS_COASTAL)) continue;
 			if (TerrainDefs[reg->type].flags & TerrainType::BARREN) continue;
-			
+
 			reg->race = -1;
 			wigout = 0; // reset sanity
-			
+
 			if (TerrainDefs[reg->type].similar_type == R_OCEAN) {
 				// setup near coastal race here
 				int d = getrandom(NDIRS);
@@ -937,7 +937,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
 						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
 							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
-						
+
 						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
@@ -952,14 +952,14 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			} else {
 				// setup noncoastal race here
 				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
-				
-				while ( reg->race == -1 || 
+
+				while ( reg->race == -1 ||
 						(ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
 			}
-			
+
 			/* leave out this sort of check for the moment
 			if (wigout > 100) {
 				// do something!
@@ -968,10 +968,10 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				Awrite(" region type");
 			}
 			*/
-			
+
 			if (reg->race == -1) {
-				cout << "Hey! No race anchor got assigned to the " 
-					<< TerrainDefs[reg->type].name 
+				std::cout << "Hey! No race anchor got assigned to the "
+					<< TerrainDefs[reg->type].name
 					<< " at " << x << "," << y << "\n";
 			}
 		}

--- a/battle.cpp
+++ b/battle.cpp
@@ -32,6 +32,8 @@
 #include "quests.h"
 #include "items.h"
 
+using namespace std;
+
 enum StatsCategory {
 	ROUND,
 	BATTLE
@@ -40,13 +42,13 @@ enum StatsCategory {
 void WriteStats(Battle &battle, Army &army, StatsCategory category) {
 	auto leaderName = std::string(army.leader->name->Str());
 	std::string header = std::string(army.leader->name->Str()) + " army:";
-	
+
 	battle.AddLine(AString(header.c_str()));
 
 	auto stats = category == StatsCategory::ROUND
 		? army.stats.roundStats
 		: army.stats.battleStats;
-	
+
 	int statLines = 0;
 	for (auto &uskv : stats) {
 		UnitStat us = uskv.second;
@@ -81,7 +83,7 @@ void WriteStats(Battle &battle, Army &army, StatsCategory category) {
 				case MAGIC_ENERGY: s += "magic"; break;
 				case MAGIC_SPIRIT: s += "magic"; break;
 				case MAGIC_WEATHER: s += "magic"; break;
-				
+
 				default: s += "unknown"; break;
 			}
 
@@ -92,7 +94,7 @@ void WriteStats(Battle &battle, Army &army, StatsCategory category) {
 				case ATTACK_ENERGY: s += " energy"; break;
 				case ATTACK_SPIRIT: s += " spirit"; break;
 				case ATTACK_WEATHER: s += " weather"; break;
-				
+
 				default: s += " unknown"; break;
 			}
 
@@ -278,10 +280,10 @@ void Battle::NormalRound(int round,Army * a,Army * b)
 	AddLine(AString("Round ") + round + ":");
 
 	if (a->tactics_bonus > b->tactics_bonus) {
-		AddLine(*(a->leader->name) + " tactics bonus " + a->tactics_bonus + ".");	
+		AddLine(*(a->leader->name) + " tactics bonus " + a->tactics_bonus + ".");
 	}
 	if (b->tactics_bonus > a->tactics_bonus) {
-		AddLine(*(b->leader->name) + " tactics bonus " + b->tactics_bonus + ".");	
+		AddLine(*(b->leader->name) + " tactics bonus " + b->tactics_bonus + ".");
 	}
 
 	/* Update both army's shields */
@@ -355,7 +357,7 @@ void Battle::NormalRound(int round,Army * a,Army * b)
 
 	a->Reset();
 	a->stats.ClearRound();
-	
+
 	b->Reset();
 	b->stats.ClearRound();
 }
@@ -415,7 +417,7 @@ void Battle::GetSpoils(AList *losers, ItemList *spoils, int ass)
 }
 
 void AddBattleFact(
-	Events* events, 
+	Events* events,
 	ARegion* region,
 	Unit* attacker,
 	Unit* defender,
@@ -428,10 +430,10 @@ void AddBattleFact(
 	auto fact = new BattleFact();
 
 	fact->location = EventLocation::Create(region);
-	
+
 	fact->attacker.AssignUnit(attacker);
 	fact->attacker.AssignArmy(attackerArmy);
-	
+
 	fact->defender.AssignUnit(defender);
 	fact->defender.AssignArmy(defenderArmy);
 
@@ -470,13 +472,13 @@ void AddBattleFact(
 		fact->fortification = name;
 		fact->fortificationType = fortType;
 	}
-	
+
 
 	events->AddFact(fact);
 }
 
 void AddAssassinationFact(
-	Events* events, 
+	Events* events,
 	ARegion* region,
 	Unit* defender,
 	Army* defenderArmy,
@@ -487,16 +489,16 @@ void AddAssassinationFact(
 	auto fact = new AssassinationFact();
 
 	fact->location = EventLocation::Create(region);
-	
+
 	// fact->victim.AssignUnit(defender);
 	// fact->victim.AssignArmy(defenderArmy);
-	
+
 	fact->outcome = outcome;
 
 	events->AddFact(fact);
 }
 
-int Battle::Run(Events* events, 
+int Battle::Run(Events* events,
 		ARegion * region,
 		Unit * att,
 		AList * atts,
@@ -583,7 +585,7 @@ int Battle::Run(Events* events,
 		}
 
 		armies[1]->Win(this, spoils);
-		
+
 		AddLine("");
 		AddLine(temp);
 		AddLine("");
@@ -672,7 +674,7 @@ int Battle::Run(Events* events,
 	}
 
 	AddLine("Total Casualties:");
-	
+
 	armies[0]->Tie(this);
 	armies[1]->Tie(this);
 	temp = "Spoils: none.";
@@ -741,7 +743,7 @@ void Battle::build_json_report(json& j, Faction *fac) {
 		return;
 	}
 	j["type"] = "battle";
-	j["report"] = text; 
+	j["report"] = text;
 }
 
 void Battle::AddLine(const AString & s) {
@@ -751,7 +753,7 @@ void Battle::AddLine(const AString & s) {
 void Game::GetDFacs(ARegion * r,Unit * t,AList & facs)
 {
 	int AlliesIncluded = 0;
-	
+
 	// First, check whether allies should assist in this combat
 	if (Globals->ALLIES_NOAID == 0) {
 		AlliesIncluded = 1;
@@ -775,13 +777,13 @@ void Game::GetDFacs(ARegion * r,Unit * t,AList & facs)
 		//delete obj;
 		//delete u;
 	}
-	
+
 	forlist((&r->objects)) {
 		Object * obj = (Object *) elem;
 		for(auto u: obj->units) {
 			if (u->IsAlive()) {
 				if (u->faction == t->faction ||
-					(AlliesIncluded == 1 && 
+					(AlliesIncluded == 1 &&
 					 u->guard != GUARD_AVOID &&
 					 u->GetAttitude(r,t) == A_ALLY) ) {
 

--- a/events.cpp
+++ b/events.cpp
@@ -78,7 +78,7 @@ void BattleSide::AssignArmy(Army* army) {
             if (lost) this->fmiLost++;
             continue;
         }
-        
+
         if (item.type & IT_UNDEAD) {
             this->undead++;
             if (lost) this->undeadLost++;
@@ -165,7 +165,7 @@ void populateRegionLandmark(std::vector<Landmark> &landmarks, ARegion *source, A
     if (type == events::LandmarkType::UNKNOWN) {
         return;
     }
-    
+
     landmarks.push_back({
         .type = type,
         .name = name,
@@ -251,7 +251,7 @@ const EventLocation EventLocation::Create(ARegion* region) {
     loc.z = region->zloc;
     loc.terrainType = region->type;
     loc.province = region->name->Str();
-    
+
     if (region->town) {
         loc.settlement = region->town->name->Str();
         loc.settlementType = region->town->TownType();
@@ -306,7 +306,7 @@ bool compareEvents(const Event &first, const Event &second) {
     return first.score > second.score;
 }
 
-std::list<string> wrapText(std::string input, std::size_t width) {
+std::list<std::string> wrapText(std::string input, std::size_t width) {
     std::size_t curpos = 0;
     std::size_t nextpos = 0;
 
@@ -315,7 +315,7 @@ std::list<string> wrapText(std::string input, std::size_t width) {
 
     while (substr.length() == width + 1 && (nextpos = substr.rfind(' ')) != input.npos) {
         lines.push_back(input.substr(curpos, nextpos));
-        
+
         curpos += nextpos + 1;
         substr = input.substr(curpos, width + 1);
     }

--- a/events.h
+++ b/events.h
@@ -90,9 +90,9 @@ struct BattleSide {
     int monsters;
     int undead;
     int fmi;
-    
+
     int lost;
-    
+
     int magesLost;
     int fmiLost;
     int undeadLost;
@@ -138,7 +138,7 @@ struct EventLocation {
     std::string settlement;
     int settlementType;
 
-    vector<Landmark> landmarks;
+    std::vector<Landmark> landmarks;
 
     const std::string GetTerrainName(const bool plural);
     const Landmark* GetSignificantLandmark();
@@ -150,7 +150,7 @@ class BattleFact : public FactBase {
 public:
     BattleFact();
     ~BattleFact();
-    
+
     void GetEvents(std::list<Event> &events);
 
     EventLocation location;
@@ -183,7 +183,7 @@ class AnnihilationFact : public FactBase {
 
         void GetEvents(std::list<Event> &events);
 
-        string message;
+        std::string message;
 };
 
 class AnomalyFact : public FactBase {

--- a/faction.h
+++ b/faction.h
@@ -257,7 +257,7 @@ public:
 	int startturn;
 
 private:
-	vector<FactionStatistic> compute_faction_statistics(Game *game, size_t **citems);
+	std::vector<FactionStatistic> compute_faction_statistics(Game *game, size_t **citems);
 	void gm_report_setup(Game *game);
 	void build_gm_json_report(json& j, Game *game);
 };

--- a/fracas/map.cpp
+++ b/fracas/map.cpp
@@ -155,21 +155,21 @@ void ARegionList::CreateSurfaceLevel(int level, int xSize, int ySize, char const
 	int sea = Globals->OCEAN;
 	if (Globals->SEA_LIMIT)
 		sea = sea * (100 + 2 * Globals->SEA_LIMIT) / 100;
-			
+
 	MakeLand(pRegionArrays[level], sea, Globals->CONTINENT_SIZE);
-	
+
 	CleanUpWater(pRegionArrays[level]);
 
 	SetupAnchors(pRegionArrays[level]);
-	
+
 	GrowTerrain(pRegionArrays[level], 0);
-	
+
 	AssignTypes(pRegionArrays[level]);
 
 	SeverLandBridges(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -281,9 +281,9 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1;  
-				reg->wages = -1; 
-				
+				reg->race = -1;
+				reg->wages = -1;
+
 				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
@@ -376,7 +376,7 @@ void ARegionList::MakeIcosahedralRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1; // 
+				reg->race = -1; //
 				reg->wages = -1; // initially store: name
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
@@ -431,7 +431,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 		if (!reg) continue;
 		ARegion *newreg = reg;
 		ARegion *seareg = reg;
-		
+
 		// Archipelago or Continent?
 		if (getrandom(100) < Globals->ARCHIPELAGO) {
 			// Make an Archipelago:
@@ -511,7 +511,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
-					&& (getrandom(4) < 3)) continue;				
+					&& (getrandom(4) < 3)) continue;
 				ARegion *newreg = reg->neighbors[dir];
 				if (!newreg) break;
 				int polecheck = 0;
@@ -774,7 +774,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 				if (!reg) continue;
 				if ((j > 0) && (j < 21) && (getrandom(3) < 2)) continue;
 				if (reg->type == R_NUM) {
-				
+
 					// Check for Lakes
 					if (Globals->LAKES &&
 						(getrandom(100) < (Globals->LAKES/10 + 1))) {
@@ -788,7 +788,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 							reg->wages = AGetName(0, reg);
 						break;
 					}
-					
+
 
 					int init = getrandom(6);
 					for (int i=0; i<NDIRS; i++) {
@@ -920,14 +920,14 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			int xoff = x + 2 - getrandom(3) - getrandom(3);
 			ARegion *reg = pArr->GetRegion(xoff, y);
 			if (!reg) continue;
-			
+
 			if ((reg->type == R_LAKE) && (!Globals->LAKESIDE_IS_COASTAL))
 				continue;
 			if (TerrainDefs[reg->type].flags & TerrainType::BARREN) continue;
-			
+
 			reg->race = -1;
 			wigout = 0; // reset sanity
-			
+
 			if (TerrainDefs[reg->type].similar_type == R_OCEAN) {
 				// setup near coastal race here
 				int d = getrandom(NDIRS);
@@ -938,7 +938,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
 						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
 								sizeof(TerrainDefs[nreg->type].coastal_races[0]);
-						
+
 						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
@@ -953,13 +953,13 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			} else {
 				// setup noncoastal race here
 				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
-				
+
 				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
 			}
-			
+
 			/* leave out this sort of check for the moment
 			if (wigout > 100) {
 				// do something!
@@ -968,10 +968,10 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				Awrite(" region type");
 			}
 			*/
-			
+
 			if (reg->race == -1) {
-				cout << "Hey! No race anchor got assigned to the " 
-					<< TerrainDefs[reg->type].name 
+				std::cout << "Hey! No race anchor got assigned to the "
+					<< TerrainDefs[reg->type].name
 					<< " at " << x << "," << y << "\n";
 			}
 		}

--- a/game.h
+++ b/game.h
@@ -40,9 +40,9 @@ class Game;
 class OrdersCheck
 {
 public:
-	OrdersCheck(ostream& f) : pCheckFile(f), numshows(0), numerrors(0) { }
+	OrdersCheck(std::ostream& f) : pCheckFile(f), numshows(0), numerrors(0) { }
 
-	ostream& pCheckFile;
+	std::ostream& pCheckFile;
 	Unit dummyUnit;
 	Faction dummyFaction;
 	Order dummyOrder;
@@ -87,7 +87,7 @@ public:
 	// LLS
 	void UnitFactionMap();
 	int GenRules(const AString &, const AString &, const AString &);
-	string FactionTypeDescription(Faction &fac);
+	std::string FactionTypeDescription(Faction &fac);
 	int DoOrdersCheck(const AString &strOrders, const AString &strCheck);
 
 	Faction *AddFaction(int noleader = 0, ARegion *pStart = NULL);
@@ -174,8 +174,8 @@ private:
 	int MakeWMon(ARegion *pReg);
 	void MakeLMon(Object *pObj);
 
-	void WriteSurfaceMap(ostream& f, ARegionArray *pArr, int type);
-	void WriteUnderworldMap(ostream& f, ARegionArray *pArr, int type);
+	void WriteSurfaceMap(std::ostream& f, ARegionArray *pArr, int type);
+	void WriteUnderworldMap(std::ostream& f, ARegionArray *pArr, int type);
 	char GetRChar(ARegion *r);
 	AString GetXtraMap(ARegion *, int);
 
@@ -290,7 +290,7 @@ private:
 
 	AList factions;
 	std::vector<std::string> newfactions; /* List of strings */
-	vector<Battle *> battles;
+	std::vector<Battle *> battles;
 	ARegionList regions;
 	int factionseq;
 	unsigned int unitseq;
@@ -305,10 +305,10 @@ private:
 	// For our existing case, these are going to be used by the unit test framework to ensure a consistent
 	// run (by overriding the seeding of the random number generator).  In general, there should be *very*
 	// few of these hooks and they should exist for a very explicit purpose and be used with extreme care.
-	
+
 	// control the random number seed used for new game generation (by default it uses the existing
 	// seedrandomrandom function) which uses the current time.
-	std::function<void()> init_random_seed = seedrandomrandom; 
+	std::function<void()> init_random_seed = seedrandomrandom;
 
 	enum
 	{
@@ -332,7 +332,7 @@ private:
 	UnitId *ParseUnit(AString *s);
 	int ParseDir(AString *token);
 
-	void ParseOrders(int faction, istream& ordersFile, OrdersCheck *pCheck);
+	void ParseOrders(int faction, std::istream& ordersFile, OrdersCheck *pCheck);
 	void ProcessOrder(int orderNum, Unit *unit, AString *order,
 					  OrdersCheck *pCheck);
 	void ProcessMoveOrder(Unit *, AString *, OrdersCheck *pCheck);
@@ -393,7 +393,7 @@ private:
 	void ProcessIdleOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessTransportOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessShareOrder(Unit *, AString *, OrdersCheck *pCheck);
-	AString *ProcessTurnOrder(Unit *, istream& f, OrdersCheck *pCheck, int);
+	AString *ProcessTurnOrder(Unit *, std::istream& f, OrdersCheck *pCheck, int);
 	void ProcessJoinOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessAnnihilateOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessSacrificeOrder(Unit *, AString *, OrdersCheck *pCheck);

--- a/havilah/map.cpp
+++ b/havilah/map.cpp
@@ -155,21 +155,21 @@ void ARegionList::CreateSurfaceLevel(int level, int xSize, int ySize, char const
 	int sea = Globals->OCEAN;
 	if (Globals->SEA_LIMIT)
 		sea = sea * (100 + 2 * Globals->SEA_LIMIT) / 100;
-			
+
 	MakeLand(pRegionArrays[level], sea, Globals->CONTINENT_SIZE);
-	
+
 	CleanUpWater(pRegionArrays[level]);
 
 	SetupAnchors(pRegionArrays[level]);
-	
+
 	GrowTerrain(pRegionArrays[level], 0);
-	
+
 	AssignTypes(pRegionArrays[level]);
 
 	SeverLandBridges(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -191,7 +191,7 @@ void ARegionList::CreateIslandLevel(int level, int nPlayers, char const *name)
 	RandomTerrain(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -230,7 +230,7 @@ void ARegionList::CreateUnderworldLevel(int level, int xSize, int ySize,
 	MakeUWMaze(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -259,7 +259,7 @@ void ARegionList::CreateUnderdeepLevel(int level, int xSize, int ySize,
 	MakeUWMaze(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -287,9 +287,9 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1;  
-				reg->wages = -1; 
-				
+				reg->race = -1;
+				reg->wages = -1;
+
 				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
@@ -382,7 +382,7 @@ void ARegionList::MakeIcosahedralRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1; // 
+				reg->race = -1; //
 				reg->wages = -1; // initially store: name
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
@@ -437,7 +437,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 		if (!reg) continue;
 		ARegion *newreg = reg;
 		ARegion *seareg = reg;
-		
+
 		// Archipelago or Continent?
 		if (getrandom(100) < Globals->ARCHIPELAGO) {
 			// Make an Archipelago:
@@ -519,7 +519,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
-					&& (getrandom(4) < 3)) continue;				
+					&& (getrandom(4) < 3)) continue;
 				ARegion *newreg = reg->neighbors[dir];
 				if (!newreg) break;
 				int polecheck = 0;
@@ -782,7 +782,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 				if (!reg) continue;
 				if ((j > 0) && (j < 21) && (getrandom(3) < 2)) continue;
 				if (reg->type == R_NUM) {
-				
+
 					// Check for Lakes
 					if (Globals->LAKES &&
 						(getrandom(100) < (Globals->LAKES/10 + 1))) {
@@ -796,7 +796,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 							reg->wages = AGetName(0, reg);
 						break;
 					}
-					
+
 
 					int init = getrandom(6);
 					for (int i=0; i<NDIRS; i++) {
@@ -928,14 +928,14 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			int xoff = x + 2 - getrandom(3) - getrandom(3);
 			ARegion *reg = pArr->GetRegion(xoff, y);
 			if (!reg) continue;
-			
+
 			if ((reg->type == R_LAKE) && (!Globals->LAKESIDE_IS_COASTAL))
 				continue;
 			if (TerrainDefs[reg->type].flags & TerrainType::BARREN) continue;
-			
+
 			reg->race = -1;
 			wigout = 0; // reset sanity
-			
+
 			if (TerrainDefs[reg->type].similar_type == R_OCEAN) {
 				// setup near coastal race here
 				int d = getrandom(NDIRS);
@@ -946,7 +946,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
 						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
 							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
-						
+
 						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
@@ -961,13 +961,13 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			} else {
 				// setup noncoastal race here
 				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
-				
+
 				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
 			}
-			
+
 			/* leave out this sort of check for the moment
 			if (wigout > 100) {
 				// do something!
@@ -976,10 +976,10 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				Awrite(" region type");
 			}
 			*/
-			
+
 			if (reg->race == -1) {
-				cout << "Hey! No race anchor got assigned to the " 
-					<< TerrainDefs[reg->type].name 
+				std::cout << "Hey! No race anchor got assigned to the "
+					<< TerrainDefs[reg->type].name
 					<< " at " << x << "," << y << "\n";
 			}
 		}
@@ -1155,7 +1155,7 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 								found = 1;
 								Object *o = new Object(AC);
 								o->num = AC->buildingseq++;
-								o->name = new AString(AString("Gateway to ") + 
+								o->name = new AString(AString("Gateway to ") +
 									TerrainDefs[type].name + " [" + o->num + "]");
 								o->type = O_GATEWAY;
 								o->incomplete = 0;

--- a/indenter.cpp
+++ b/indenter.cpp
@@ -1,14 +1,14 @@
 #include "indenter.hpp"
 
 namespace indent {
-  const int indentbuf::idx = ios_base::xalloc();
+  const int indentbuf::idx = std::ios_base::xalloc();
 
-  ostream &wrap(ostream &os) {
+  std::ostream &wrap(std::ostream &os) {
     os << wrap(70);
     return os;
   }
 
-  ostream &comment(ostream &os) {
+  std::ostream &comment(std::ostream &os) {
     if(os.pword(indentbuf::idx) != nullptr) {
       indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
       buf->comment();
@@ -20,7 +20,7 @@ namespace indent {
     return os;
   }
 
-  ostream& incr(ostream& os) {
+  std::ostream& incr(std::ostream& os) {
     if(os.pword(indentbuf::idx) != nullptr) {
       indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
       buf->adjust_indent(2);
@@ -31,7 +31,7 @@ namespace indent {
     return os;
   }
 
-  ostream& decr(ostream& os) {
+  std::ostream& decr(std::ostream& os) {
     if(os.pword(indentbuf::idx) != nullptr) {
       indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
       buf->adjust_indent(-2);
@@ -40,12 +40,12 @@ namespace indent {
   }
 
   // This removes all indenting, wrapping and commenting from the output stream.
-  ostream& clear(ostream& os) {
+  std::ostream& clear(std::ostream& os) {
     if(os.pword(indentbuf::idx) != nullptr) {
       indentbuf *buf = static_cast<indentbuf *>(os.pword(indentbuf::idx));
       delete buf;
       os.pword(indentbuf::idx) = nullptr;
     }
     return os;
-  }    
+  }
 }

--- a/indenter.hpp
+++ b/indenter.hpp
@@ -6,14 +6,13 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
-using namespace std;
 
 namespace indent {
-  class indentbuf: public streambuf {
+  class indentbuf: public std::streambuf {
   public:
     static const int idx;
 
-    indentbuf(ostream& orig, size_t indent)
+    indentbuf(std::ostream& orig, size_t indent)
     : orig(orig),
       orig_buf(orig.rdbuf()),
       comment_on(false),
@@ -84,7 +83,7 @@ namespace indent {
       if (traits_type::eq_int_type(ch, traits_type::eof())) {
         return traits_type::not_eof(ch);
       }
-      
+
       if (suppress) {
         return orig_buf->sputc(ch);
       }
@@ -98,7 +97,7 @@ namespace indent {
           size_t wrap_pos = buffer.find_last_of("\n ", wrap);
           size_t extra = 1;
           // If we didn't find a space, just wrap at the wrap point.
-          if (wrap_pos == string::npos || (wrap - wrap_pos > lookback)) { wrap_pos = wrap; extra = 0; }
+          if (wrap_pos == std::string::npos || (wrap - wrap_pos > lookback)) { wrap_pos = wrap; extra = 0; }
           if (comment_on) orig_buf->sputc(';');
           orig_buf->sputn(buffer.c_str(), wrap_pos);
           orig_buf->sputc('\n');
@@ -106,7 +105,7 @@ namespace indent {
           // If the remaining buffer is just a newline, clear it
           if (buffer == "\n") buffer.clear();
           if (buffer.size() > 0) {
-            buffer = prefix + string(string_wrap_indent, ' ') + buffer;
+            buffer = prefix + std::string(string_wrap_indent, ' ') + buffer;
           }
         }
         if (buffer.size() > 0) {
@@ -134,35 +133,35 @@ namespace indent {
       if (line_indent < 0) line_indent = 0;
       // Just make sure we never get a huge indent.
       if (line_indent > 30) line_indent = 30;
-      if (line_indent) prefix = string(line_indent, ' ');
+      if (line_indent) prefix = std::string(line_indent, ' ');
       else prefix.clear();
     }
 
-    ostream& orig;
-    streambuf *orig_buf;
+    std::ostream& orig;
+    std::streambuf *orig_buf;
     bool comment_on;
     bool suppress;
     int_type line_indent;
     size_t wrap;
     size_t lookback;
     size_t string_wrap_indent;
-    string buffer;
-    string prefix;
-    vector<int_type> line_indent_stack;
+    std::string buffer;
+    std::string prefix;
+    std::vector<int_type> line_indent_stack;
   };
 
-  ostream &wrap(ostream &os);
-  ostream &comment(ostream &os);
-  ostream &incr(ostream &os);
-  ostream &decr(ostream &os);
-  ostream &clear(ostream &os);
+  std::ostream &wrap(std::ostream &os);
+  std::ostream &comment(std::ostream &os);
+  std::ostream &incr(std::ostream &os);
+  std::ostream &decr(std::ostream &os);
+  std::ostream &clear(std::ostream &os);
 
   struct wrap_data { size_t wrap; size_t lookback; size_t string_wrap_indent; };
   inline wrap_data wrap(size_t wrap=70, size_t lookback=30, size_t string_wrap_indent=2) {
     return { wrap, lookback, string_wrap_indent };
   }
   template<typename _CharT, typename _Traits>
-  inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& os, wrap_data data) {
+  inline std::basic_ostream<_CharT, _Traits>& operator<<(std::basic_ostream<_CharT, _Traits>& os, wrap_data data) {
     if(os.pword(indentbuf::idx) == nullptr) {
       indentbuf *newbuf = new indentbuf(os, 0);
       newbuf->set_wrap(data.wrap, data.lookback, data.string_wrap_indent);
@@ -177,7 +176,7 @@ namespace indent {
   struct indent_data { size_t indent; };
   inline indent_data set_indent(size_t indent=2) { return { indent }; }
   template<typename _CharT, typename _Traits>
-  inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& os, indent_data data) {
+  inline std::basic_ostream<_CharT, _Traits>& operator<<(std::basic_ostream<_CharT, _Traits>& os, indent_data data) {
     if(os.pword(indentbuf::idx) == nullptr) {
       indentbuf *newbuf = new indentbuf(os, data.indent);
       os.pword(indentbuf::idx) = newbuf;
@@ -191,7 +190,7 @@ namespace indent {
   struct suppress_data { bool suppress; };
   inline suppress_data suppress_format(bool suppress) { return { suppress }; }
   template<typename _CharT, typename _Traits>
-  inline basic_ostream<_CharT, _Traits>&operator<<(basic_ostream<_CharT, _Traits>& os, suppress_data data) {
+  inline std::basic_ostream<_CharT, _Traits>&operator<<(std::basic_ostream<_CharT, _Traits>& os, suppress_data data) {
     if(os.pword(indentbuf::idx) == nullptr) {
       indentbuf *newbuf = new indentbuf(os, 0);
       os.pword(indentbuf::idx) = newbuf;
@@ -205,7 +204,9 @@ namespace indent {
   inline push_indent_data push_indent(size_t indent) { return { indent, true }; }
   inline push_indent_data pop_indent() { return { 0, false }; }
   template<typename _CharT, typename _Traits>
-  inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& os, push_indent_data data) {
+  inline std::basic_ostream<_CharT, _Traits>& operator<<(
+    std::basic_ostream<_CharT, _Traits>& os, push_indent_data data
+  ) {
     if(os.pword(indentbuf::idx) == nullptr) {
       indentbuf *newbuf = new indentbuf(os, 0);
       os.pword(indentbuf::idx) = newbuf;

--- a/items.cpp
+++ b/items.cpp
@@ -29,6 +29,8 @@
 #include "object.h"
 #include "gamedata.h"
 
+using namespace std;
+
 const int MonType::getAggression() {
 	int aggression = this->hostile;
 	aggression *= Globals->MONSTER_ADVANCE_HOSTILE_PERCENT;
@@ -675,10 +677,10 @@ AString *ItemDescription(int item, int full)
 
 	AString *temp = new AString;
 	int illusion = (ItemDefs[item].type & IT_ILLUSION);
-	
+
 	*temp += AString(illusion?"illusory ":"")+ ItemDefs[item].name + " [" +
 			(illusion?"I":"") + ItemDefs[item].abr + "]";
-		
+
 	/* new ship items */
 	if (ItemDefs[item].type & IT_SHIP) {
 		if (ItemDefs[item].swim > 0) {
@@ -737,7 +739,7 @@ AString *ItemDescription(int item, int full)
 			}
 		}
 	} else {
-		
+
 		*temp += AString(", weight ") + ItemDefs[item].weight;
 
 		if (ItemDefs[item].walk) {
@@ -874,7 +876,7 @@ AString *ItemDescription(int item, int full)
 		for (int c = 0; c < NUM_ATTACK_TYPES; c++) {
 			*temp += AString(" ") + MonResist(c,mp->defense[c], full);
 		}
-		
+
 		if (mp->special && mp->special != NULL) {
 			*temp += AString(" ") +
 				"Monster can cast " +
@@ -1003,11 +1005,11 @@ AString *ItemDescription(int item, int full)
 		*temp += " This is a free-moving-item (FMI).";
 		MonType *mp = FindMonster(ItemDefs[item].abr, (ItemDefs[item].type & IT_ILLUSION));
 		*temp += AString(" This FMI attacks with a combat skill of ") + mp->attackLevel + ".";
-		
+
 		for (int c = 0; c < NUM_ATTACK_TYPES; c++) {
 			*temp += AString(" ") + FMIResist(c,mp->defense[c], full);
 		}
-		
+
 		if (mp->special && mp->special != NULL) {
 			*temp += AString(" ") +
 				"FMI can cast " +
@@ -1299,7 +1301,7 @@ AString *ItemDescription(int item, int full)
 		} else {
 			*temp +=  AString(pM->minBonus) + " when ridden into combat.";
 		}
-		
+
 		*temp += AString(" This mount gives a maximum bonus of +");
 		if (Globals->HALF_RIDING_BONUS) {
 			*temp += AString(((pM->maxBonus + 1) / 2)) + " when ridden into combat.";
@@ -1814,16 +1816,16 @@ int ManType::CanProduce(int item)
 int ManType::CanUse(int item)
 {
 	if (ItemDefs[item].flags & ItemType::DISABLED) return 0;
-	
+
 	// Check if the item is a mount
 	if (ItemDefs[item].type & IT_MOUNT) return 1;
 
 	// Check if the item is a weapon
 	if (ItemDefs[item].type & IT_WEAPON) return 1;
-	
+
 	// Check if the item is a tool
 	if (ItemDefs[item].type & IT_TOOL) return 1;
-	
+
 	// Check if the item is an armor
 	if (ItemDefs[item].type & IT_ARMOR) {
 		ArmorType *armor = FindArmor(ItemDefs[item].abr);
@@ -1853,6 +1855,6 @@ int ManType::CanUse(int item)
 			if (mayWearArmor) return 1;
 		}
 	}
-	
+
 	return 0;
 }

--- a/items.h
+++ b/items.h
@@ -195,7 +195,7 @@ class ManType
 		int defaultlevel;
 		char const *skills[6];
 		Ethnicity ethnicity;
-		
+
 		int CanProduce(int);
 		int CanUse(int);
 };
@@ -239,7 +239,7 @@ class MonType
 		The general algorithm of the monster movement:
 
 		There are three categories of terrain: 1) what monster likes, 2) what monster is neutral, and 3) what monster dislikes.
-		
+
 		Monster will freely move through the terrain he likes, and there will be a standard chance to move into the terrain he likes.
 
 		The monster will never enter the terrain he dislikes and will have a 2x lower chance to enter neutral terrain.
@@ -456,9 +456,9 @@ class Item : public AListElem
 		Item();
 		~Item();
 
-		void Readin(istream& f);
-		void Writeout(ostream& f);
-		
+		void Readin(std::istream& f);
+		void Writeout(std::ostream& f);
+
 		AString Report(int);
 
 		int type;
@@ -470,8 +470,8 @@ class Item : public AListElem
 class ItemList : public AList
 {
 	public:
-		void Readin(istream& f);
-		void Writeout(ostream& f);
+		void Readin(std::istream& f);
+		void Writeout(std::ostream& f);
 
 		AString Report(int, int, int);
 		AString BattleReport();

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -295,25 +295,25 @@ void ARegionList::CreateSurfaceLevel(int level, int xSize, int ySize, char const
 	int sea = Globals->OCEAN;
 	if (Globals->SEA_LIMIT)
 		sea = sea * (100 + 2 * Globals->SEA_LIMIT) / 100;
-	
+
 	InitGeographicMap(pRegionArrays[level]);
-		
+
 	MakeLand(pRegionArrays[level], sea, Globals->CONTINENT_SIZE);
-	
+
 	RescaleFractalParameters(pRegionArrays[level]);
 
 	CleanUpWater(pRegionArrays[level]);
 
-	SetFractalTerrain(pRegionArrays[level]);	
-	
+	SetFractalTerrain(pRegionArrays[level]);
+
 	GrowTerrain(pRegionArrays[level], 0);
-	
+
 	AssignTypes(pRegionArrays[level]);
 
 	SeverLandBridges(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	NameRegions(pRegionArrays[level]);
 
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
@@ -407,18 +407,18 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1; // 
+				reg->race = -1; //
 				reg->wages = -1; // initially store: name
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
-				
+
 				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
 			}
 		}
 	}
-	
+
 	SetupNeighbors(arr);
 
 	Awrite("");
@@ -504,7 +504,7 @@ void ARegionList::MakeIcosahedralRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1; // 
+				reg->race = -1; //
 				reg->wages = -1; // initially store: name
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
@@ -551,7 +551,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 		for (int y=0; y < pRegs->y; y++) {
 			ARegion *r = pRegs->GetRegion(x,y);
 			if (!r) continue;
-			total++;				
+			total++;
 		}
 	}
 	ocean = total;
@@ -573,7 +573,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			if (!reg) continue;
 			ARegion *newreg = reg;
 			ARegion *seareg = reg;
-		
+
 			// Archipelago or Continent?
 			if (getrandom(100) < Globals->ARCHIPELAGO) {
 				// Make an Archipelago:
@@ -644,7 +644,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 				}
 			} else {
 				// make a continent
-				
+
 				if (reg->type == -1) {
 					reg->type = R_NUM;
 					ocean--;
@@ -654,7 +654,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 					if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 						&& (getrandom(4) < 3)) continue;
 					if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
-						&& (getrandom(4) < 3)) continue;				
+						&& (getrandom(4) < 3)) continue;
 					ARegion *newreg = reg->neighbors[dir];
 					if (!newreg) break;
 					int polecheck = 0;
@@ -668,7 +668,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 						reg->type = R_NUM;
 						ocean--;
 					}
-				}	
+				}
 			}
 		}
 	} else {
@@ -707,14 +707,14 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 						reg->type = R_NUM;
 						ocean--;
 					}
-				}				
+				}
 			}
 		}
 		sealevel--;
 		Adot();
 	}
 	Awrite("");
-	
+
 	Awrite("Add further land");
 	int coast = sealevel;
 	int dotter = 0;
@@ -743,7 +743,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			sealevel--;
 			margin = getrandom(sealevel/10 + 2) + 2;
 		}
-		
+
 		int cont = 0;
 		for (int i=0; i<NDIRS; i++) {
 			ARegion *nr = reg->neighbors[i];
@@ -751,7 +751,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			if (nr->elevation >= reg->elevation-3) cont++;
 		}
 		if (cont < 3) continue;
-	
+
 		if (dotter%50 == 0) Adot();
 		// make a continent
 		if (reg->type == -1) {
@@ -776,11 +776,11 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 			}
 			if (d1 >= 0) dir = d1;
 				else dir = getrandom(NDIRS);
-			
+
 			if ((reg->yloc < yoff*2) && ((dir < 2) || (dir = NDIRS-1))
 				&& (getrandom(4) < 3)) continue;
 			if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
-				&& (getrandom(4) < 3)) continue;				
+				&& (getrandom(4) < 3)) continue;
 			ARegion *newreg = reg->neighbors[dir];
 			if (!newreg) break;
 			int polecheck = 0;
@@ -797,7 +797,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 		}
 	}
 	}
-	
+
 	// At this point, go back through and set all the rest to ocean
 	SetRegTypes(pRegs, R_OCEAN);
 	Awrite("");
@@ -969,7 +969,7 @@ void ARegionList::RescaleFractalParameters(ARegionArray *pArr)
 				reg->culture = 100 * (old - cult_min) / (cult_max - cult_min);
 				if (getrandom(cult_max - cult_min) < (100 * (old - cult_min) % (cult_max - cult_min)))
 					reg->culture++;
-				
+
 			}
 		}
 	}
@@ -989,7 +989,7 @@ void ARegionList::SetFractalTerrain(ARegionArray *pArr)
 	for (int l=0; l < 2; l++) {
 		int set = 0;
 		//Awrite(AString("Fractal Terrain: run #") + (l+1) + ".");
-		
+
 		int skip = 250;
 		int f = 2;
 		if (Globals->TERRAIN_GRANULARITY) {
@@ -1113,12 +1113,12 @@ void ARegionList::NameRegions(ARegionArray *pArr)
 					r1->wages = AGetName(0, r1);
 					r1->population = (getrandom(2) + sz / 2)
 						* (getrandom(2) + sz);
-					
+
 					if (r1->xloc > xmin)
 						tnamedx[TerrainDefs[r1->type].similar_type] = r1->xloc;
 					if (r1->yloc > ymin)
 						tnamedy[TerrainDefs[r1->type].similar_type] = r1->yloc;
-					unnamed = 1;	
+					unnamed = 1;
 				}
 			}
 		}
@@ -1128,7 +1128,7 @@ void ARegionList::NameRegions(ARegionArray *pArr)
 			for (int x = 0; x < pArr->x; x++) {
 				for (int y = 0; y < pArr->y; y++) {
 					ARegion *reg = pArr->GetRegion(x,y);
-					if ((!reg) || (reg->type == R_OCEAN) 
+					if ((!reg) || (reg->type == R_OCEAN)
 						|| (reg->wages >= 0) || (reg->type == R_NUM)) continue;
 					int name1 = -99, name2 = -99;
 					int nw1 = 0, nw2 = 0, nc1 = 0, nc2 = 0, nn = 0;
@@ -1236,7 +1236,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 				if (!reg) continue;
 				if ((j > 0) && (j < 21) && (getrandom(3) < 2)) continue;
 				if (reg->type == R_NUM) {
-				
+
 					// Check for Lakes
 					if (Globals->LAKES &&
 						(getrandom(100) < (Globals->LAKES/10 + 1))) {
@@ -1250,7 +1250,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 						//	reg->wages = AGetName(0, reg);
 						break;
 					}
-					
+
 
 					int init = getrandom(6);
 					for (int i=0; i<NDIRS; i++) {
@@ -1663,7 +1663,7 @@ GeoMap::GeoMap(int x, int y)
 	for (int a=0; a<x; a++) {
 		for (int b=0; b<y; b++) {
 			long int coords = (size+1)*a + b;
-			geomap.insert(make_pair(coords, g));
+			geomap.insert(std::make_pair(coords, g));
 		}
 	}
 }
@@ -1691,7 +1691,7 @@ void GeoMap::Generate(int spread, int smoothness)
 				g.culture = GetCulture((x-size), y);
 			}
 			geomap.erase(coords);
-			geomap.insert(make_pair(coords, g));
+			geomap.insert(std::make_pair(coords, g));
 		}
 	}
 	int frac = 25;
@@ -1762,8 +1762,8 @@ void GeoMap::Generate(int spread, int smoothness)
 				if (g.humidity > 100) g.humidity = 100 - getrandom(4);
 				long int coords = (size+1) * xcoor + ycoor;
 				geomap.erase(coords);
-				geomap.insert(make_pair(coords, g));
-				
+				geomap.insert(std::make_pair(coords, g));
+
 			}
 		}
 		Adot();
@@ -1833,7 +1833,7 @@ void GeoMap::Generate(int spread, int smoothness)
 							nb++;
 						}
 					}
-					
+
 					Geography g;
 					int r1 = getrandom(2*frac) - frac;
 					int r2 = getrandom(2*frac) - frac;
@@ -1857,11 +1857,11 @@ void GeoMap::Generate(int spread, int smoothness)
 						g.temperature = 100 - getrandom(4);
 					}
 					if (g.humidity < 1) g.humidity = getrandom(5);
-					if (g.humidity > 100) g.humidity = 100 - getrandom(4);	
+					if (g.humidity > 100) g.humidity = 100 - getrandom(4);
 					long int coords = (size+1) * dx + dy;
 					geomap.erase(coords);
-					geomap.insert(make_pair(coords, g));
-					
+					geomap.insert(std::make_pair(coords, g));
+
 				}
 			}
 		}
@@ -1874,7 +1874,7 @@ void GeoMap::Generate(int spread, int smoothness)
 int GeoMap::GetElevation(int x, int y)
 {
 	long int coords = (size+1)*x + y;
-	map<long int,Geography>::iterator it = geomap.find(coords);
+	std::map<long int,Geography>::iterator it = geomap.find(coords);
 	if (it != geomap.end()) {
 		Geography g = it->second;
 		return g.elevation;
@@ -1885,7 +1885,7 @@ int GeoMap::GetElevation(int x, int y)
 int GeoMap::GetHumidity(int x, int y)
 {
 	long int coords = (size+1)*x + y;
-	map<long int,Geography>::iterator it = geomap.find(coords);
+	std::map<long int,Geography>::iterator it = geomap.find(coords);
 	if (it != geomap.end()) {
 		Geography g = it->second;
 		return g.humidity;
@@ -1896,7 +1896,7 @@ int GeoMap::GetHumidity(int x, int y)
 int GeoMap::GetTemperature(int x, int y)
 {
 	long int coords = (size+1)*x + y;
-	map<long int,Geography>::iterator it = geomap.find(coords);
+	std::map<long int,Geography>::iterator it = geomap.find(coords);
 	if (it != geomap.end()) {
 		Geography g = it->second;
 		return g.temperature;
@@ -1907,7 +1907,7 @@ int GeoMap::GetTemperature(int x, int y)
 int GeoMap::GetVegetation(int x, int y)
 {
 	long int coords = (size+1)*x + y;
-	map<long int,Geography>::iterator it = geomap.find(coords);
+	std::map<long int,Geography>::iterator it = geomap.find(coords);
 	if (it != geomap.end()) {
 		Geography g = it->second;
 		return g.vegetation;
@@ -1918,7 +1918,7 @@ int GeoMap::GetVegetation(int x, int y)
 int GeoMap::GetCulture(int x, int y)
 {
 	long int coords = (size+1)*x + y;
-	map<long int,Geography>::iterator it = geomap.find(coords);
+	std::map<long int,Geography>::iterator it = geomap.find(coords);
 	if (it != geomap.end()) {
 		Geography g = it->second;
 		return g.culture;
@@ -1926,7 +1926,7 @@ int GeoMap::GetCulture(int x, int y)
 	return 0;
 }
 
-void GeoMap::ApplyGeography(ARegionArray *pArr) 
+void GeoMap::ApplyGeography(ARegionArray *pArr)
 {
 	int x, y;
 	int hmin = 100;
@@ -1958,7 +1958,7 @@ void GeoMap::ApplyGeography(ARegionArray *pArr)
 			reg->humidity = reg->humidity / ctr;
 			reg->temperature = reg->temperature / ctr;
 			reg->vegetation = reg->vegetation / ctr;
-			reg->culture = reg->culture / ctr;	
+			reg->culture = reg->culture / ctr;
 			if (reg->humidity > hmax) hmax = reg->humidity;
 			if (reg->humidity < hmin) hmin = reg->humidity;
 		}

--- a/market.cpp
+++ b/market.cpp
@@ -68,7 +68,7 @@ void Market::post_turn(int population, int wages)
 	}
 }
 
-void Market::write_out(ostream& f)
+void Market::write_out(std::ostream& f)
 {
 	f << type << '\n';
 	f << (item == -1 ? "NO_ITEM" : ItemDefs[item].abr) << '\n';
@@ -81,7 +81,7 @@ void Market::write_out(ostream& f)
 	f << baseprice << '\n';
 }
 
-void Market::read_in(istream& f)
+void Market::read_in(std::istream& f)
 {
 	AString temp;
 
@@ -90,7 +90,7 @@ void Market::read_in(istream& f)
 
 	type = MarketType{t};
 
-	f >> ws >> temp;
+	f >> std::ws >> temp;
 	item = LookupItem(&temp);
 
 	f >> price;

--- a/market.h
+++ b/market.h
@@ -27,8 +27,6 @@
 
 #include <iostream>
 
-using namespace std;
-
 class Market {
 public:
 	enum MarketType : int {
@@ -52,7 +50,7 @@ public:
 	int item;
 	int price;
 	int amount;
-	
+
 	int minpop;
 	int maxpop;
 	int minamt;

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -36,6 +36,8 @@
 #include "gamedata.h"
 #include "quests.h"
 
+using namespace std;
+
 void Game::RunMovementOrders()
 {
 	int phase, error;
@@ -171,7 +173,7 @@ void Game::RunMovementOrders()
 					u->savedmovement = 0;
 					u->savedmovedir = -1;
 				}
-				if (u->monthorders && 
+				if (u->monthorders &&
 						(u->monthorders->type == O_MOVE ||
 						u->monthorders->type == O_ADVANCE)) {
 					mo = (MoveOrder *) u->monthorders;
@@ -195,7 +197,7 @@ void Game::RunMovementOrders()
 			}
 			Unit *u = o->GetOwner();
 			if (o->IsFleet() && u && !u->nomove &&
-					u->monthorders && 
+					u->monthorders &&
 					u->monthorders->type == O_SAIL) {
 				so = (SailOrder *) u->monthorders;
 				if (so->dirs.Num() > 0) {
@@ -551,7 +553,7 @@ void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
 		u->monthorders = 0;
 		return;
 	}
-	
+
 	int needed = buildobj->incomplete;
 	int type = buildobj->type;
 	// AS
@@ -620,7 +622,7 @@ void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
 	}
 
 	/* Perform the build */
-	
+
 	if (obj != buildobj)
 		u->MoveUnit(buildobj);
 
@@ -635,7 +637,7 @@ void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
 	} else {
 		u->ConsumeShared(it, num);
 	}
-	
+
 	/* Regional economic improvement */
 	r->improvement += num;
 
@@ -670,7 +672,7 @@ void Game::RunBuildShipOrder(ARegion * r,Object * obj,Unit * u)
 
 	// get needed to complete
 	maxbuild = 0;
-	if ((u->monthorders) && 
+	if ((u->monthorders) &&
 		(u->monthorders->type == O_BUILD)) {
 			BuildOrder *border = (BuildOrder *) u->monthorders;
 			maxbuild = border->needtocomplete;
@@ -681,16 +683,16 @@ void Game::RunBuildShipOrder(ARegion * r,Object * obj,Unit * u)
 		unfinished = 0;
 	} else {
 		output = ShipConstruction(r, u, u, level, maxbuild, ship);
-		
+
 		if (output < 1) return;
-		
+
 		// are there unfinished ship items of the given type?
 		unfinished = u->items.GetNum(ship);
-		
+
 		if (unfinished == 0) {
 			// Start a new ship's construction from scratch
 			unfinished = ItemDefs[ship].pMonths;
-			u->items.SetNum(ship, unfinished);	
+			u->items.SetNum(ship, unfinished);
 		}
 
 		// Now reduce unfinished by produced amount
@@ -807,7 +809,7 @@ void Game::RunBuildHelpers(ARegion *r)
 							int skill = LookupSkill(&skname);
 							int level = u->GetSkill(skill);
 							int needed = 0;
-							if ((target->monthorders) && 
+							if ((target->monthorders) &&
 									(target->monthorders->type == O_BUILD)) {
 										BuildOrder *border = (BuildOrder *) target->monthorders;
 										needed = border->needtocomplete;
@@ -820,21 +822,21 @@ void Game::RunBuildHelpers(ARegion *r)
 							}
 							int output = ShipConstruction(r, u, target, level, needed, ship);
 							if (output < 1) continue;
-							
+
 							int unfinished = target->items.GetNum(ship);
 							if (unfinished == 0) {
 								// Start construction on a new ship
 								unfinished = ItemDefs[ship].pMonths;
-								target->items.SetNum(ship, unfinished);	
+								target->items.SetNum(ship, unfinished);
 							}
 							unfinished -= output;
-							
+
 							// practice
 							u->Practice(skill);
-							
+
 							if (unfinished > 0) {
 								target->items.SetNum(ship, unfinished);
-								if ((target->monthorders) && 
+								if ((target->monthorders) &&
 									(target->monthorders->type == O_BUILD)) {
 										BuildOrder *border = (BuildOrder *) target->monthorders;
 										border->needtocomplete = unfinished;
@@ -843,16 +845,16 @@ void Game::RunBuildHelpers(ARegion *r)
 								// CreateShip(r, target, ship);
 								// don't create the ship yet; leave that for the unit we're helping
 								target->items.SetNum(ship, 1);
-								if ((target->monthorders) && 
+								if ((target->monthorders) &&
 									(target->monthorders->type == O_BUILD)) {
 										BuildOrder *border = (BuildOrder *) target->monthorders;
 										border->needtocomplete = 0;
 								}
-							} 
+							}
 							int percent = 100 * output / ItemDefs[ship].pMonths;
-							u->event("Helps " + string(target->name->const_str()) + " with construction of a " + 
+							u->event("Helps " + string(target->name->const_str()) + " with construction of a " +
 								ItemDefs[ship].name + " (" + to_string(percent) + "%) in " +
-								r->ShortPrint().const_str() + ".", "build", r);							
+								r->ShortPrint().const_str() + ".", "build", r);
 						}
 						// no need to move unit if item-type ships
 						// are being built. (leave this commented out)
@@ -863,7 +865,7 @@ void Game::RunBuildHelpers(ARegion *r)
 						Object *buildobj;
 						if (u->build > 0) {
 							buildobj = r->GetObject(u->build);
-							if (buildobj && 
+							if (buildobj &&
 									buildobj != r->GetDummy() &&
 									buildobj != u->object)
 							{
@@ -877,7 +879,7 @@ void Game::RunBuildHelpers(ARegion *r)
 	}
 }
 
-/* Creates a new ship - either by adding it to a 
+/* Creates a new ship - either by adding it to a
  * compatible fleet object or creating a new fleet
  * object with Unit u as owner consisting of exactly
  * ONE ship of the given type.
@@ -941,10 +943,10 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 		// don't adjust for pMonths
 		// - pMonths represents total requirement
 		maxproduced = number;
-	
+
 	// adjust maxproduced for items needed until completion
 	if (needed < maxproduced) maxproduced = needed;
-		
+
 	// adjust maxproduced for unfinished ships
 	if ((unfinished > 0) && (maxproduced > unfinished))
 		maxproduced = unfinished;
@@ -961,7 +963,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 		if (maxproduced > count)
 			maxproduced = count;
 		count = maxproduced;
-		
+
 		// no required materials?
 		if (count < 1) {
 			u->error("BUILD: Don't have the required materials.");
@@ -969,7 +971,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 			u->monthorders = 0;
 			return 0;
 		}
-		
+
 		/* regional economic improvement */
 		r->improvement += count;
 
@@ -1001,7 +1003,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 				}
 			}
 		}
-		
+
 		// no required materials?
 		if (maxproduced < 1) {
 			u->error("BUILD: Don't have the required materials.");
@@ -1009,10 +1011,10 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 			u->monthorders = 0;
 			return 0;
 		}
-		
+
 		/* regional economic improvement */
 		r->improvement += maxproduced;
-		
+
 		// Deduct the items spent
 		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[ship].pInput[c].item;
@@ -1028,7 +1030,7 @@ int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int nee
 
 	delete u->monthorders;
 	u->monthorders = 0;
-	
+
 	return output;
 }
 
@@ -1121,7 +1123,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 		if (maxproduced > count)
 			maxproduced = count;
 		count = maxproduced;
-		
+
 		/* regional economic improvement */
 		r->improvement += count;
 
@@ -1153,10 +1155,10 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 				}
 			}
 		}
-		
+
 		/* regional economic improvement */
 		r->improvement += maxproduced;
-		
+
 		// Deduct the items spent
 		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
 			int i = ItemDefs[o->item].pInput[c].item;
@@ -1174,7 +1176,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
 	if (ItemDefs[o->item].flags & ItemType::SKILLOUT_HALF) {
 		output *= (level + 1) / 2;
 	}
-		
+
 	u->items.SetNum(o->item,u->items.GetNum(o->item) + output);
 	u->event("Produces " + ItemString(o->item,output) + " in " + r->ShortPrint().const_str() + ".",
 		"produce", r);
@@ -1418,7 +1420,7 @@ void Game::Do1StudyOrder(Unit *u,Object *obj)
 		u->error("STUDY: " + SkillDefs[sk].name + " cannot be studied.");
 		return;
 	}
-	
+
 	// Small patch for Ceran Mercs
 	if (u->GetMen(I_MERC)) {
 		u->error("STUDY: Mercenaries are not allowed to study.");
@@ -1517,7 +1519,7 @@ void Game::Do1StudyOrder(Unit *u,Object *obj)
 
 	// If TACTICS_NEEDS_WAR is enabled, and the unit is trying to study to tact-5,
 	// check that there's still space...
-	if (Globals->TACTICS_NEEDS_WAR && sk == S_TACTICS && 
+	if (Globals->TACTICS_NEEDS_WAR && sk == S_TACTICS &&
 			u->GetSkill(sk) == 4 && u->skills.GetDays(sk)/u->GetMen() >= 300) {
 		if (CountTacticians(u->faction) >=
 				AllowedTacticians(u->faction)) {
@@ -1528,9 +1530,9 @@ void Game::Do1StudyOrder(Unit *u,Object *obj)
 			u->error("STUDY: Only 1-man units can study to level 5 in tactics.");
 			return;
 		}
-		
+
 	} // end tactics check
-	
+
 	// adjust teaching for study rate
 	taughtdays = ((long int) o->days * u->skills.GetStudyRate(sk, u->GetMen()) / 30);
 
@@ -1581,7 +1583,7 @@ void Game::Do1StudyOrder(Unit *u,Object *obj)
 			} else {
 				string msg = "Completes study to level " + to_string(o->level) + " in " + SkillDefs[sk].name + ".";
 				u->event(msg, "study");
-			}	
+			}
 		}
 	} else {
 		// if we just tried to become a mage or apprentice, but

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -192,7 +192,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				reward_count = (QUEST_MAX_REWARD + getrandom(QUEST_MAX_REWARD / 2)) / ItemDefs[i].baseprice;
 
 				printf("\nQuest reward: %s x %d.\n", ItemDefs[i].name.c_str(), reward_count);
-				
+
 				// Setup reward
 				Item item;
 				item.type = i;
@@ -310,7 +310,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 		forlist(regions) {
 			r = (ARegion *) elem;
 			// No need to check if quests do not require exploration
-			if (r->Population() > 0 && (r->visited || QUEST_EXPLORATION_PERCENT == 0)) { 
+			if (r->Population() > 0 && (r->visited || QUEST_EXPLORATION_PERCENT == 0)) {
 				stlstr = r->name->Str();
 				// This looks like a null operation, but
 				// actually forces the map<> element creation
@@ -1177,11 +1177,11 @@ void Game::ModifyTablesPerRuleset(void)
 	EnableItem(I_ILLYRTHID);
 	EnableItem(O_ILAIR);
 	EnableItem(I_DEVIL);
-	
+
 	EnableItem(I_STORMGIANT);
 	EnableItem(I_CLOUDGIANT);
 	EnableItem(O_GIANTCASTLE);
-	
+
 	EnableItem(I_WARRIORS);
 
 	EnableItem(I_DARKMAGE);
@@ -1219,7 +1219,7 @@ void Game::ModifyTablesPerRuleset(void)
 	ModifyRaceSkills("HUMN", 3, "MINI");
 	ModifyRaceSkills("HUMN", 4, "FARM");
 	ModifyRaceSkills("HUMN", 5, "COOK");
-	
+
 	EnableItem(I_HILLDWARF);
 	ModifyItemBasePrice(I_HILLDWARF, 40);
 	ModifyRaceSkillLevels("HDWA", 5, 2);
@@ -1237,7 +1237,7 @@ void Game::ModifyTablesPerRuleset(void)
 	ModifyRaceSkills("IDWA", 2, "MINI");
 	ModifyRaceSkills("IDWA", 3, "FISH");
 	ModifyRaceSkills("IDWA", 4, "ARMO");
-	
+
 	EnableItem(I_HIGHELF);
 	ModifyItemBasePrice(I_HIGHELF, 40);
 	ModifyRaceSkillLevels("HELF", 5, 2);
@@ -1390,7 +1390,7 @@ void Game::ModifyTablesPerRuleset(void)
 	ModifyTerrainCoastRace(R_JUNGLE, 1, I_WOODELF);
 	ModifyTerrainCoastRace(R_JUNGLE, 2, I_LIZARDMAN);
 	ModifyTerrainEconomy(R_JUNGLE, 500, 11, 20, 2);
-	
+
 	ClearTerrainRaces(R_DESERT);
 	ModifyTerrainRace(R_DESERT, 0, I_GNOLL);
 	ModifyTerrainRace(R_DESERT, 1, I_GOBLINMAN);

--- a/neworigins/map.cpp
+++ b/neworigins/map.cpp
@@ -134,7 +134,7 @@ int ZoneRegion::CountNeighbors(Province* province) {
 std::vector<Zone *> ZoneRegion::GetNeihborZones() {
 	std::vector<Zone *> items;
 	items.reserve(NDIRS);
-	
+
 	for (int i = 0; i < NDIRS; i++) {
 		auto n = this->neighbors[i];
 		if (n == NULL) continue;
@@ -227,7 +227,7 @@ std::unordered_set<Province *> Province::GetNeighbors() {
 
 std::unordered_set<int> Province::GetNeighborBiomes() {
 	std::unordered_set<int> biomes;
-	
+
 	auto tmp = this->GetNeighbors();
 	for (auto &n : tmp) {
 		if (n->biome != -1) biomes.insert(n->biome);
@@ -253,7 +253,7 @@ Coords Province::GetLocation() {
 
 			continue;
 		}
-		
+
 		xMin = std::min(xMin, reg->location.x);
 		yMin = std::min(yMin, reg->location.y);
 		xMax = std::max(xMax, reg->location.x);
@@ -441,7 +441,7 @@ void Zone::AddNeighbor(Zone* zone) {
 
 void Zone::SetConnections() {
 	std::unordered_set<Zone *> visited;
-	
+
 	for (auto &region : this->regions) {
 		for (auto &n : region.second->neighbors) {
 			if (n == NULL) continue;
@@ -557,7 +557,7 @@ int EstimateMaxZones(int area, int radius) {
 int GetRegionIndex(const int x, const int y, const int w, const int h) {
 	int xx = (x + w) % w;
 	int yy = (y + h) % h;
-	
+
 	if ((xx + yy) % 2) {
 		return -1;
 	}
@@ -781,14 +781,14 @@ void MapBuilder::GrowZones() {
 
 	ClearEmptyZones();
 	ConnectZones();
-} 
+}
 
 void MapBuilder::MergeZoneInto(Zone* src, Zone* dest) {
 	if (src == NULL) {
 		Awrite("src cannot be null");
 		exit(1);
 	}
-	
+
 	if (dest == NULL) {
 		Awrite("dest cannot be null");
 		exit(1);
@@ -829,7 +829,7 @@ void MapBuilder::SplitZone(Zone* zone) {
 	auto blob = zone->TraverseRegions();
 	while (zone->regions.size() != blob.size()) {
 		Zone* newZone = CreateZone(zone->type);
-		
+
 		for (auto &region : blob) {
 			zone->RemoveRegion(region);
 			newZone->AddRegion(region);
@@ -874,7 +874,7 @@ std::vector<ZoneRegion *> FindBorderRegions(Zone* zone, Zone* borderZone, const 
 					int roll = makeRoll(1, 5);
 					if (roll < diff) continue;
 				}
-				
+
 				visited.insert(region);
 			}
 
@@ -892,7 +892,7 @@ std::vector<ZoneRegion *> FindBorderRegions(Zone* zone, Zone* borderZone, const 
 					int roll = makeRoll(1, 5);
 					if (roll < diff) continue;
 				}
-				
+
 				v.push_back(region);
 			}
 		}
@@ -1011,11 +1011,11 @@ void MapBuilder::SpecializeZones(size_t continents, int continentAreaFraction) {
 		if (depthRoll == 1) {
 			if (sideADepth == 0) {
 				sideADepth = 1;
-				sideARandom = true;	
+				sideARandom = true;
 			}
 			else {
 				sideBDepth = 1;
-				sideBRandom = true;	
+				sideBRandom = true;
 			}
 		}
 		else if (depthRoll == 2) {
@@ -1045,7 +1045,7 @@ void MapBuilder::SpecializeZones(size_t continents, int continentAreaFraction) {
 			otherZone->RemoveRegion(r);
 			strait->AddRegion(r);
 		}
-		
+
 		SplitZone(strait);
 
 		if (sideADepth > 0) SplitZone(nonIsland);
@@ -1275,7 +1275,7 @@ void MapBuilder::AddVolcanoes() {
 					candidates.clear();
 					for (auto &kv : zone->regions) {
 						auto region = kv.second;
-						
+
 						if (region->IsInner()) continue;
 
 						for (int i = 0; i < NDIRS; i++) {
@@ -1450,7 +1450,7 @@ void MapBuilder::GrowLandInZone(Zone* zone) {
 		while (attempts++ < 1000) {
 			ZoneRegion* next = candidates[getrandom(candidates.size())];
 			if (next->province != NULL) continue;
-			
+
 			provinces.push_back(zone->CreateProvince(next, this->h));
 			break;
 		}
@@ -1525,7 +1525,7 @@ void MapBuilder::GrowLandInZone(Zone* zone) {
 		while (small != NULL);
 	}
 
-	// set biomes for provinces	
+	// set biomes for provinces
 	std::unordered_set<int> biomes;
 	for (auto &kv : zone->provinces) {
 		auto p = kv.second;
@@ -1742,21 +1742,21 @@ void ARegionList::CreateSurfaceLevel(int level, int xSize, int ySize, char const
 	int sea = Globals->OCEAN;
 	if (Globals->SEA_LIMIT)
 		sea = sea * (100 + 2 * Globals->SEA_LIMIT) / 100;
-			
+
 	MakeLand(pRegionArrays[level], sea, Globals->CONTINENT_SIZE);
-	
+
 	CleanUpWater(pRegionArrays[level]);
 
 	SetupAnchors(pRegionArrays[level]);
-	
+
 	GrowTerrain(pRegionArrays[level], 0);
-	
+
 	AssignTypes(pRegionArrays[level]);
 
 	SeverLandBridges(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -1847,7 +1847,7 @@ void ARegionList::CreateIslandLevel(int level, int nPlayers, char const *name)
 	RandomTerrain(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -1883,7 +1883,7 @@ void ARegionList::CreateIslandRingLevel(int level, int xSize, int ySize, char co
 		if (n) {
 			Object *o = new Object(n);
 			o->num = n->buildingseq++;
-			string altar_name = string(ObjectDefs[O_RITUAL_ALTAR].name) + " [" + to_string(o->num) + "]";
+			std::string altar_name = std::string(ObjectDefs[O_RITUAL_ALTAR].name) + " [" + std::to_string(o->num) + "]";
 			o->name = new AString(altar_name);
 			o->type = O_RITUAL_ALTAR;
 			o->incomplete = -(ObjectDefs[O_RITUAL_ALTAR].sacrifice_amount);
@@ -1952,7 +1952,7 @@ void ARegionList::CreateUnderworldRingLevel(int level, int xSize, int ySize, cha
 	// Put the monolith in the underworld center
 	o = new Object(reg);
 	o->num = reg->buildingseq++;
-	string monolith_name = string(ObjectDefs[O_DORMANT_MONOLITH].name) + " [" + to_string(o->num) + "]";
+	std::string monolith_name = std::string(ObjectDefs[O_DORMANT_MONOLITH].name) + " [" + std::to_string(o->num) + "]";
 	o->name = new AString(monolith_name);
 	o->type = O_DORMANT_MONOLITH;
 	o->incomplete = -(ObjectDefs[O_DORMANT_MONOLITH].sacrifice_amount);
@@ -1984,7 +1984,7 @@ void ARegionList::CreateUnderworldLevel(int level, int xSize, int ySize, char co
 	MakeUWMaze(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -2013,7 +2013,7 @@ void ARegionList::CreateUnderdeepLevel(int level, int xSize, int ySize,
 	MakeUWMaze(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -2041,9 +2041,9 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1;  
-				reg->wages = -1; 
-				
+				reg->race = -1;
+				reg->wages = -1;
+
 				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
@@ -2136,7 +2136,7 @@ void ARegionList::MakeIcosahedralRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1; // 
+				reg->race = -1; //
 				reg->wages = -1; // initially store: name
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
@@ -2191,7 +2191,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 		if (!reg) continue;
 		ARegion *newreg = reg;
 		ARegion *seareg = reg;
-		
+
 		// Archipelago or Continent?
 		if (getrandom(100) < Globals->ARCHIPELAGO) {
 			// Make an Archipelago:
@@ -2273,7 +2273,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
-					&& (getrandom(4) < 3)) continue;				
+					&& (getrandom(4) < 3)) continue;
 				ARegion *newreg = reg->neighbors[dir];
 				if (!newreg) break;
 				int polecheck = 0;
@@ -2611,7 +2611,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 				if (!reg) continue;
 				if ((j > 0) && (j < 21) && (getrandom(3) < 2)) continue;
 				if (reg->type == R_NUM) {
-				
+
 					// Check for Lakes
 					if (Globals->LAKES &&
 						(getrandom(100) < (Globals->LAKES/10 + 1))) {
@@ -2625,7 +2625,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 							reg->wages = AGetName(0, reg);
 						break;
 					}
-					
+
 
 					int init = getrandom(6);
 					for (int i=0; i<NDIRS; i++) {
@@ -2759,14 +2759,14 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			int xoff = x + 2 - getrandom(3) - getrandom(3);
 			ARegion *reg = pArr->GetRegion(xoff, y);
 			if (!reg) continue;
-			
+
 			if ((reg->type == R_LAKE) && (!Globals->LAKESIDE_IS_COASTAL))
 				continue;
 			if (TerrainDefs[reg->type].flags & TerrainType::BARREN) continue;
-			
+
 			reg->race = -1;
 			wigout = 0; // reset sanity
-			
+
 			if (TerrainDefs[reg->type].similar_type == R_OCEAN) {
 				// setup near coastal race here
 				int d = getrandom(NDIRS);
@@ -2777,7 +2777,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
 						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
 							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
-						
+
 						while (reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
@@ -2792,13 +2792,13 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			} else {
 				// setup noncoastal race here
 				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
-				
+
 				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
 			}
-			
+
 			/* leave out this sort of check for the moment
 			if (wigout > 100) {
 				// do something!
@@ -2807,10 +2807,10 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				Awrite(" region type");
 			}
 			*/
-			
+
 			if (reg->race == -1) {
-				cout << "Hey! No race anchor got assigned to the " 
-					<< TerrainDefs[reg->type].name 
+				std::cout << "Hey! No race anchor got assigned to the "
+					<< TerrainDefs[reg->type].name
 					<< " at " << x << "," << y << "\n";
 			}
 		}
@@ -2996,10 +2996,10 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 				std::map<int, ARegion *> dests;
 				for (int type = R_PLAIN; type <= R_TUNDRA; type++) {
 					if (candidates[type].size() == 0) {
-						cout << "Error: No valid candidate found for gateway to " << TerrainDefs[type].name << "\n";
+						std::cout << "Error: No valid candidate found for gateway to " << TerrainDefs[type].name << "\n";
 						exit(1);
 					}
-					Awrite("Found " + to_string(candidates[type].size()) + " candidates for " +
+					Awrite("Found " + std::to_string(candidates[type].size()) + " candidates for " +
 						TerrainDefs[type].name + " gateway");
 					std::uniform_int_distribution<std::size_t> dist(0, candidates[type].size() - 1);
 					int index = dist(gen);
@@ -3025,7 +3025,7 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 						dest = candidates[type][index];
 					}
 					// store the best we have so far
-					Awrite("Best distance of " + to_string(maxMin) + " for " + TerrainDefs[type].name);
+					Awrite("Best distance of " + std::to_string(maxMin) + " for " + TerrainDefs[type].name);
 					dests[type] = best;
 				}
 

--- a/object.cpp
+++ b/object.cpp
@@ -100,7 +100,7 @@ Object::~Object()
 	region = (ARegion *)NULL;
 }
 
-void Object::Writeout(ostream& f)
+void Object::Writeout(std::ostream& f)
 {
 	f << num << '\n';
 	f << (type == -1
@@ -119,24 +119,24 @@ void Object::Writeout(ostream& f)
 	WriteoutFleet(f);
 }
 
-void Object::Readin(istream& f, AList *facs)
+void Object::Readin(std::istream& f, AList *facs)
 {
 	AString temp;
 
 	f >> num;
 
-	f >> ws >> temp;
+	f >> std::ws >> temp;
 	type = LookupObject(&temp);
 
 	f >> incomplete;
 
 	if (name) delete name;
-	f >> ws >> temp;
+	f >> std::ws >> temp;
 	name = new AString(temp);
 	AString *tmp = name->stripnumber();
 	SetName(tmp);
 
-	f >> ws >> temp;
+	f >> std::ws >> temp;
 	describe = temp.getlegal();
 	if (*describe == "none") {
 		delete describe;
@@ -291,7 +291,7 @@ void Object::build_json_report(json& j, Faction *fac, int obs, int truesight,
 	if (type != O_DUMMY) {
 		ObjectType& ob = ObjectDefs[type];
 
-		string s = name->const_str();
+		std::string s = name->const_str();
 		container["name"] = s.substr(0, s.find(" [")); // remove the object number.
 		container["number"] = num;
 		container["type"] = ob.name;
@@ -412,7 +412,7 @@ int Object::CheckShip(int item)
 	return 0;
 }
 
-void Object::WriteoutFleet(ostream& f)
+void Object::WriteoutFleet(std::ostream& f)
 {
 	if (!IsFleet()) return;
 	f << ships.Num() << "\n";
@@ -420,7 +420,7 @@ void Object::WriteoutFleet(ostream& f)
 		((Item *) elem)->Writeout(f);
 }
 
-void Object::ReadinFleet(istream &f)
+void Object::ReadinFleet(std::istream &f)
 {
 	if (type != O_FLEET) return;
 	int nships;
@@ -486,11 +486,11 @@ void Object::SetNumShips(int type, int num)
 /* Adds one ship of the given type.
  */
 void Object::AddShip(int type)
-{	
+{
 	if (CheckShip(type) == 0) return;
 	int num = GetNumShips(type);
 	num++;
-	SetNumShips(type, num);	
+	SetNumShips(type, num);
 }
 
 /* Returns the String 'Fleet' for multi-ship fleets
@@ -586,7 +586,7 @@ int Object::SailThroughCheck(int dir)
 		if (!region->neighbors[dir]) {
 			return 0;
 		}
-		
+
 		// flying fleets always can sail through
 		if (flying == 1) {
 			return 1;
@@ -736,7 +736,7 @@ int Object::GetFleetSpeed(int report)
 
 	// check for sufficient sailing skill!
 	if (tskill < (weight / 50)) return 0;
-	
+
 	// count wind mages
 	for(auto unit: units) {
 		int wb = unit->GetAttribute("wind");
@@ -762,7 +762,7 @@ int Object::GetFleetSpeed(int report)
 
 	// check for being overloaded
 	if (FleetLoad() > capacity) return 0;
-	
+
 	// speed bonus due to low load:
 	int loadfactor = (capacity / FleetLoad());
 	bonus = 0;
@@ -825,7 +825,7 @@ AString *ObjectDescription(int obj)
 		*temp += AString(" This structure provides defense to the first ") +
 			o->protect + " men inside it.";
 		// Now do the defences. First, figure out how many to do.
-		int totaldef = 0; 
+		int totaldef = 0;
 		for (int i=0; i<NUM_ATTACK_TYPES; i++) {
 			totaldef += (o->defenceArray[i] != 0);
 		}
@@ -836,7 +836,7 @@ AString *ObjectDescription(int obj)
 				totaldef--;
 				*temp += AString(o->defenceArray[i]) + " against " +
 					AttType(i) + AString(" attacks");
-				
+
 				if (totaldef >= 2) {
 					*temp += AString(", ");
 				} else {
@@ -845,7 +845,7 @@ AString *ObjectDescription(int obj)
 					} else {	// last bonus
 						*temp += AString(".");
 					}
-				} // end if 
+				} // end if
 			}
 		} // end for
 

--- a/object.h
+++ b/object.h
@@ -111,8 +111,8 @@ class Object : public AListElem
 		Object(ARegion *region);
 		~Object();
 
-		void Readin(istream& f, AList *);
-		void Writeout(ostream& f);
+		void Readin(std::istream& f, AList *);
+		void Writeout(std::ostream& f);
 		void build_json_report(json& j, Faction *, int, int, int, int, int, int, int);
 
 		void SetName(AString *);
@@ -134,10 +134,10 @@ class Object : public AListElem
 
 		void SetPrevDir(int);
 		void MoveObject(ARegion *toreg);
-		
+
 		// Fleets
-		void ReadinFleet(istream &f);
-		void WriteoutFleet(ostream &f);
+		void ReadinFleet(std::istream &f);
+		void WriteoutFleet(std::ostream &f);
 		int CheckShip(int);
 		int GetNumShips(int);
 		void SetNumShips(int, int);
@@ -149,7 +149,7 @@ class Object : public AListElem
 		int FleetSailingSkill(int);
 		int GetFleetSize();
 		int GetFleetSpeed(int);
-		
+
 		AString *name;
 		AString *describe;
 		ARegion *region;

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -31,6 +31,8 @@
 #include "skills.h"
 #include "gamedata.h"
 
+using namespace std;
+
 void OrdersCheck::error(const string& err)
 {
 	pCheckFile << "\n\n*** Error: " << err << " ***\n";
@@ -164,7 +166,7 @@ int ParseFactionType(AString *o, std::unordered_map<std::string, int> &type)
 
 	while(token) {
 		bool foundone = false;
-		
+
 		for (auto &ft : *FactionTypes) {
 			if (*token == ft.c_str()) {
 				delete token;
@@ -773,7 +775,7 @@ void Game::ProcessReshowOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 {
 	int sk, lvl, item, obj;
 	AString *token;
-	
+
 	token = o->gettoken();
 	if (!token) {
 		// LLS
@@ -1481,7 +1483,7 @@ void Game::ProcessPromoteOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 
 void Game::ProcessLeaveOrder(Unit *u, OrdersCheck *pCheck)
 {
-	if (!pCheck) {	
+	if (!pCheck) {
 		// if the unit isn't already trying to enter a building,
 		// then set it to leave.
 		if (u->enter == 0) u->enter = -1;
@@ -1516,7 +1518,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	// 'incomplete' for ships:
 	maxbuild = 0;
 	unit->build = 0;
-	
+
 	if (token) {
 		if (*token == "help") {
 			// "build help unitnum"
@@ -1542,14 +1544,14 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 				parse_error(pCheck, unit, 0, "BUILD: Not a valid object name.");
 				return;
 			}
-			
+
 			if (!pCheck) {
 				ARegion *reg = unit->object->region;
 				if (TerrainDefs[reg->type].similar_type == R_OCEAN){
 					unit->error("BUILD: Can't build in an ocean.");
 					return;
 				}
-				
+
 				if (ot < 0) {
 					/* Build SHIP item */
 					int st = abs(ot+1);
@@ -1568,7 +1570,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 					// ship, see how much work is left
 					if (unit->items.GetNum(st) > 0)
 						maxbuild = unit->items.GetNum(st);
-					// Don't create a fleet yet	
+					// Don't create a fleet yet
 				} else {
 					/* build standard OBJECT */
 					if (ObjectDefs[ot].flags & ObjectType::DISABLED) {
@@ -1604,7 +1606,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 						break;
 				}
 			}
-			
+
 			if (st == O_DUMMY) {
 				// Build whatever we happen to be in when
 				// we get to the build phase
@@ -1617,19 +1619,19 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	}
 	// set neededtocomplete
 	if (maxbuild != 0) order->needtocomplete = maxbuild;
-	
-	
+
+
 	// Now do all of the generic bits...
 	// Check that the unit isn't doing anything else important
 	if (unit->monthorders ||
 			(Globals->TAX_PILLAGE_MONTH_LONG &&
-				((unit->taxing == TAX_TAX) || 
+				((unit->taxing == TAX_TAX) ||
 					(unit->taxing == TAX_PILLAGE)))) {
 		if (unit->monthorders) delete unit->monthorders;
 		string err = string("BUILD: Overwriting previous ") + (unit->inTurnBlock ? "DELAYED " : "") + "month-long order.";
 		parse_error(pCheck, unit, 0, err);
 	}
-	
+
 	// reset their taxation status if taxing is a month-long order
 	if (Globals->TAX_PILLAGE_MONTH_LONG) unit->taxing = TAX_NONE;
 	unit->monthorders = order;
@@ -1854,7 +1856,7 @@ void Game::ProcessStudyOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 		delete token;
 	} else
 		order->level = -1;
-	
+
 	if (u->monthorders ||
 		(Globals->TAX_PILLAGE_MONTH_LONG &&
 		 ((u->taxing == TAX_TAX) || (u->taxing == TAX_PILLAGE)))) {
@@ -2055,7 +2057,7 @@ AString *Game::ProcessTurnOrder(Unit *unit, istream& f, OrdersCheck *pCheck, int
 					if (!turnLast) {
 						parse_error(pCheck, unit, 0, "ENDTURN: without TURN.");
 					} else {
-						if (--turnDepth) 
+						if (--turnDepth)
 							tOrder->turnOrders.push_back(saveorder.const_str());
 						turnLast = 0;
 					}
@@ -2365,7 +2367,7 @@ void Game::ProcessNameOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 		parse_error(pCheck, unit, 0, "NAME: No argument.");
 		return;
 	}
-	
+
 	if (*token == "faction") {
 		delete token;
 		token = o->gettoken();
@@ -2966,7 +2968,7 @@ void Game::ProcessTransportOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 
 	if (!pCheck) {
 		TransportOrder *order = new TransportOrder;
-		// At this point we don't know that transport phase for the order but 
+		// At this point we don't know that transport phase for the order but
 		// we will set that later.
 		order->item = item;
 		order->target = tar;

--- a/quests.cpp
+++ b/quests.cpp
@@ -46,9 +46,9 @@ Quest::~Quest()
 	rewards.clear();
 }
 
-string Quest::get_rewards()
+std::string Quest::get_rewards()
 {
-	string quest_rewards;
+	std::string quest_rewards;
 	bool first = true;
 
 	quest_rewards = "Quest rewards: ";
@@ -67,7 +67,7 @@ string Quest::get_rewards()
 	return quest_rewards;
 }
 
-int QuestList::read_quests(istream& f)
+int QuestList::read_quests(std::istream& f)
 {
 	int count, dests, rewards;
 	std::shared_ptr<Quest> quest;
@@ -90,16 +90,16 @@ int QuestList::read_quests(istream& f)
 				f >> quest->regionnum;
 				break;
 			case Quest::BUILD:
-				f >> ws >> name;
+				f >> std::ws >> name;
 				quest->building = LookupObject(&name);
-				f >> ws >> quest->regionname;
+				f >> std::ws >> quest->regionname;
 				break;
 			case Quest::VISIT:
-				f >> ws >> name;
+				f >> std::ws >> name;
 				quest->building = LookupObject(&name);
 				f >> dests;
 				while (dests-- > 0) {
-					f >> ws  >> name;
+					f >> std::ws  >> name;
 					quest->destinations.insert(name.Str());
 				}
 				break;
@@ -110,13 +110,13 @@ int QuestList::read_quests(istream& f)
 			default:
 				f >> quest->target;
 				quest->objective.Readin(f);
-				f >> ws >> name;
+				f >> std::ws >> name;
 				quest->building = LookupObject(&name);
 				f >> quest->regionnum;
-				f >> ws >> quest->regionname;
+				f >> std::ws >> quest->regionname;
 				f >> dests;
 				while (dests-- > 0) {
-					f >> ws >> name;
+					f >> std::ws >> name;
 					quest->destinations.insert(name.Str());
 				}
 				break;
@@ -135,7 +135,7 @@ int QuestList::read_quests(istream& f)
     return 1;
 }
 
-void QuestList::write_quests(ostream& f)
+void QuestList::write_quests(std::ostream& f)
 {
 	f << quests.size() << '\n';
 	for(auto q: quests) {
@@ -183,7 +183,7 @@ void QuestList::write_quests(ostream& f)
 	f << 0 << '\n';
 }
 
-string QuestList::distribute_rewards(Unit *u, shared_ptr<Quest> q)
+std::string QuestList::distribute_rewards(Unit *u, std::shared_ptr<Quest> q)
 {
 	for(auto i: q->rewards) {
 		u->items.SetNum(i.type, u->items.GetNum(i.type) + i.num);
@@ -192,7 +192,7 @@ string QuestList::distribute_rewards(Unit *u, shared_ptr<Quest> q)
 	return q->get_rewards();
 }
 
-int QuestList::check_kill_target(Unit *u, ItemList *reward, string *quest_rewards)
+int QuestList::check_kill_target(Unit *u, ItemList *reward, std::string *quest_rewards)
 {
 	for(auto q: quests) {
 		if (q->type == Quest::SLAY && q->target == u->num) {
@@ -208,7 +208,7 @@ int QuestList::check_kill_target(Unit *u, ItemList *reward, string *quest_reward
 	return 0;
 }
 
-int QuestList::check_harvest_target(ARegion *r, int item, int harvested, int max, Unit *u, string *quest_rewards)
+int QuestList::check_harvest_target(ARegion *r, int item, int harvested, int max, Unit *u, std::string *quest_rewards)
 {
 	for(auto q: quests) {
 		if (q->type == Quest::HARVEST && q->regionnum == r->num && q->objective.type == item) {
@@ -222,7 +222,7 @@ int QuestList::check_harvest_target(ARegion *r, int item, int harvested, int max
 	return 0;
 }
 
-int QuestList::check_build_target(ARegion *r, int building, Unit *u, string *quest_rewards)
+int QuestList::check_build_target(ARegion *r, int building, Unit *u, std::string *quest_rewards)
 {
 	for(auto q: quests) {
 		if (q->type == Quest::BUILD && q->building == building && q->regionname == *r->name) {
@@ -234,9 +234,9 @@ int QuestList::check_build_target(ARegion *r, int building, Unit *u, string *que
 	return 0;
 }
 
-int QuestList::check_visit_target(ARegion *r, Unit *u, string *quest_rewards)
+int QuestList::check_visit_target(ARegion *r, Unit *u, std::string *quest_rewards)
 {
-	set<string> intersection;
+	std::set<std::string> intersection;
 
 	for(auto q: quests) {
 		if (q->type != Quest::VISIT) continue;
@@ -252,7 +252,7 @@ int QuestList::check_visit_target(ARegion *r, Unit *u, string *quest_rewards)
 					u->visited.begin(),
 					u->visited.end(),
 					inserter(intersection, intersection.begin()),
-					less<string>()
+					std::less<std::string>()
 				);
 				if (intersection.size() == q->destinations.size()) {
 					// This unit has visited the required buildings in all those regions, so they completed a quest
@@ -266,7 +266,7 @@ int QuestList::check_visit_target(ARegion *r, Unit *u, string *quest_rewards)
 	return 0;
 }
 
-int QuestList::check_demolish_target(ARegion *r, int building, Unit *u, string *quest_rewards)
+int QuestList::check_demolish_target(ARegion *r, int building, Unit *u, std::string *quest_rewards)
 {
 	for(auto q: quests) {
 		if (q->type == Quest::DEMOLISH && q->regionnum == r->num && q->target == building) {

--- a/quests.h
+++ b/quests.h
@@ -54,7 +54,7 @@ class Quest
 		int	building;
 		int	regionnum;
 		AString	regionname;
-		set<std::string> destinations;
+		std::set<std::string> destinations;
 		std::vector<Item> rewards;
 		std::string get_rewards();
 };
@@ -65,8 +65,8 @@ class QuestList
 public:
 	using iterator = typename std::list<std::shared_ptr<Quest>>::iterator;
 
-	int read_quests(istream& f);
-	void write_quests(ostream& f);
+	int read_quests(std::istream& f);
+	void write_quests(std::ostream& f);
 
 	int check_kill_target(Unit *u, ItemList *reward, std::string *quest_rewards);
 	int check_harvest_target(ARegion *r,	int item, int harvested, int max, Unit *u, std::string *quest_rewards);
@@ -77,7 +77,7 @@ public:
 	inline void push_back(std::shared_ptr<Quest> q) { quests.push_back(q); }
 	inline iterator begin() { return quests.begin(); }
 	inline iterator end() { return quests.end(); }
-	inline size_t erase(shared_ptr<Quest> q) { return std::erase(quests, q); }
+	inline size_t erase(std::shared_ptr<Quest> q) { return std::erase(quests, q); }
 	inline size_t size() { return quests.size(); }
 
 	std::string distribute_rewards(Unit *u, std::shared_ptr<Quest> q);

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -27,6 +27,8 @@
 #include "gamedata.h"
 #include "quests.h"
 
+using namespace std;
+
 void Game::RunOrders()
 {
 	//
@@ -72,8 +74,6 @@ void Game::RunOrders()
 	RunQuitOrders();
 	Awrite("Removing Empty Units...");
 	DeleteEmptyUnits();
-	// SinkUncrewedFleets();
-	// DrownUnits();
 	if (Globals->ALLOW_WITHDRAW) {
 		Awrite("Running WITHDRAW Orders...");
 		DoWithdrawOrders();
@@ -88,12 +88,7 @@ void Game::RunOrders()
 		RunSacrificeOrders();
 		break;
 	}
-/*
-	Awrite("Running Sail Orders...");
-	RunSailOrders();
-	Awrite("Running Move Orders...");
-	RunMoveOrders();
-*/
+
 	Awrite("Running Consolidated Movement Orders...");
 	RunMovementOrders();
 
@@ -128,9 +123,6 @@ void Game::RunOrders()
 	Awrite("Post-Turn Processing...");
 	PostProcessTurn();
 	DeleteEmptyUnits();
-	// EmptyHell(); moved to Game::RunGame()
-	// to prevent dead mages from causing
-	// a segfault with IMPROVED_FARSIGHT
 	RemoveEmptyObjects();
 }
 
@@ -163,24 +155,6 @@ void Game::RunCastOrders()
 		}
 	}
 }
-
-/* Moved to game.cpp, where it belongs...
-int Game::CountMages(Faction *pFac)
-{
-	int i = 0;
-	forlist(&regions) {
-		ARegion *r = (ARegion *) elem;
-		forlist(&r->objects) {
-			Object *o = (Object *) elem;
-			forlist(&o->units) {
-				Unit *u = (Unit *) elem;
-				if (u->faction == pFac && u->type == U_MAGE) i++;
-			}
-		}
-	}
-	return(i);
-}
-*/
 
 bool Game::ActivityCheck(ARegion *pReg, Faction *pFac, FactionActivity activity) {
 	if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_FACTION_TYPES) {
@@ -365,7 +339,7 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
 	}
 
 	// Make sure we dispose of the allocated AList properly until we get rid of alists entirely.
-	std::unique_ptr<AList> seers(CanSeeSteal(r, u)); 
+	std::unique_ptr<AList> seers(CanSeeSteal(r, u));
 	int succ = 1;
 	forlist(seers) {
 		Faction *f = ((FactionPtr *) elem)->ptr;
@@ -601,7 +575,7 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 		}
 		else {
 			u->event("Destroys " + string(o->name->const_str()) + ".", "destroy");
-	
+
 			Object *dest = r->GetDummy();
 			for(auto u: o->units) {
 				u->destroy = 0;
@@ -690,7 +664,7 @@ int Game::FortTaxBonus(Object *o, Unit *u)
 			}
 		}
 		protect -= men;
-		if (protect < 0) protect = 0;	
+		if (protect < 0) protect = 0;
 	}
 	return(fortbonus);
 }
@@ -1129,7 +1103,7 @@ void Game::RemoveEmptyObjects()
 		ARegion *r = (ARegion *) elem;
 		forlist(&r->objects) {
 			Object *o = (Object *) elem;
-			if ((o->IsFleet()) && 
+			if ((o->IsFleet()) &&
 				(TerrainDefs[r->type].similar_type != R_OCEAN)) continue;
 			if (ObjectDefs[o->type].cost &&
 					o->incomplete >= ObjectDefs[o->type].cost) {
@@ -1561,7 +1535,7 @@ void Game::RunBuyOrders()
 		ARegion *r = (ARegion *) elem;
 		for (const auto& m : r->markets) {
 			if (m->type == Market::M_BUY) DoBuy(r, m);
-		}	
+		}
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
 			for(auto u: obj->units) {
@@ -1683,8 +1657,8 @@ void Game::DoBuy(ARegion *r, Market *m)
 									if (skill == -1) continue;
 									int curxp = u->skills.GetExp(skill);
 									u->skills.SetExp(skill,exp+curxp);
-								} 
-							}	
+								}
+							}
 						}
 						/* region economy effects */
 						r->Recruit(temp);
@@ -2428,7 +2402,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 				if (ship > 0) u->items.SetNum(ship,0);
 				return 0;
 			// abandon fleet ships
-			} else if (!(u->object->IsFleet()) || 
+			} else if (!(u->object->IsFleet()) ||
 				(u->num != u->object->GetOwner()->num)) {
 				u->error(ord + ": only fleet owner can give ships.");
 				return 0;
@@ -2640,7 +2614,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
 		}
 		return 0;
 	}
-	
+
 	if (o->target->unitnum == -1) {
 		/* Give 0 */
 		// Check there is enough to give
@@ -3051,7 +3025,7 @@ void Game::CheckTransportOrders()
 					} else { // sender isn't a valid QM
 						if (!target_is_valid_qm) { // Non-qms or invalid qms can only send to valid QMs
 							// Give a specific error message depending on why they aren't considered a quartermaster
-							string temp = "TRANSPORT: Target " + string(tar->unit->name->const_str()); 
+							string temp = "TRANSPORT: Target " + string(tar->unit->name->const_str());
 							temp += (
 								target_owns_qm_building ?
 								" does not own a transport structure." :
@@ -3466,7 +3440,7 @@ void Game::RunAnnihilateOrders() {
 
 				// annihilate our neigbors
 				for (auto n = 0; n < NDIRS; n++) {
-					ARegion *neigh = r->neighbors[n];		
+					ARegion *neigh = r->neighbors[n];
 					if (neigh == nullptr) continue;
 					Do1Annihilate(neigh);
 				}

--- a/skills.cpp
+++ b/skills.cpp
@@ -204,7 +204,7 @@ int StudyRateAdjustment(int days, int exp)
 			if ((clevel > level)	&& (rate > 5)) {
 				level = clevel;
 				switch(level) {
-					case 1: slope = 80;	
+					case 1: slope = 80;
 						prevd += cdays /slope;
 						ctr += cdays;
 						cdays = 0;
@@ -214,18 +214,18 @@ int StudyRateAdjustment(int days, int exp)
 						ctr += cdays;
 						cdays = 0;
 						break;
-				}	
+				}
 			}
 		}
 	}
 	return rate;
 }
 
-void Skill::Readin(istream &f)
+void Skill::Readin(std::istream &f)
 {
 	AString temp, *token;
 
-	f >> ws >> temp;
+	f >> std::ws >> temp;
 	token = temp.gettoken();
 	type = LookupSkill(token);
 	delete token;
@@ -233,7 +233,7 @@ void Skill::Readin(istream &f)
 	token = temp.gettoken();
 	days = token->value();
 	delete token;
-	
+
 	exp = 0;
 	if (Globals->REQUIRED_EXPERIENCE) {
 		token = temp.gettoken();
@@ -242,7 +242,7 @@ void Skill::Readin(istream &f)
 	}
 }
 
-void Skill::Writeout(ostream& f)
+void Skill::Writeout(std::ostream& f)
 {
 	if (type != -1) {
 		f << SkillDefs[type].abbr << " " << days;
@@ -367,7 +367,7 @@ int SkillList::GetStudyRate(int skill, int nummen)
 				exp = s->exp / nummen;
 		}
 	}
-	
+
 	return StudyRateAdjustment(days, exp);
 }
 
@@ -400,7 +400,7 @@ AString SkillList::Report(int nummen)
 	return temp;
 }
 
-void SkillList::Readin(istream& f)
+void SkillList::Readin(std::istream& f)
 {
 	int n;
 	f >> n;
@@ -412,7 +412,7 @@ void SkillList::Readin(istream& f)
 	}
 }
 
-void SkillList::Writeout(ostream& f)
+void SkillList::Writeout(std::ostream& f)
 {
 	f << size() << '\n';
 	for(auto s: skills) s->Writeout(f);

--- a/skills.h
+++ b/skills.h
@@ -122,8 +122,8 @@ struct ShowSkill {
 
 class Skill {
 public:
-	void Readin(istream& f);
-	void Writeout(ostream &f);
+	void Readin(std::istream& f);
+	void Writeout(std::ostream &f);
 	Skill *Split(int total, int split);
 
 	int type;
@@ -145,8 +145,8 @@ public:
 	int GetStudyRate(int sk, int men);
 	SkillList *Split(int total, int split);
 	AString Report(int men);
-	void Readin(istream& f);
-	void Writeout(ostream& f);
+	void Readin(std::istream& f);
+	void Writeout(std::ostream& f);
 	inline int size() { return skills.size(); }
 	inline Skill *front() { return skills.front(); }
 

--- a/spells.cpp
+++ b/spells.cpp
@@ -25,6 +25,8 @@
 #include "game.h"
 #include "gamedata.h"
 
+using namespace std;
+
 static int RandomiseSummonAmount(int num)
 {
 	int retval, i;
@@ -1978,7 +1980,7 @@ int Game::RunTransmutation(ARegion *r, Unit *u)
 		u->error("CAST: Can't create that by transmutation.");
 		return 0;
 	}
-	
+
 	switch(order->item) {
 		case I_ADMANTIUM:
 		case I_MITHRIL:
@@ -1998,7 +2000,7 @@ int Game::RunTransmutation(ARegion *r, Unit *u)
 			source = I_HORSE;
 			break;
 	}
-	
+
 	num = u->GetSharedNum(source);
 	if (num > ItemDefs[order->item].mOut * level)
 		num = ItemDefs[order->item].mOut * level;
@@ -2034,13 +2036,13 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 	tower = 0;
 	sactype = IT_LEADER;
 	sacrifices = 0;
-	
+
 	forlist(&r->objects) {
 		o = (Object *) elem;
 		if (o->type == O_BKEEP && !o->incomplete) {
 			tower = o;
 		}
-			
+
 		for(auto u: o->units) {
 			if (u->faction->num == mage->faction->num) {
 				forlist(&u->items) {
@@ -2097,7 +2099,7 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 			r->Kill(victim);
 		if (!mage->GetMen())
 			break;
-		
+
 		relics = mage->items.GetNum(I_RELICOFGRACE);
 		mage->items.SetNum(I_RELICOFGRACE, relics + 1);
 	}

--- a/standard/map.cpp
+++ b/standard/map.cpp
@@ -142,21 +142,21 @@ void ARegionList::CreateSurfaceLevel(int level, int xSize, int ySize, char const
 	int sea = Globals->OCEAN;
 	if (Globals->SEA_LIMIT)
 		sea = sea * (100 + 2 * Globals->SEA_LIMIT) / 100;
-			
+
 	MakeLand(pRegionArrays[level], sea, Globals->CONTINENT_SIZE);
-	
+
 	CleanUpWater(pRegionArrays[level]);
 
 	SetupAnchors(pRegionArrays[level]);
-	
+
 	GrowTerrain(pRegionArrays[level], 0);
-	
+
 	AssignTypes(pRegionArrays[level]);
 
 	SeverLandBridges(pRegionArrays[level]);
 
 	if (Globals->LAKES) RemoveCoastalLakes(pRegionArrays[level]);
-	
+
 	if (Globals->GROW_RACES) GrowRaces(pRegionArrays[level]);
 
 	FinalSetup(pRegionArrays[level]);
@@ -268,8 +268,8 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1;  
-				reg->wages = -1; 
+				reg->race = -1;
+				reg->wages = -1;
 
 				reg->level = arr;
 				Add(reg);
@@ -363,7 +363,7 @@ void ARegionList::MakeIcosahedralRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1; // 
+				reg->race = -1; //
 				reg->wages = -1; // initially store: name
 				reg->population = -1; // initially used as flag
 				reg->elevation = -1;
@@ -418,7 +418,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 		if (!reg) continue;
 		ARegion *newreg = reg;
 		ARegion *seareg = reg;
-		
+
 		// Archipelago or Continent?
 		if (getrandom(100) < Globals->ARCHIPELAGO) {
 			// Make an Archipelago:
@@ -498,7 +498,7 @@ void ARegionList::MakeLand(ARegionArray *pRegs, int percentOcean,
 				if ((reg->yloc < yoff*2) && ((dir < 2) || (dir == (NDIRS-1)))
 					&& (getrandom(4) < 3)) continue;
 				if ((reg->yloc > (yband+yoff)*2) && ((dir < 5) && (dir > 1))
-					&& (getrandom(4) < 3)) continue;				
+					&& (getrandom(4) < 3)) continue;
 				ARegion *newreg = reg->neighbors[dir];
 				if (!newreg) break;
 				int polecheck = 0;
@@ -761,7 +761,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 				if (!reg) continue;
 				if ((j > 0) && (j < 21) && (getrandom(3) < 2)) continue;
 				if (reg->type == R_NUM) {
-				
+
 					// Check for Lakes
 					if (Globals->LAKES &&
 						(getrandom(100) < (Globals->LAKES/10 + 1))) {
@@ -775,7 +775,7 @@ void ARegionList::GrowTerrain(ARegionArray *pArr, int growOcean)
 							reg->wages = AGetName(0, reg);
 						break;
 					}
-					
+
 
 					int init = getrandom(6);
 					for (int i=0; i<NDIRS; i++) {
@@ -907,14 +907,14 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			int xoff = x + 2 - getrandom(3) - getrandom(3);
 			ARegion *reg = pArr->GetRegion(xoff, y);
 			if (!reg) continue;
-			
+
 			if ((reg->type == R_LAKE) && (!Globals->LAKESIDE_IS_COASTAL))
 				continue;
 			if (TerrainDefs[reg->type].flags & TerrainType::BARREN) continue;
-			
+
 			reg->race = -1;
 			wigout = 0; // reset sanity
-			
+
 			if (TerrainDefs[reg->type].similar_type == R_OCEAN) {
 				// setup near coastal race here
 				int d = getrandom(NDIRS);
@@ -925,7 +925,7 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 					if (TerrainDefs[nreg->type].similar_type != R_OCEAN) {
 						int rnum = sizeof(TerrainDefs[nreg->type].coastal_races) /
 							sizeof(TerrainDefs[nreg->type].coastal_races[0]);
-						
+
 						while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 							reg->race = TerrainDefs[nreg->type].coastal_races[getrandom(rnum)];
 							if (++wigout > 100) break;
@@ -940,13 +940,13 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 			} else {
 				// setup noncoastal race here
 				int rnum = sizeof(TerrainDefs[reg->type].races)/sizeof(TerrainDefs[reg->type].races[0]);
-				
+
 				while ( reg->race == -1 || (ItemDefs[reg->race].flags & ItemType::DISABLED)) {
 					reg->race = TerrainDefs[reg->type].races[getrandom(rnum)];
 					if (++wigout > 100) break;
 				}
 			}
-			
+
 			/* leave out this sort of check for the moment
 			if (wigout > 100) {
 				// do something!
@@ -955,10 +955,10 @@ void ARegionList::RaceAnchors(ARegionArray *pArr)
 				Awrite(" region type");
 			}
 			*/
-			
+
 			if (reg->race == -1) {
-				cout << "Hey! No race anchor got assigned to the " 
-					<< TerrainDefs[reg->type].name 
+				std::cout << "Hey! No race anchor got assigned to the "
+					<< TerrainDefs[reg->type].name
 					<< " at " << x << "," << y << "\n";
 			}
 		}

--- a/text_report_generator.hpp
+++ b/text_report_generator.hpp
@@ -17,7 +17,7 @@ private:
     void output_event(std::ostream& f, const json& event);
     void output_region(std::ostream& f, const json& region, bool show_unit_attitudes, bool show_region_depth);
     void output_region_header(std::ostream& f, const json& region, bool show_region_depth);
-    void output_item_list(std::ostream& f, const json& item_list, string header);
+    void output_item_list(std::ostream& f, const json& item_list, std::string header);
     void output_items(std::ostream& f, const json& item_list, bool assume_singular = false, bool show_single_amt = false);
     void output_item(std::ostream& f, const json& item, bool assume_singular = false, bool show_single_amt = false);
     void output_ships(std::ostream& f, const json& ships);
@@ -28,7 +28,7 @@ private:
     void output_region_map_header(std::ostream& f, const json& region, bool show_region_depth);
     void output_region_map_header_line(std::ostream& f, std::string line);
     std::string next_map_header_line(int line, const json& region);
-    std::string map_header_item(const string& header, const json& item);
+    std::string map_header_item(const std::string& header, const json& item);
     void output_unit_template(std::ostream& f, const json& unit, int template_type);
     void output_unit_orders(std::ostream& f, const json& orders);
 

--- a/unit.h
+++ b/unit.h
@@ -122,8 +122,8 @@ class Unit
 		void SetMonFlags();
 		void MakeWMon(char const *,int,int);
 
-		void Writeout(ostream& f);
-		void Readin(istream& f, AList *);
+		void Writeout(std::ostream& f);
+		void Readin(std::istream& f, AList *);
 
 		AString SpoilsReport(void);
 		int CanGetSpoil(Item *i);
@@ -135,7 +135,7 @@ class Unit
 		AString ReadyItem();
 		AString StudyableSkills();
 		AString * BattleReport(int);
-		
+
 		void ClearOrders();
 		void ClearCastOrders();
 		void DefaultOrders(Object *);
@@ -297,7 +297,7 @@ class Unit
 		int format;
 
 		// Used for tracking VISIT quests
-		set<string> visited;
+		std::set<std::string> visited;
 		int raised;
 
 		// Used for tracking movement for NO7 victory condition

--- a/unittest/faction_test.cpp
+++ b/unittest/faction_test.cpp
@@ -38,16 +38,16 @@ ut::suite<"Faction"> faction_suite = []
     // It groks strings, so we'll just compare the string values.  We could compare char * but then we would
     // get just a 'true' or 'false' in the compare, rather than the nice verbose output we get in this case
     // if the strings don't match.
-    string current = faction->name->Str();
-    string expected = "Test Faction (1)";
+    std::string current = faction->name->Str();
+    std::string expected = "Test Faction (1)";
     expect(eq(current, expected));
   };
 
   "SetName filters illegal characters"_test = [faction]
   {
     faction->SetName(new AString("Test Faction || bar"));
-    string current = faction->name->Str();
-    string expected = "Test Faction  bar (1)";
+    std::string current = faction->name->Str();
+    std::string expected = "Test Faction  bar (1)";
     expect(eq(current, expected));
   };
 

--- a/unittest/indent_formatter_test.cpp
+++ b/unittest/indent_formatter_test.cpp
@@ -9,6 +9,7 @@
 // using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
+using namespace std;
 
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"Indent Formatter"> indent_formatter_suite = []

--- a/unittest/n07_victory_test.cpp
+++ b/unittest/n07_victory_test.cpp
@@ -8,6 +8,7 @@
 // using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
+using namespace std;
 
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"NO7 Victory Conditions"> no7victory_suite = []

--- a/unittest/quartermaster_test.cpp
+++ b/unittest/quartermaster_test.cpp
@@ -20,7 +20,7 @@ ut::suite<"Quartermaster"> quartermaster_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name = "Test Faction";
     Faction *faction = helper.create_faction(name);
     ARegion *region = helper.get_region(0, 0, 0);
     Unit *unit1 = helper.get_first_unit(faction);
@@ -37,7 +37,7 @@ ut::suite<"Quartermaster"> quartermaster_suite = []
 
     // We have two quartermasters, each with a caravanserai, and two units, so we will use transport to move 50
     // stone from unit1 to unit2.
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "transport 3 50 stone\n";  // unit 1 -> QM 1
@@ -81,7 +81,7 @@ ut::suite<"Quartermaster"> quartermaster_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name = "Test Faction";
     Faction *faction = helper.create_faction(name);
     ARegion *region = helper.get_region(0, 0, 0);
     Unit *unit1 = helper.get_first_unit(faction);
@@ -102,7 +102,7 @@ ut::suite<"Quartermaster"> quartermaster_suite = []
 
     // We have three quartermasters, each with a caravanserai, and two units, and we will try to chain transport
     // through multiple quartermasters.  This should fail, as quartermasters cannot chain.
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "transport 3 50 stone\n";  // unit 1 -> QM 1

--- a/unittest/spell_test.cpp
+++ b/unittest/spell_test.cpp
@@ -20,7 +20,7 @@ ut::suite<"Spells"> spell_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name = "Test Faction";
     Faction *faction = helper.create_faction(name);
     ARegion *region = helper.get_region(0, 0, 0);
     Unit *leader = helper.get_first_unit(faction);
@@ -31,7 +31,7 @@ ut::suite<"Spells"> spell_suite = []
     leader->Study(S_ILLUSION, 450);
     leader->Study(S_CREATE_PHANTASMAL_BEASTS, 180);
 
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "cast create_phantasmal_beasts DRAGON 4\n";
@@ -64,7 +64,7 @@ ut::suite<"Spells"> spell_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name ="Test Faction";
     Faction *faction = helper.create_faction(name);
     ARegion *region = helper.get_region(0, 0, 0);
     Unit *leader = helper.get_first_unit(faction);
@@ -75,7 +75,7 @@ ut::suite<"Spells"> spell_suite = []
     leader->Study(S_ILLUSION, 450);
     leader->Study(S_CREATE_PHANTASMAL_BEASTS, 300);
 
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "cast create_phantasmal_beasts DRAGON 4\n";

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -9,13 +9,13 @@ UnitTestHelper::UnitTestHelper() {
     game.init_random_seed = seed_random;
 
     // Set up the output streams to capture the output.
-    cout_streambuf = cout.rdbuf();
-    cout.rdbuf(cout_buffer.rdbuf());
+    cout_streambuf = std::cout.rdbuf();
+    std::cout.rdbuf(cout_buffer.rdbuf());
 }
 
 UnitTestHelper::~UnitTestHelper() {
     // Restore the output streams.
-    cout.rdbuf(cout_streambuf);
+    std::cout.rdbuf(cout_streambuf);
 }
 
 int UnitTestHelper::initialize_game() {
@@ -39,7 +39,7 @@ Game& UnitTestHelper::game_object() {
     return game;
 }
 
-Faction *UnitTestHelper::create_faction(string name) {
+Faction *UnitTestHelper::create_faction(std::string name) {
     auto fac = game.AddFaction(0, nullptr);
     AString *tmp = new AString(name); // because the guts of SetName frees the string passed in. :/
     fac->SetName(tmp);
@@ -73,14 +73,14 @@ Unit *UnitTestHelper::create_unit(Faction *faction, ARegion *region) {
 void UnitTestHelper::create_fleet(ARegion *region, Unit *owner, int ship_type, int ship_count) {
     for (auto i = 0; i < ship_count; i++)
         game.CreateShip(region, owner, ship_type);
- 
+
 }
 
 void UnitTestHelper::create_building(ARegion *region, Unit *owner, int building_type) {
     Object * obj = new Object(region);
     obj->type = building_type;
     obj->num = region->buildingseq++;
-    string name = "Building [" + to_string(obj->num) + "]";
+    std::string name = "Building [" + std::to_string(obj->num) + "]";
     obj->name = new AString(name);
     region->objects.Add(obj);
     ObjectType ob = ObjectDefs[building_type];
@@ -100,11 +100,11 @@ int UnitTestHelper::connected_distance(ARegion *reg1, ARegion *reg2, int penalty
     return game.regions.get_connected_distance(reg1, reg2, penalty, max);
 }
 
-string UnitTestHelper::cout_data() {
+std::string UnitTestHelper::cout_data() {
     return cout_buffer.str();
 }
 
-void UnitTestHelper::parse_orders(int faction_id, istream& orders, OrdersCheck *check) {
+void UnitTestHelper::parse_orders(int faction_id, std::istream& orders, OrdersCheck *check) {
     game.ParseOrders(faction_id, orders, check);
 }
 

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -45,14 +45,14 @@ public:
     // Just get a total count of regions so we can make sure we got the world we exepected.
     int get_region_count();
     // Create a faction that we can use for testing.
-    Faction *create_faction(string name);
+    Faction *create_faction(std::string name);
     // Get any existing faction
     Faction *get_faction(int id);
     // Get a region by coordinates
     ARegion *get_region(int x, int y, int level);
     // Get all regions
     ARegionList *get_regions() { return &game.regions; }
-    // get the game month 
+    // get the game month
     int get_month() { return game.month; }
     // Find the first unit for a given faction
     Unit *get_first_unit(Faction *faction);
@@ -63,7 +63,7 @@ public:
     // Create a building in the given region.
     void create_building(ARegion *region, Unit *owner, int building_type);
     // Parse the orders contained in the input stream.
-    void parse_orders(int faction_id, istream& orders, OrdersCheck *check = nullptr);
+    void parse_orders(int faction_id, std::istream& orders, OrdersCheck *check = nullptr);
     // Run the transport order checks
     void check_transport_orders();
     // Execute movement orders
@@ -85,7 +85,7 @@ public:
     int get_seed() { return getrandom(10000); };
 
     // Get the contents of cout as a string.
-    string cout_data();
+    std::string cout_data();
 
     // Activate a specific spell for testing.   Since the spells can have different arguments, we use a helper struct
     // to pass in the arguments and call the appropriate Run<Spell> function based on the skill associate with the spell.
@@ -96,8 +96,8 @@ public:
     void enable(Type type, int id, bool enable);
 
 private:
-    stringstream cout_buffer;
-    streambuf *cout_streambuf;
+    std::stringstream cout_buffer;
+    std::streambuf *cout_streambuf;
     Game game;
 };
 

--- a/unittest/unit_test.cpp
+++ b/unittest/unit_test.cpp
@@ -35,16 +35,16 @@ ut::suite<"Unit"> unit_suite = []
     // It groks strings, so we'll just compare the string values.  We could compare char * but then we would
     // get just a 'true' or 'false' in the compare, rather than the nice verbose output we get in this case
     // if the strings don't match.
-    string current = unit->name->Str();
-    string expected = "Test Unit (500)";
+    std::string current = unit->name->Str();
+    std::string expected = "Test Unit (500)";
     expect(eq(current, expected));
   };
 
   "SetName filters illegal characters"_test = [unit]
   {
     unit->SetName(new AString("Test Unit || bar"));
-    string current = unit->name->Str();
-    string expected = "Test Unit  bar (500)";
+    std::string current = unit->name->Str();
+    std::string expected = "Test Unit  bar (500)";
     expect(eq(current, expected));
   };
 
@@ -73,8 +73,8 @@ ut::suite<"Unit"> unit_suite = []
     // Someone with no observation should not see the unit's faction, since it's not revealing.
     // Technically they shouldn't even see the unit, but that's handled in the region code, NOT in the unit code.
     // This function is only called if something asserts the unit is visible before calling this.
-    string current = unit->GetName(0).Str();
-    string expected = "Test Unit (500)";
+    std::string current = unit->GetName(0).Str();
+    std::string expected = "Test Unit (500)";
     expect(eq(current, expected));
 
     // Someone with observation 2 should not see the unit's faction.

--- a/unittest/unit_test_helper_test.cpp
+++ b/unittest/unit_test_helper_test.cpp
@@ -31,8 +31,8 @@ ut::suite<"UnitTestHelper"> unit_test_helper_suite = []
     // initialize the game which will generate a small bit of output
     helper.initialize_game();
     // The output will have the fact that it created the world and 1 '.' for each region.
-    string current = helper.cout_data();
-    string expected = "Creating world\n.....";
+    std::string current = helper.cout_data();
+    std::string expected = "Creating world\n.....";
     expect(current == expected);
   };
 


### PR DESCRIPTION
It's pretty bad form to have header files do 'using namespace' directives and pull in a lot of definitions that way.  While it isn't too horrible in a private project it's just bad practice.

This removes all the `using namespace std;` from the header files
and declares the objects with explicit namespaces.   For the .cpp
files, if there were only a few uses of the namespace, just do the
in-place explicit naming.  If the cpp file used it in a lot of
places, those are a much more common (and expected) place to add
those sort of `using` directives.

Also removed a couple of long-commented out functions.