### PR TITLE
Make clear that tactics bonus is first round only

### DIFF
--- a/genrules.cpp
+++ b/genrules.cpp
@@ -461,7 +461,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 
 	f << enclose("ul", true);
 	f << enclose("li", true) << url("#intro", "Introduction") << '\n' << enclose("li", false);
-	
+
 	f << enclose("li", true);
 	f << url("#playing", "Playing Atlantis") << '\n';
 	f << enclose("ul", true);
@@ -1251,7 +1251,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			  << "as the magical entry into Atlantis.";
 
 		} else {
-			f << "inside of the normal world of Atlantis, but " 
+			f << "inside of the normal world of Atlantis, but "
 			  << (Globals->MULTI_HEX_NEXUS ? "each contains " : "contains ")
 			  << "a starting city with all its benefits"
 			  << (Globals->GATES_EXIST ? ", including a gate" : "") << ". "
@@ -1285,7 +1285,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			if (Globals->START_CITIES_START_UNLIMITED) {
 				f << (!Globals->SAFE_START_CITIES && Globals->CITY_MONSTERS_EXIST
 				      ? "until someone conquers the guardsmen, "
-				      : "") 
+				      : "")
 				  << "there are unlimited amounts of many materials and men (though the prices are often quite high).";
 			} else {
 				f << "there are materials as well as a very large supply of men (though the prices are often quite high).";
@@ -1591,7 +1591,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			f << enclose("td align=\"center\"", true) << ItemDefs[i].weight/50 << '\n'  << enclose("td", false);
 			f << enclose("td align=\"center\"", true) << slevel << '\n'  << enclose("td", false);
 			f << enclose("tr", false);
-		}					
+		}
 		for (int i = 0; i < NOBJECTS; i++) {
 			if (ObjectDefs[i].flags & ObjectType::DISABLED) continue;
 			if (!ObjectIsShip(i)) continue;
@@ -1835,8 +1835,8 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			rate = study_rate(days, 0);
 			days += rate;
 			months5++;
-		}		
-		mlevel = GetLevelByDays(days);	
+		}
+		mlevel = GetLevelByDays(days);
 
 		f << enclose("p", true);
 		f << "To illustrate this, a unit would have to spend " << num_to_word(months2)
@@ -1849,7 +1849,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			  << "skill level 3 by studying without experience. ";
 		}
 		f << "The maximum skill level that is possible through continuous study only (i.e. no experience "
-		  << "involved) is " << num_to_word(mlevel) + ", " 
+		  << "involved) is " << num_to_word(mlevel) + ", "
 		  << (months5 > 36 ? "although it is hardly feasible without any experience at all, " : "")
 		  << "taking " << num_to_word(months5) << " months of studying to achieve. "
 		  << "Note that this assumes that the unit type is allowed to achieve this level at all "
@@ -1906,7 +1906,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		int level = 0;
 		int plevel = 0;
 		int next = study_rate(days, 0);
