### PR TITLE
Fix missing newline after assassination report

### DIFF
--- a/battle.cpp
+++ b/battle.cpp
@@ -739,6 +739,7 @@ void Battle::build_json_report(json& j, Faction *fac) {
 		j["type"] = "assassination";
 		j["report"] = json::array();
 		j["report"].push_back(asstext);
+		j["report"].push_back(""); // All battle reports end with a new line.  Pre-json code added the line here.
 		return;
 	}
 	j["type"] = "battle";


### PR DESCRIPTION
When I created the json report I missed that the report added a newline after the assassination report, which made it consistent with all other battle reports.  This corrects that.

This fix has already been applied to the neworigins-v7 branch