### PR TITLE
Remove AList from items

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -827,18 +827,16 @@ void ARegion::Kill(Unit *u)
 	}
 
 	if (first) {
-		// give u's stuff to first
-		forlist(&u->items) {
-			Item *i = (Item *) elem;
-			if (ItemDefs[i->type].type & IT_SHIP &&
-					first->items.GetNum(i->type) > 0) {
-				if (first->items.GetNum(i->type) > i->num)
-					first->items.SetNum(i->type, i->num);
+		// give u's stuff to first.  Since this can modify the list via SetNum, copy thelist
+		ItemList itemCopy = u->items;
+		for(auto i: itemCopy) {
+			if (ItemDefs[i.type].type & IT_SHIP && first->items.GetNum(i.type) > 0) {
+				if (first->items.GetNum(i.type) > i.num)
+					first->items.SetNum(i.type, i.num);
 				continue;
 			}
-			if (!IsSoldier(i->type)) {
-				first->items.SetNum(i->type, first->items.GetNum(i->type) +
-									i->num);
+			if (!IsSoldier(i.type)) {
+				first->items.SetNum(i.type, first->items.GetNum(i.type) + i.num);
 				// If we're in ocean and not in a structure, make sure that
 				// the first unit can actually hold the stuff and not drown
 				// If the item would cause them to drown then they won't
@@ -846,13 +844,12 @@ void ARegion::Kill(Unit *u)
 				if (TerrainDefs[type].similar_type == R_OCEAN) {
 					if (first->object->type == O_DUMMY) {
 						if (!first->CanReallySwim()) {
-							first->items.SetNum(i->type,
-									first->items.GetNum(i->type) - i->num);
+							first->items.SetNum(i.type, first->items.GetNum(i.type) - i.num);
 						}
 					}
 				}
 			}
-			u->items.SetNum(i->type, 0);
+			u->items.SetNum(i.type, 0);
 		}
 	}
 

--- a/army.h
+++ b/army.h
@@ -171,16 +171,16 @@ class Army
 		Army(Unit *,AList *,int,int = 0);
 		~Army();
 
-		void WriteLosses(Battle *);
-		void Lose(Battle *,ItemList *);
-		void Win(Battle *,ItemList *);
-		void Tie(Battle *);
+		void WriteLosses(Battle *b);
+		void Lose(Battle *b,ItemList &spoils);
+		void Win(Battle *b,ItemList& spoils);
+		void Tie(Battle *b);
 		int CanBeHealed();
-		void DoHeal(Battle *);
-		void DoHealLevel(Battle *, int level, int rate, int useItems);
-		void Regenerate(Battle *);
+		void DoHeal(Battle *b);
+		void DoHealLevel(Battle *b, int level, int rate, int useItems);
+		void Regenerate(Battle *b);
 
-		void GetMonSpoils(ItemList *,int, int);
+		void GetMonSpoils(ItemList& spoils, int monitem, int free);
 
 		int Broken();
 		int NumAlive();

--- a/battle.h
+++ b/battle.h
@@ -67,7 +67,7 @@ class Battle : public AListElem
 		void DoAttack(int round, Soldier *a, Army *attackers, Army *def,
 				int behind, int ass = 0, bool canAttackBehind = false, bool canAttackFromBehind = false);
 
-		void GetSpoils(AList *,ItemList *, int);
+		void GetSpoils(AList *loser, ItemList& spoils, int assasination);
 
 		//
 		// These functions should be implemented in specials.cpp

--- a/faction.cpp
+++ b/faction.cpp
@@ -657,15 +657,14 @@ int Faction::CanSee(ARegion* r, Unit* u, int practice)
 	if (u->reveal == REVEAL_FACTION) return 2;
 
 	// If the unit has any items which prevent stealth, then we can see them.
-	forlist((&u->items)) {
-		Item* item = (Item *) elem;
-		if (ItemDefs[item->type].flags & ItemType::NOSTEALTH) return 2;
+	for(auto item: u->items) {
+		if (ItemDefs[item.type].flags & ItemType::NOSTEALTH) return 2;
 	}
 
 	int retval = 0;
 	if (u->reveal == REVEAL_UNIT) retval = 1;
 	if (u->guard == GUARD_GUARD) retval = 1;
-	forlist_reuse((&r->objects)) {
+	forlist((&r->objects)) {
 		Object* obj = (Object *) elem;
 		int dummy = 0;
 		if (obj->type == O_DUMMY) dummy = 1;

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -164,7 +164,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 					if (u->faction->num == monfaction) {
 						if (!d--) {
 							q->target = u->num;
-							
+
 						}
 					}
 				}
@@ -338,7 +338,6 @@ Faction *Game::CheckVictory()
 	int skilldays, magicdays, skilllevels, magiclevels;
 	int dir, found;
 	unsigned ucount;
-	Item *item;
 	ARegion *r, *start;
 	Object *o;
 	Faction *f;
@@ -602,17 +601,16 @@ Faction *Game::CheckVictory()
 					for(auto u: o->units) {
 						if (u->faction == f) {
 							units++;
-							forlist(&u->items) {
-								item = (Item *) elem;
-								if (ItemDefs[item->type].type & IT_LEADER)
-									leaders += item->num;
-								else if (ItemDefs[item->type].type & IT_MAN)
-									men += item->num;
-								else if (ItemDefs[item->type].type & IT_MONEY)
-									silver += item->num * ItemDefs[item->type].baseprice;
+							for(auto item: u->items) {
+								if (ItemDefs[item.type].type & IT_LEADER)
+									leaders += item.num;
+								else if (ItemDefs[item.type].type & IT_MAN)
+									men += item.num;
+								else if (ItemDefs[item.type].type & IT_MONEY)
+									silver += item.num * ItemDefs[item.type].baseprice;
 								else
-									stuff += item->num * ItemDefs[item->type].baseprice;
-									
+									stuff += item.num * ItemDefs[item.type].baseprice;
+
 							}
 							for(auto s: u->skills) {
 								if (SkillDefs[s->type].flags & SkillType::MAGIC) {

--- a/items.h
+++ b/items.h
@@ -32,6 +32,7 @@ class ItemType;
 #include "alist.h"
 #include "astring.h"
 #include <vector>
+#include <string>
 
 enum {
 	ATTACK_COMBAT,
@@ -450,7 +451,7 @@ extern AString *ItemDescription(int item, int full);
 
 extern int IsSoldier(int);
 
-class Item : public AListElem
+class Item
 {
 	public:
 		Item();
@@ -467,15 +468,19 @@ class Item : public AListElem
 		int checked; // flag whether item has been reported, counted etc.
 };
 
-class ItemList : public AList
+class ItemList
 {
+	std::vector<Item> items;
+
 	public:
+		using iterator = typename std::vector<Item>::iterator;
+
 		void Readin(std::istream& f);
 		void Writeout(std::ostream& f);
 
-		AString Report(int, int, int);
-		AString BattleReport();
-		AString ReportByType(int, int, int, int);
+		std::string Report(int obs, int seeillusions, int nofirstcomma);
+		std::string BattleReport();
+		std::string ReportByType(int, int, int, int);
 
 		int Weight();
 		int GetNum(int);
@@ -483,6 +488,12 @@ class ItemList : public AList
 		int CanSell(int);
 		void Selling(int, int); /* type, number */
 		void UncheckAll(); // re-set checked flag for all
+
+		iterator begin() { return items.begin(); }
+		iterator end() { return items.end(); }
+		iterator erase(iterator i) { return items.erase(i); }
+		inline size_t size() { return items.size(); }
+		inline void clear() { items.clear(); }
 };
 
 extern AString ShowSpecial(char const *special, int level, int expandLevel, int fromItem);

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -755,8 +755,7 @@ void Game::RunBuildHelpers(ARegion *r)
 							continue;
 						}
 						// Make sure that unit is building
-						if (!target->monthorders ||
-								target->monthorders->type != O_BUILD) {
+						if (!target->monthorders || target->monthorders->type != O_BUILD) {
 							u->error("BUILD: Unit isn't building.");
 							u->monthorders = nullptr;
 							continue;
@@ -1261,8 +1260,7 @@ void Game::RunAProduction(ARegion * r, Production * p)
 
 			amt -= ubucks;
 			attempted -= uatt;
-			u->items.SetNum(po->item,u->items.GetNum(po->item)
-							+ ubucks);
+			u->items.SetNum(po->item,u->items.GetNum(po->item) + ubucks);
 			u->faction->DiscoverItem(po->item, 0, 1);
 			p->activity += ubucks;
 			po->target -= ubucks;
@@ -1630,9 +1628,8 @@ Location *Game::DoAMoveOrder(Unit *unit, ARegion *region, Object *obj)
 		}
 
 		// Make sure that items which cannot go through a shaft don't
-		forlist(&unit->items) {
-			Item *i = (Item *) elem;
-			if (ItemDefs[i->type].flags & ItemType::NO_SHAFT) {
+		for(auto i: unit->items) {
+			if (ItemDefs[i.type].flags & ItemType::NO_SHAFT) {
 				unit->error("MOVE: Unable to fit through the shaft.");
 				goto done_moving;
 			}

--- a/object.h
+++ b/object.h
@@ -167,7 +167,7 @@ class Object : public AListElem
 		int movepoints;
 		int destroyed;	// how much points was destroyed so far this turn
 		std::vector<Unit *> units;
-		AList ships;
+		ItemList ships;
 };
 
 #endif

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -1593,11 +1593,10 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 		if (!pCheck) {
 			// look for an incomplete ship type in inventory
 			int st = O_DUMMY;
-			forlist(&unit->items) {
-				Item * it = (Item *) elem;
-				if ((ItemDefs[it->type].type & IT_SHIP)
-					&& (!(ItemDefs[it->type].flags & ItemType::DISABLED))) {
-						st = -(it->type);
+			for(auto it: unit->items) {
+				if ((ItemDefs[it.type].type & IT_SHIP)
+					&& (!(ItemDefs[it.type].flags & ItemType::DISABLED))) {
+						st = -(it.type);
 						break;
 				}
 			}

--- a/quests.cpp
+++ b/quests.cpp
@@ -192,13 +192,13 @@ std::string QuestList::distribute_rewards(Unit *u, std::shared_ptr<Quest> q)
 	return q->get_rewards();
 }
 
-int QuestList::check_kill_target(Unit *u, ItemList *reward, std::string *quest_rewards)
+int QuestList::check_kill_target(Unit *u, ItemList& reward, std::string *quest_rewards)
 {
 	for(auto q: quests) {
 		if (q->type == Quest::SLAY && q->target == u->num) {
 			// This dead thing was the target of a quest!
 			for(auto i: q->rewards) {
-				reward->SetNum(i.type, reward->GetNum(i.type) + i.num);
+				reward.SetNum(i.type, reward.GetNum(i.type) + i.num);
 			}
 			*quest_rewards = q->get_rewards();
 			erase(q); // this is safe since we immediately return and don't use the iterator again

--- a/quests.h
+++ b/quests.h
@@ -68,7 +68,7 @@ public:
 	int read_quests(std::istream& f);
 	void write_quests(std::ostream& f);
 
-	int check_kill_target(Unit *u, ItemList *reward, std::string *quest_rewards);
+	int check_kill_target(Unit *u, ItemList& reward, std::string *quest_rewards);
 	int check_harvest_target(ARegion *r,	int item, int harvested, int max, Unit *u, std::string *quest_rewards);
 	int check_build_target(ARegion *r, int building, Unit *u, std::string *quest_rewards);
 	int check_visit_target(ARegion *r, Unit *u, std::string *quest_rewards);

--- a/spells.cpp
+++ b/spells.cpp
@@ -923,7 +923,7 @@ int Game::RunMindReading(ARegion *r,Unit *u)
 		return 1;
 	}
 
-	temp += string(tar->items.Report(2,5,0).const_str()) + ". Skills: ";
+	temp += string(tar->items.Report(2, 5, 0)) + ". Skills: ";
 	temp += string(tar->skills.Report(tar->GetMen()).const_str()) + ".";
 
 	u->event(temp, "spell");
@@ -1982,7 +1982,6 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 	int level, num, sactype, sacrifices, i, sac, relics;
 	Object *o, *tower;
 	Unit *victim;
-	Item *item;
 	AString message;
 
 	level = mage->GetSkill(S_BLASPHEMOUS_RITUAL);
@@ -2007,10 +2006,9 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 
 		for(auto u: o->units) {
 			if (u->faction->num == mage->faction->num) {
-				forlist(&u->items) {
-					item = (Item *) elem;
-					if (ItemDefs[item->type].type & sactype) {
-						sacrifices += item->num;
+				for(auto item: u->items) {
+					if (ItemDefs[item.type].type & sactype) {
+						sacrifices += item.num;
 					}
 				}
 			}
@@ -2033,14 +2031,13 @@ int Game::RunBlasphemousRitual(ARegion *r, Unit *mage)
 			o = (Object *) elem;
 			for(auto u: o->units) {
 				if (u->faction->num == mage->faction->num) {
-					forlist(&u->items) {
-						item = (Item *) elem;
-						if (ItemDefs[item->type].type & sactype) {
-							if (!victim && i < item->num) {
+					for(auto item: u->items) {
+						if (ItemDefs[item.type].type & sactype) {
+							if (!victim && i < item.num) {
 								victim = u;
-								sac = item->type;
+								sac = item.type;
 							}
-							i -= item->num;
+							i -= item.num;
 						}
 					}
 				}

--- a/unit.h
+++ b/unit.h
@@ -126,7 +126,7 @@ class Unit
 		void Readin(std::istream& f, AList *);
 
 		AString SpoilsReport(void);
-		int CanGetSpoil(Item *i);
+		int CanGetSpoil(Item& i);
 		json build_json_descriptor();
 		void build_json_report(json& j, int obs, int truesight, int detfac, int autosee, int attitude, int showattitudes);
 		json write_json_orders();
@@ -154,9 +154,9 @@ class Unit
 		int GetMoney();
 		void SetMoney(int);
 		int GetSharedNum(int);
-		void ConsumeShared(int,int);
+		void ConsumeShared(int item, int needed);
 		int GetSharedMoney();
-		void ConsumeSharedMoney(int);
+		void ConsumeSharedMoney(int needed);
 		int IsAlive();
 
 		int MaintCost(ARegionList *regions, ARegion *current_region);


### PR DESCRIPTION
Items and ItemList no longer use AList.
ItemLists now statically allocate the Item as well rather than using pointers to a dynamically allocated item (one less thing to free and saving the memory footprint of the extra pointer since the item itself still takes the same memory for the class).