-		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next 
+		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next
 		  << ")</font>\n" << enclose("td", false);
 		for (int m = 0; m < 9; m++) {
 			days += study_rate(days, 0);
@@ -1928,7 +1928,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		level = 0;
 		plevel = 0;
 		next = study_rate(days, 30);
-		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next 
+		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next
 		  << ")</font>\n" << enclose("td", false);
 		for (int m = 0; m < 9; m++) {
 			days += study_rate(days, 30);
@@ -1984,7 +1984,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	// a table of all skills/costs.
 	f << enclose("p", true) << "Most skills cost $" << SkillDefs[S_COMBAT].cost
 	  << " per person per month to study (in addition to normal maintenance costs).  The exceptions are ";
-	if (has_stea || has_obse) {		
+	if (has_stea || has_obse) {
 		f << (has_stea ? "Stealth" : "") << (has_stea && has_obse ? " and " : "") << (has_obse ? "Observation" : "")
 		  << " (" << (has_stea && has_obse ? "both of which cost $" : "which costs $") << SkillDefs[S_STEALTH].cost
 		  << "), ";
@@ -2127,7 +2127,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		if (!evenly_divisible) {
 			f << "Food value for a fractional maintenance cost still consumes the entire unit of food. ";
 		}
-		
+
 		if (Globals->UPKEEP_MINIMUM_FOOD > 0) {
 			f << "A unit must be given at least " << Globals->UPKEEP_MINIMUM_FOOD
 			  << " maintenance per man in the form of food. ";
@@ -2180,7 +2180,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << "were given above in the section on Movement, but many things were left out. Here is a table "
 	  << "giving some information about common items in Atlantis:\n"
 	  << enclose("p", false);
-	
+
 	f << anchor("tableiteminfo") << '\n';
 	f << enclose("center", true);
 	f << enclose("table border=\"1\"", true);
@@ -2252,7 +2252,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 					(wp->flags & WeaponType::RANGED) ||
 					(wp->flags & WeaponType::NEEDSKILL)) {
 				if (wp->flags & WeaponType::RANGED)
-					f << "Ranged weapon";			 			
+					f << "Ranged weapon";
 				else
 					f << "Weapon";
 				f << " which gives " << (wp->attackBonus > -1 ? "+" : "")
@@ -2340,7 +2340,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << " factions can issue " << url("#produce", "PRODUCE") << " orders however, regardless of skill levels.\n"
 		  << enclose("p", false);
 	}
-	
+
 	f << enclose("p", true) << "Items which increase production may increase production of advanced items in "
 	  << "addition to the basic items listed.  Some of them also increase production of other tools.  Read the skill "
 	  << "descriptions for details on which tools aid which production when not noted above.\n"
@@ -2431,7 +2431,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	}
 	f << enclose("table", false);
 	f << enclose("center", false);
-	
+
 	f << enclose("p", true) << "Size is the number of people that the building can shelter. Cost is both "
 	  << "the number of man-months of labor and the number of units of material required to complete the building.  ";
 	if (Globals->LIMITED_MAGES_PER_BUILDING) {
@@ -2648,7 +2648,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			f << enclose("td align=\"center\"", true) << ItemDefs[i].weight/50 << '\n' << enclose("td", false);
 			f << enclose("td align=\"center\"", true) << slevel << '\n' << enclose("td", false);
 			f << enclose("tr", false);
-		}					
+		}
 		for (int i = 0; i < NOBJECTS; i++) {
 			if (ObjectDefs[i].flags & ObjectType::DISABLED) continue;
 			if (!ObjectIsShip(i)) continue;
@@ -2674,7 +2674,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << "to complete the ship. The sailors are the number of skill levels of the Sailing skill that must be "
 		  << "aboard the ship (and issuing the " << url("#sail", "SAIL") << " order) in order for the ship to sail.\n"
 		  << enclose("p", false);
-		
+
 		f << enclose("p", true) << "When a ship is built, if its builder is already the owner of a fleet, then "
 		  << "the ship will be added to that fleet; otherwise a new fleet will be created to hold the ship.  A fleet "
 		  << "has the combined capacity and sailor requirement of its constituent vessels, and moves at the speed of "
@@ -2759,7 +2759,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << "the faction in question Friendly. Units on guard will also block " << url("#pillage", "PILLAGE")
 	  << " orders issued by other factions in the same region, regardless of your attitude towards the faction "
 	  << "in question, and they will attempt to prevent Unfriendly units from entering the region.  Only units "
-	  << "which are able to tax may be on guard.  Units on guard " 
+	  << "which are able to tax may be on guard.  Units on guard "
 	  << (has_stea ? " are always visible regardless of Stealth skill, and " : "")
 	  << "will be marked as being \"on guard\" in the region description.\n"
 	  << enclose("p", false);
@@ -2936,7 +2936,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			  ? "these restrictions do "
 			  : "this restriction does ")
 		  << "not apply for sea combat, as "
-		  << (has_stea ? "units within a fleet are always visible" : "");		  
+		  << (has_stea ? "units within a fleet are always visible" : "");
 		if (!(SkillDefs[S_RIDING].flags & SkillType::DISABLED)) {
 			f << (has_stea ? ", and" : "") << " Riding does not play a part in combat on board fleets";
 		}
@@ -3009,10 +3009,10 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		f << " The computer selects the best tactician from each side; that unit is regarded as the leader of "
 		  << "its side.  If two or more units on one side have the same Tactics skill, then the one with the lower "
 		  << "unit number is regarded as the leader of that side.  If one side's leader has a better Tactics skill "
-		  << "than the other side's,"
+		  << "than the other side's, then that side gets a "
 		  << (Globals->ADVANCED_TACTICS
-		      ? "then that side gets a tactics difference bonus to their attack and defense."
-			  : "then that side gets a free round of attacks.");
+		      ? "tactics difference bonus to their attack and defense for the first round of combat."
+			  : "free round of attacks.");
 	}
 	f << '\n' << enclose("p", false);
 	f << enclose("p", true) << "In each combat round, the combatants each get to attack once, in "
@@ -3112,7 +3112,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << "the battle is over, by any living healers on the winning side.\n"
 		  << enclose("p", false);
 	}
