### PR TITLE
Fix QM bug on master

### DIFF
--- a/runorders.cpp
+++ b/runorders.cpp
@@ -3154,7 +3154,7 @@ void Game::RunTransportPhase(TransportOrder::TransportPhase phase) {
 					}
 
 					if (phase == TransportOrder::TransportPhase::INTER_QM_TRANSPORT) {
-						tar->unit->transport_items.SetNum(t->item, amt);
+						tar->unit->transport_items.SetNum(t->item, tar->unit->transport_items.GetNum(t->item) + amt);
 					} else {
 						tar->unit->items.SetNum(t->item, tar->unit->items.GetNum(t->item) + amt);
 					}

--- a/unittest/quartermaster_test.cpp
+++ b/unittest/quartermaster_test.cpp
@@ -40,38 +40,39 @@ ut::suite<"Quartermaster"> quartermaster_suite = []
     std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
-    ss << "transport 3 50 stone\n";  // unit 1 -> QM 1
+    ss << "transport 3 70 stone\n";  // unit 1 -> QM 1
     ss << "unit 3\n";
     ss << "transport 4 50 stone\n"; // QM 1 -> QM 2
+    ss << "transport 4 20 stone\n"; // QM 1 -> QM 2 (should make 70 stone total, not 20 as in reported bug)
     ss << "unit 4\n";
     ss << "transport 5 50 stone\n"; // QM 2 -> unit 2
     helper.parse_orders(faction->num, ss);
     helper.check_transport_orders();
 
     helper.transport_phase(TransportOrder::TransportPhase::SHIP_TO_QM);
-    expect(unit1->items.GetNum(I_STONE) == 50_i);
-    expect(qm1->items.GetNum(I_STONE) == 50_i);
+    expect(unit1->items.GetNum(I_STONE) == 30_i);
+    expect(qm1->items.GetNum(I_STONE) == 70_i);
     expect(qm2->items.GetNum(I_STONE) == 0_i);
     expect(unit2->items.GetNum(I_STONE) == 0_i);
 
     helper.transport_phase(TransportOrder::TransportPhase::INTER_QM_TRANSPORT);
-    expect(unit1->items.GetNum(I_STONE) == 50_i);
+    expect(unit1->items.GetNum(I_STONE) == 30_i);
     expect(qm1->items.GetNum(I_STONE) == 0_i);
-    expect(qm2->transport_items.GetNum(I_STONE) == 50_i);
+    expect(qm2->transport_items.GetNum(I_STONE) == 70_i);
     expect(qm2->items.GetNum(I_STONE) == 0_i);
     expect(unit2->items.GetNum(I_STONE) == 0_i);
 
     helper.collect_transported_goods();
-    expect(unit1->items.GetNum(I_STONE) == 50_i);
+    expect(unit1->items.GetNum(I_STONE) == 30_i);
     expect(qm1->items.GetNum(I_STONE) == 0_i);
     expect(qm2->transport_items.GetNum(I_STONE) == 0_i);
-    expect(qm2->items.GetNum(I_STONE) == 50_i);
+    expect(qm2->items.GetNum(I_STONE) == 70_i);
     expect(unit2->items.GetNum(I_STONE) == 0_i);
 
     helper.transport_phase(TransportOrder::TransportPhase::DISTRIBUTE_FROM_QM);
-    expect(unit1->items.GetNum(I_STONE) == 50_i);
+    expect(unit1->items.GetNum(I_STONE) == 30_i);
     expect(qm1->items.GetNum(I_STONE) == 0_i);
-    expect(qm2->items.GetNum(I_STONE) == 0_i);
+    expect(qm2->items.GetNum(I_STONE) == 20_i);
     expect(unit2->items.GetNum(I_STONE) == 50_i);
   };
 


### PR DESCRIPTION
This makes it so that multiple QM->QM orders from the same initiator to the same target for the same item do not lose items.
Not sure why someone would do this, but someone did and it broke.  This is just 100% correct.  It would have also broken if multiple source QMs sent the same item to the same target QM so...