### PR TITLE
Fix bug with sail order and new victory condition checking

### DIFF
--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -296,30 +296,30 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 			stop = 1;
 		}
 
-		// Check the new region for barriers and the fleet units for keys to the barriers
-		int needed_key = -1;
-		forlist(&newreg->objects) {
-			Object *o = (Object *) elem;
-			if (ObjectDefs[o->type].flags & ObjectType::KEYBARRIER) {
-				needed_key = ObjectDefs[o->type].key_item;
-			}
-		}
-		if (needed_key != -1) { // we found a barrier
-			bool has_key = false;
-			for(auto u: fleet->units) {
-				if (u->items.GetNum(needed_key) > 0) {
-					has_key = true;
-					break;
+		if (!stop) {
+			// Check the new region for barriers and the fleet units for keys to the barriers
+			int needed_key = -1;
+			forlist(&newreg->objects) {
+				Object *o = (Object *) elem;
+				if (ObjectDefs[o->type].flags & ObjectType::KEYBARRIER) {
+					needed_key = ObjectDefs[o->type].key_item;
 				}
 			}
-			if (!has_key) {
-				cap->error("SAIL: Can't sail " + DirectionStrs[x.dir] + " from " +
-					reg->ShortPrint().const_str() + " due to mystical barrier.");
-				stop = 1;
+			if (needed_key != -1) { // we found a barrier
+				bool has_key = false;
+				for(auto u: fleet->units) {
+					if (u->items.GetNum(needed_key) > 0) {
+						has_key = true;
+						break;
+					}
+				}
+				if (!has_key) {
+					cap->error("SAIL: Can't sail " + DirectionStrs[x.dir] + " from " +
+						reg->ShortPrint().const_str() + " due to mystical barrier.");
+					stop = 1;
+				}
 			}
-		}
 
-		if (!stop) {
 			fleet->movepoints -= cost * Globals->MAX_SPEED;
 			if (x.dir != MOVE_PAUSE) {
 				fleet->MoveObject(newreg);


### PR DESCRIPTION
My checking for the KEYBARRIER weren't correctly guarded in the case where the new region didn't exist (edge of map/undworld block).. 

Moving it inside the if(!stop) block fixes this.