-	
+
 	f << enclose("p", true) << "Any items owned by dead combatants on the losing side have a 50% chance of being "
 	  << "found and collected by the winning side. Each item which is recovered is picked up by one of the "
 	  << "survivors able to carry it (see the " << url("#spoils", "SPOILS") << " command) at random, so the "
@@ -3705,7 +3705,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << example_start("Change your faction's email address to atlantis@rahul.net.")
 	  << "ADDRESS atlantis@rahul.net\n"
 	  << example_end();
-	
+
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
 	f << anchor("advance") << '\n';
 	f << enclose("h4", true) << "ADVANCE [dir] ...\n" << enclose("h4", false);
@@ -3845,7 +3845,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << example_start("To help unit 5789 build a structure.")
 	  << "BUILD HELP 5789\n"
 	  << example_end();
-	
+
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
 	f << anchor("buy") << '\n';
 	f << enclose("h4", true) << "BUY [quantity] [item]\n" << enclose("h4", false);
@@ -3875,7 +3875,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << "BUY 5 barbarians\n"
 		  << example_end();
 	}
-	
+
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
 	f << anchor("cast") << '\n';
 	f << enclose("h4", true) << "CAST [skill] [arguments]\n" << enclose("h4", false);
@@ -4127,7 +4127,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("p", true) << "Form a new unit.  The newly created unit will be in your faction, in the same "
 	  << "region as the unit which formed it, and in the same structure if any.  It will start off, however, with "
 	  << "no people or items; you should, in the same month, issue orders to transfer people into the new unit, or "
-	  << "have it recruit members. The new unit will inherit its flags from the unit that forms it, such as "	
+	  << "have it recruit members. The new unit will inherit its flags from the unit that forms it, such as "
 	  << "avoiding, behind, revealing and sharing, with the exception of the guard and autotax flags.  If the new "
 	  << "unit wants to guard or automatically tax then those flags will have to be explicitly set in its orders.\n"
 	  << enclose("p", false);
@@ -4394,7 +4394,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("p", true) << "If multiple units are on one side in a battle, they must all have the NOAID flag on, "
 	  << "or they will receive aid from other hexes.\n"
 	  << enclose("p", false);
-	f << enclose("p", true) << "Example:\n" << enclose("p", false);	
+	f << enclose("p", true) << "Example:\n" << enclose("p", false);
 	f << example_start("Set a unit to receive no aid in battle.")
 	  << "NOAID 1\n"
 	  << example_end();
@@ -4588,7 +4588,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("p", true) << "Note that although this order affects the faction as a whole, it nevertheless needs "
 	  << "to be issued by an individual unit, and so the email containing the command to quit needs to include both "
 	  << "#atlantis and unit lines.\n"
-	  << enclose("p", false);	
+	  << enclose("p", false);
 	f << enclose("p", true) << "Example:\n" << enclose("p", false);
 	f << example_start("Quit the game for faction 27 if your password is foobar.")
 	  << "#atlantis 27 \"foobar\"\n"
@@ -4622,7 +4622,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << "affiliation (REVEAL FACTION), in the turn report, to all other factions in the region. "
 	  << (has_stea ? "Used to reveal high stealth scouts, should there be some reason to. " : "")
 	  << "REVEAL is used to cancel this.\n"
-	  << enclose("p", false);	
+	  << enclose("p", false);
 	f << enclose("p", true) << "Examples:\n" << enclose("p", false);
 	f << example_start("Show the unit to all factions.")
 	  << "REVEAL UNIT\n"

--- a/skillshows.cpp
+++ b/skillshows.cpp
@@ -241,7 +241,7 @@ AString *ShowSkill::Report(Faction *f) const
 					"bonus to their attack and defense during first battle "
 					"round. Bonus equals to the difference in skills but can be "
 					"+3 at most. The army with the highest level tactician "
-					"in a battle will receive this bonus round; if the highest "
+					"in a battle will receive this bonus; if the highest "
 					"levels are equal, no bonus is awarded.";
 			} else {
 				*str += "Tactics allows the unit, and all allies, to gain a "
@@ -462,7 +462,7 @@ AString *ShowSkill::Report(Faction *f) const
 			if (Globals->APPRENTICES_EXIST) {
 				*str += " or ";
 				*str += Globals->APPRENTICE_NAME;
-			}				
+			}
 			*str += ", make a temporary Gate between two regions, and "
 				"send units from one region to another. In order to do this, "
 				"both mages (the caster, and the target mage) must have "
@@ -708,12 +708,12 @@ AString *ShowSkill::Report(Faction *f) const
 						"12 sailing skill points per skill level "
 						"of Summon Wind. ";
 				}
-					 
+
 				/*
 				*str += " If the mage is flying, he will receive 2 extra "
 					"movement points.";
 				*/
-				*str += "The effects of all such mages in a fleet are cumulative. ";	
+				*str += "The effects of all such mages in a fleet are cumulative. ";
 			}
 			break;
 		case S_SUMMON_STORM:
@@ -1584,7 +1584,7 @@ AString *ShowSkill::Report(Faction *f) const
 				temp2 += "] via magic";
 				count = 0;
 				for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(ItemDefs[i].mInput[0]); c++) {
-					if (ItemDefs[i].mInput[c].item == -1) continue;	
+					if (ItemDefs[i].mInput[c].item == -1) continue;
 					count++;
 				}
 				if (count > 0) {
@@ -1592,7 +1592,7 @@ AString *ShowSkill::Report(Faction *f) const
 					temp4 = "";
 					count = 0;
 					for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(ItemDefs[i].mInput[0]); c++) {
-						if (ItemDefs[i].mInput[c].item == -1) continue;	
+						if (ItemDefs[i].mInput[c].item == -1) continue;
 						if (!(temp4 == "")) {
 							if (count > 0)
 								temp2 += ", ";
@@ -1659,7 +1659,7 @@ AString *ShowSkill::Report(Faction *f) const
 					temp4 = "";
 					count = 0;
 					for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(ItemDefs[i].pInput[0]); c++) {
-						if (ItemDefs[i].pInput[c].item == -1) continue;	
+						if (ItemDefs[i].pInput[c].item == -1) continue;
 						if (!(temp4 == "")) {
 							if (count > 0)
 								temp1 += ", ";
@@ -1875,7 +1875,7 @@ AString *ShowSkill::Report(Faction *f) const
 		if (!(*str == "")) *str += " ";
 		*str += "This skill cannot be taught to other units.";
 	}
-	if ((Globals->SKILL_PRACTICE_AMOUNT > 0) && 
+	if ((Globals->SKILL_PRACTICE_AMOUNT > 0) &&
 			(SkillDefs[skill].flags & SkillType::NOEXP)) {
 		if (!(*str == "")) *str += " ";
 		*str += "This skill cannot be increased through experience.";

--- a/snapshot-tests/neworigins_turns/turn_0/report.1
+++ b/snapshot-tests/neworigins_turns/turn_0/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_0/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_0/report.1.json
@@ -23414,7 +23414,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_1/report.1
+++ b/snapshot-tests/neworigins_turns/turn_1/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_1/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_1/report.1.json
@@ -23457,7 +23457,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_10/report.1
+++ b/snapshot-tests/neworigins_turns/turn_10/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_10/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_10/report.1.json
@@ -23851,7 +23851,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_11/report.1
+++ b/snapshot-tests/neworigins_turns/turn_11/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_11/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_11/report.1.json
@@ -23986,7 +23986,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_12/report.1
+++ b/snapshot-tests/neworigins_turns/turn_12/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_12/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_12/report.1.json
@@ -24280,7 +24280,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_13/report.1
+++ b/snapshot-tests/neworigins_turns/turn_13/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_13/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_13/report.1.json
@@ -24459,7 +24459,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_2/report.1
+++ b/snapshot-tests/neworigins_turns/turn_2/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_2/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_2/report.1.json
@@ -23534,7 +23534,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_3/report.1
+++ b/snapshot-tests/neworigins_turns/turn_3/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_3/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_3/report.1.json
@@ -23685,7 +23685,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_3/report.3
+++ b/snapshot-tests/neworigins_turns/turn_3/report.3
@@ -47,8 +47,8 @@ Skill reports:
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 Item reports:

--- a/snapshot-tests/neworigins_turns/turn_3/report.3.json
+++ b/snapshot-tests/neworigins_turns/turn_3/report.3.json
@@ -645,7 +645,7 @@
   ],
   "skill_reports": [
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_4/report.1
+++ b/snapshot-tests/neworigins_turns/turn_4/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_4/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_4/report.1.json
@@ -23770,7 +23770,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_5/report.1
+++ b/snapshot-tests/neworigins_turns/turn_5/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_5/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_5/report.1.json
@@ -23795,7 +23795,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_6/report.1
+++ b/snapshot-tests/neworigins_turns/turn_6/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_6/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_6/report.1.json
@@ -23820,7 +23820,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_7/report.1
+++ b/snapshot-tests/neworigins_turns/turn_7/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_7/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_7/report.1.json
@@ -23820,7 +23820,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_8/report.1
+++ b/snapshot-tests/neworigins_turns/turn_8/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_8/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_8/report.1.json
@@ -23761,7 +23761,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/neworigins_turns/turn_9/report.1
+++ b/snapshot-tests/neworigins_turns/turn_9/report.1
@@ -256,8 +256,8 @@ entertainment [ENTE] 5: No skill report.
 tactics [TACT] 1: Tactics allows the unit, and all allies, to gain a
   bonus to their attack and defense during first battle round. Bonus
   equals to the difference in skills but can be +3 at most. The army
-  with the highest level tactician in a battle will receive this bonus
-  round; if the highest levels are equal, no bonus is awarded. This
+  with the highest level tactician in a battle will receive this
+  bonus; if the highest levels are equal, no bonus is awarded. This
   skill costs 200 silver per month of study.
 
 tactics [TACT] 2: No skill report.

--- a/snapshot-tests/neworigins_turns/turn_9/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_9/report.1.json
@@ -23806,7 +23806,7 @@
       "tag": "ENTE"
     },
     {
-      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus round; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
+      "description": "Tactics allows the unit, and all allies, to gain a bonus to their attack and defense during first battle round. Bonus equals to the difference in skills but can be +3 at most. The army with the highest level tactician in a battle will receive this bonus; if the highest levels are equal, no bonus is awarded. This skill costs 200 silver per month of study.",
       "level": 1,
       "name": "tactics",
       "tag": "TACT"

--- a/snapshot-tests/rules/basic.html
+++ b/snapshot-tests/rules/basic.html
@@ -3355,7 +3355,7 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       its side.  If two or more units on one side have the same Tactics skill,
       then the one with the lower unit number is regarded as the leader of
       that side.  If one side's leader has a better Tactics skill than the
-      other side's,then that side gets a free round of attacks.
+      other side's, then that side gets a free round of attacks.
     </p>
     <p>
       In each combat round, the combatants each get to attack once, in a

--- a/snapshot-tests/rules/fracas.html
+++ b/snapshot-tests/rules/fracas.html
@@ -3646,7 +3646,7 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       its side.  If two or more units on one side have the same Tactics skill,
       then the one with the lower unit number is regarded as the leader of
       that side.  If one side's leader has a better Tactics skill than the
-      other side's,then that side gets a free round of attacks.
+      other side's, then that side gets a free round of attacks.
     </p>
     <p>
       In each combat round, the combatants each get to attack once, in a

--- a/snapshot-tests/rules/havilah.html
+++ b/snapshot-tests/rules/havilah.html
@@ -3903,7 +3903,7 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       its side.  If two or more units on one side have the same Tactics skill,
       then the one with the lower unit number is regarded as the leader of
       that side.  If one side's leader has a better Tactics skill than the
-      other side's,then that side gets a free round of attacks.
+      other side's, then that side gets a free round of attacks.
     </p>
     <p>
       In each combat round, the combatants each get to attack once, in a

--- a/snapshot-tests/rules/kingdoms.html
+++ b/snapshot-tests/rules/kingdoms.html
@@ -4050,7 +4050,7 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       its side.  If two or more units on one side have the same Tactics skill,
       then the one with the lower unit number is regarded as the leader of
       that side.  If one side's leader has a better Tactics skill than the
-      other side's,then that side gets a free round of attacks.
+      other side's, then that side gets a free round of attacks.
     </p>
     <p>
       In each combat round, the combatants each get to attack once, in a

--- a/snapshot-tests/rules/neworigins.html
+++ b/snapshot-tests/rules/neworigins.html
@@ -4042,8 +4042,8 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       its side.  If two or more units on one side have the same Tactics skill,
       then the one with the lower unit number is regarded as the leader of
       that side.  If one side's leader has a better Tactics skill than the
-      other side's,then that side gets a tactics difference bonus to their
-      attack and defense.
+      other side's, then that side gets a tactics difference bonus to their
+      attack and defense for the first round of combat.
     </p>
     <p>
       In each combat round, the combatants each get to attack once, in a

--- a/snapshot-tests/rules/standard.html
+++ b/snapshot-tests/rules/standard.html
@@ -3998,7 +3998,7 @@ Shoemaking [SHOE] 3: A unit with this skill may PRODUCE Sooper Dooper
       its side.  If two or more units on one side have the same Tactics skill,
       then the one with the lower unit number is regarded as the leader of
       that side.  If one side's leader has a better Tactics skill than the
-      other side's,then that side gets a free round of attacks.
+      other side's, then that side gets a free round of attacks.
     </p>
     <p>
       In each combat round, the combatants each get to attack once, in a


### PR DESCRIPTION
Tiny fix to the rules to clarify that tactics bonus is first round only (the skill stated this but the rules didn't).  Also removed a word from the skill that seemed to be a holdover from the old tactics working that gave a free round.