### PR TITLE
Update code to remove AList from factions

### DIFF
--- a/aregion.h
+++ b/aregion.h
@@ -51,7 +51,9 @@ using json = nlohmann::json;
 #include <map>
 #include <vector>
 #include <list>
+#include <set>
 #include <functional>
+#include <memory>
 
 /* Weather Types */
 enum {
@@ -195,7 +197,7 @@ class ARegion : public AListElem
 		void SetName(char const *);
 
 		void Writeout(std::ostream& f);
-		void Readin(std::istream& f, AList *);
+		void Readin(std::istream& f, const std::vector<std::unique_ptr<Faction>>& factions);
 
 		int CanMakeAdv(Faction *, int);
 		int HasItem(Faction *, int);
@@ -216,7 +218,7 @@ class ARegion : public AListElem
 
 		void SetLoc(int, int, int);
 		int Present(Faction *);
-		AList *PresentFactions();
+		std::set<Faction *> PresentFactions();
 		int GetObservation(Faction *, int);
 		int GetTrueSight(Faction *, int);
 
@@ -461,7 +463,7 @@ class ARegionList : public AList
 
 		ARegion *GetRegion(int);
 		ARegion *GetRegion(int, int, int);
-		int ReadRegions(std::istream &f, AList *);
+		int ReadRegions(std::istream &f, const std::vector<std::unique_ptr<Faction>>& factions);
 		void WriteRegions(std::ostream&  f);
 		Location *FindUnit(int);
 		Location *GetUnitId(UnitId *id, int faction, ARegion *cur);

--- a/edit.cpp
+++ b/edit.cpp
@@ -1270,7 +1270,7 @@ void Game::EditGameUnitDetails(Unit *pUnit)
 						break;
 					}
 
-					Faction *fac = GetFaction(&factions, fnum);
+					Faction *fac = get_faction(factions, fnum);
 					if (fac) pUnit->faction = fac;
 					else Awrite("Cannot Find Faction");
 				}
@@ -1303,7 +1303,7 @@ void Game::EditGameUnitDetails(Unit *pUnit)
 
 void Game::EditGameCreateUnit()
 {
-	Faction *fac = GetFaction(&factions, 1);
+	Faction *fac = get_faction(factions, 1);
 	Unit *newunit = GetNewUnit(fac);
 	newunit->SetMen(I_LEADERS, 1);
 	newunit->reveal = REVEAL_FACTION;

--- a/faction.cpp
+++ b/faction.cpp
@@ -29,6 +29,8 @@
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
+#include <vector>
+#include <memory>
 
 using namespace std;
 
@@ -509,7 +511,7 @@ void Faction::build_json_report(json& j, Game *game, size_t **citems) {
 		for (const auto& a: attitudes) {
 			if (a.attitude == i) {
 				// Grab that faction so we can get it's number and name, and strip the " (num)" from the name for json
-				Faction *fac = GetFaction(&(game->factions), a.factionnum);
+				Faction *fac = get_faction(game->factions, a.factionnum);
 				string facname = fac->name->const_str();
 				facname = facname.substr(0, facname.find(" ("));
 				j["attitudes"][attitude].push_back({ { "name", facname }, { "number", a.factionnum } });
@@ -724,20 +726,12 @@ void Faction::TimesReward()
 	}
 }
 
-Faction *GetFaction(AList *facs, int n)
+Faction *get_faction(const std::vector<std::unique_ptr<Faction>>& factions, int faction_id)
 {
-	forlist(facs)
-		if (((Faction *) elem)->num == n)
-			return (Faction *) elem;
-	return 0;
-}
-
-Faction *GetFaction2(AList *facs, int n)
-{
-	forlist(facs)
-		if (((FactionPtr *) elem)->ptr->num == n)
-			return ((FactionPtr *) elem)->ptr;
-	return 0;
+	for (auto& faction : factions) {
+		if (faction->num == faction_id) return faction.get();
+	}
+	return nullptr;
 }
 
 void Faction::DiscoverItem(int item, int force, int full)

--- a/faction.h
+++ b/faction.h
@@ -40,7 +40,6 @@ struct ShowObject;
 #include "battle.h"
 #include "skills.h"
 #include "items.h"
-#include "alist.h"
 #include "astring.h"
 
 #include "external/nlohmann/json.hpp"
@@ -51,6 +50,7 @@ using json = nlohmann::json;
 #include <vector>
 #include <iostream>
 #include <sstream>
+#include <memory>
 
 enum
 {
@@ -111,12 +111,6 @@ enum FactionActivity
 	TRADE = 2
 };
 
-class FactionPtr : public AListElem
-{
-public:
-	Faction *ptr;
-};
-
 // Collect the faction statistics for display in the report
 struct FactionStatistic {
 	std::string item_name;
@@ -149,7 +143,7 @@ struct FactionEvent {
 	friend void to_json(json &j, const FactionEvent &e);
 };
 
-class Faction : public AListElem
+class Faction
 {
 public:
 	Faction();
@@ -215,8 +209,6 @@ public:
 	int numapprentices;
 	int numqms;
 	int numtacts;
-	// AList war_regions;
-	// AList trade_regions;
 
 	std::unordered_map<ARegion *, std::unordered_set<FactionActivity, std::hash<int>>> activity;
 	int GetActivityCost(FactionActivity type);
@@ -233,7 +225,6 @@ public:
 	// For now, just making it a vector of attitudes.  More will come later.
 	std::vector<Attitude> attitudes;
 
-	// These need to not be ALists wrapped with extra behavior at some point.
 	SkillList skills;
 	ItemList items;
 
@@ -262,7 +253,6 @@ private:
 	void build_gm_json_report(json& j, Game *game);
 };
 
-Faction *GetFaction(AList *, int);
-Faction *GetFaction2(AList *, int); /*This AList is a list of FactionPtr*/
+Faction *get_faction(const std::vector<std::unique_ptr<Faction>>& factions, int faction_id);
 
 #endif

--- a/game.h
+++ b/game.h
@@ -35,6 +35,10 @@ class Game;
 #include "object.h"
 #include "events.h"
 
+#include <set>
+#include <vector>
+#include <memory>
+
 #define CURRENT_ATL_VER MAKE_ATL_VER(5, 2, 5)
 
 class OrdersCheck
@@ -81,7 +85,6 @@ public:
 	int ReadPlayers();
 	int ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 						int newPlayer);
-	void WriteNewFac(Faction *pFac);
 
 	int ViewMap(const AString &, const AString &);
 	// LLS
@@ -288,8 +291,7 @@ private:
 						 int type, int val);
 	void ModifyHealing(int level, int patients, int success);
 
-	AList factions;
-	std::vector<std::string> newfactions; /* List of strings */
+	std::vector<std::unique_ptr<Faction>> factions;
 	std::vector<Battle *> battles;
 	ARegionList regions;
 	int factionseq;
@@ -557,7 +559,7 @@ private:
 	void RunSacrificeOrders();
 	void CollectInterQMTransportItems();
 	void CheckTransportOrders();
-	std::vector<std::shared_ptr<Faction>> CanSeeSteal(ARegion *, Unit *);
+	std::vector<Faction *> CanSeeSteal(ARegion *, Unit *);
 	void Do1Steal(ARegion *, Object *, Unit *);
 	void Do1Assassinate(ARegion *, Object *, Unit *);
 	void Do1Annihilate(ARegion *reg);
@@ -606,16 +608,20 @@ private:
 	// Battle function
 	//
 	int KillDead(Location *, Battle *, int, int);
-	int RunBattle(ARegion *, Unit *, Unit *, int = 0, int = 0);
-	void GetSides(ARegion *, AList &, AList &, AList &, AList &, Unit *, Unit *,
-				  int = 0, int = 0);
-	int CanAttack(ARegion *, AList *, Unit *);
-	void GetAFacs(ARegion *, Unit *, Unit *, AList &, AList &, AList &);
-	void GetDFacs(ARegion *, Unit *, AList &);
+	int RunBattle(ARegion *r, Unit *attacker, Unit *target, bool ass = false, bool adv = false);
+	void GetSides(
+		ARegion *r, std::set<Faction *> afacs, std::set<Faction *> dfacs, AList& atts,
+		AList& defs, Unit *att, Unit *tar, bool ass = false, bool adv = false
+	);
+	bool CanAttack(ARegion *r, std::set<Faction *> afacs, Unit *u);
+	void GetAFacs(
+		ARegion *r, Unit *att, Unit *tar, std::set<Faction *>& dfacs, std::set<Faction *>& afacs, AList &atts
+	);
+	void GetDFacs(ARegion *r, Unit *t, std::set<Faction *>& facs);
 
 	// For faction statistics
 	void CountItems(size_t **citems);
-	int CountItem(Faction *, int);
+	int CountItem(const Faction* fac, int item);
 };
 
 #endif

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -340,7 +340,6 @@ Faction *Game::CheckVictory()
 	unsigned ucount;
 	ARegion *r, *start;
 	Object *o;
-	Faction *f;
 	Location *l;
 	AString message, times, temp;
 	map <string, int> vRegions, uvRegions;
@@ -562,8 +561,7 @@ Faction *Game::CheckVictory()
 	}
 
 	// See if anyone has won by collecting enough relics of grace
-	forlist_reuse(&factions) {
-		f = (Faction *) elem;
+	for(auto& f : factions) {
 		// No accidentally sending all the Guardsmen
 		// or Creatures to the Eternal City!
 		if (f->is_npc)
@@ -574,7 +572,7 @@ Faction *Game::CheckVictory()
 			forlist(&r->objects) {
 				o = (Object *) elem;
 				for(auto u: o->units) {
-					if (u->faction == f) {
+					if (u->faction == f.get()) {
 						reliccount += u->items.GetNum(I_RELICOFGRACE);
 					}
 				}
@@ -599,7 +597,7 @@ Faction *Game::CheckVictory()
 					// and then remove them at the end.
 					std::vector<Unit *> unitsToErase;
 					for(auto u: o->units) {
-						if (u->faction == f) {
+						if (u->faction == f.get()) {
 							units++;
 							for(auto item: u->items) {
 								if (ItemDefs[item.type].type & IT_LEADER)
@@ -776,7 +774,7 @@ Faction *Game::CheckVictory()
 						"The connection between Havilah and the Eternal City has been severed.\n\n"
 						"The light fails; darkness falls forever, and all life perishes under endless ice.";
 					WriteTimesArticle(message);
-					return GetFaction(&factions, monfaction);
+					return get_faction(factions, monfaction);
 				}
 				if (o->incomplete <= ObjectDefs[o->type].cost / 2) {
 					// Half done; make a quest to destroy it

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <random>
 #include <memory>
+#include <set>
 
 #include "game.h"
 #include "gamedata.h"
@@ -214,7 +215,7 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 {
 	std::shared_ptr<SailOrder> o = std::dynamic_pointer_cast<SailOrder>(cap->monthorders);
 	int stop, wgt, slr, nomove, cost;
-	AList facs;
+	std::set<Faction *> facs;
 	ARegion *newreg;
 	Location *loc;
 
@@ -224,11 +225,8 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 	slr = 0;
 	nomove = 0;
 	for(auto unit: fleet->units) {
-		if (!GetFaction2(&facs,unit->faction->num)) {
-			FactionPtr * p = new FactionPtr;
-			p->ptr = unit->faction;
-			facs.Add(p);
-		}
+		facs.insert(unit->faction);
+
 		wgt += unit->Weight();
 		if (unit->nomove) {
 			// If any unit on-board was in a fight (and
@@ -339,15 +337,10 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 					}
 				}
 				unit->DiscardUnfinishedShips();
-				if (!GetFaction2(&facs, unit->faction->num)) {
-					FactionPtr *p = new FactionPtr;
-					p->ptr = unit->faction;
-					facs.Add(p);
-				}
+				facs.insert(unit->faction);
 			}
 
-			forlist_reuse(&facs) {
-				Faction * f = ((FactionPtr *) elem)->ptr;
+			for(auto& f: facs) {
 				string temp = fleet->name->const_str();
 				temp += (x.dir == MOVE_PAUSE ? " performs maneuvers in " : " sails from ") +
 					string(reg->ShortPrint().const_str());

--- a/npc.cpp
+++ b/npc.cpp
@@ -146,7 +146,7 @@ void Game::GrowLMons(int rate)
 		// Don't make lmons in guarded regions
 		//
 		if (r->IsGuarded()) continue;
-		
+
 		forlist(&r->objects) {
 			Object *obj = (Object *) elem;
 			if (obj->units.size()) continue;
@@ -178,7 +178,7 @@ int Game::MakeWMon(ARegion *pReg)
 
 	MonType *mp = FindMonster(ItemDefs[montype].abr,
 			(ItemDefs[montype].type & IT_ILLUSION));
-	Faction *monfac = GetFaction(&factions, monfaction);
+	Faction *monfac = get_faction(factions, monfaction);
 	Unit *u = GetNewUnit(monfac, 0);
 	u->MakeWMon(mp->name, montype, (mp->number+getrandom(mp->number)+1)/2);
 	u->MoveUnit(pReg->GetDummy());
@@ -203,7 +203,7 @@ void Game::MakeLMon(Object *pObj)
 
 	MonType *mp = FindMonster(ItemDefs[montype].abr,
 			(ItemDefs[montype].type & IT_ILLUSION));
-	Faction *monfac = GetFaction(&factions, monfaction);
+	Faction *monfac = get_faction(factions, monfaction);
 	Unit *u = GetNewUnit(monfac, 0);
 	switch(montype) {
 		case I_IMP:
@@ -358,13 +358,13 @@ Unit *Game::MakeManUnit(Faction *fac, int mantype, int num, int level, int weapo
 			// disregard picks!
 			AString *ps = new AString("PICK");
 			if (LookupItem(it) == LookupItem(ps)) continue;
-			
+
 			// Sort out the more exotic weapons!
 			int producelevel = ItemDefs[LookupItem(it)].pLevel;
 			if (ItemDefs[LookupItem(it)].pSkill != FindSkill("WEAP")->abbr) continue;
 
 			AString *s1 = new AString(WeaponDefs[i].baseSkill);
-			AString *s2 = new AString(WeaponDefs[i].orSkill);			
+			AString *s2 = new AString(WeaponDefs[i].orSkill);
 			if ((WeaponDefs[i].flags & WeaponType::RANGED)
 				&& (!behind)) continue;
 			int attack = WeaponDefs[i].attackBonus;
@@ -393,7 +393,7 @@ Unit *Game::MakeManUnit(Faction *fac, int mantype, int num, int level, int weapo
 				}
 			}
 		}
-		
+
 		if (n < 1) {
 			weaponlevel++;
 			continue;
@@ -436,7 +436,7 @@ Unit *Game::MakeManUnit(Faction *fac, int mantype, int num, int level, int weapo
 	for (unsigned int i=0; i<(sizeof(men->skills)/sizeof(men->skills[0])); i++) {
 		if (FindSkill(men->skills[i]) == FindSkill(SkillDefs[sk].abbr)) {
 			special = 1;
-		}		
+		}
 	}
 	if (special) maxskill = men->speciallevel;
 	if (level > maxskill) level = maxskill;

--- a/object.cpp
+++ b/object.cpp
@@ -30,6 +30,8 @@
 #include "gamedata.h"
 #include "unit.h"
 #include "indenter.hpp"
+#include <vector>
+#include <memory>
 
 int LookupObject(AString *token)
 {
@@ -119,7 +121,7 @@ void Object::Writeout(std::ostream& f)
 	WriteoutFleet(f);
 }
 
-void Object::Readin(std::istream& f, AList *facs)
+void Object::Readin(std::istream& f, const std::vector<std::unique_ptr<Faction>>& factions)
 {
 	AString temp;
 
@@ -153,7 +155,7 @@ void Object::Readin(std::istream& f, AList *facs)
 	f >> i;
 	for (int j = 0; j < i; j++) {
 		Unit *temp = new Unit;
-		temp->Readin(f, facs);
+		temp->Readin(f, factions);
 		if (!temp->faction)
 			continue;
 		temp->MoveUnit(this);

--- a/object.h
+++ b/object.h
@@ -33,6 +33,7 @@ class Object;
 #include "faction.h"
 #include "items.h"
 #include <map>
+#include <memory>
 
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
@@ -111,7 +112,7 @@ class Object : public AListElem
 		Object(ARegion *region);
 		~Object();
 
-		void Readin(std::istream& f, AList *);
+		void Readin(std::istream& f, const std::vector<std::unique_ptr<Faction>>& factions);
 		void Writeout(std::ostream& f);
 		void build_json_report(json& j, Faction *, int, int, int, int, int, int, int);
 

--- a/standard/monsters.cpp
+++ b/standard/monsters.cpp
@@ -39,7 +39,7 @@ void Game::CreateVMons()
 		forlist(&r->objects) {
 			Object * obj = (Object *) elem;
 			if (obj->type != O_BKEEP) continue;
-			Faction *monfac = GetFaction( &factions, 2 );
+			Faction *monfac = get_faction(factions, 2);
 			Unit *u = GetNewUnit( monfac, 0 );
 			u->MakeWMon( "Elder Demons", I_BALROG, 200);
 			u->MoveUnit(obj);

--- a/unit.cpp
+++ b/unit.cpp
@@ -26,6 +26,8 @@
 #include "unit.h"
 #include "gamedata.h"
 #include <stack>
+#include <vector>
+#include <memory>
 
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
@@ -197,7 +199,7 @@ void Unit::Writeout(ostream& f)
 	}
 }
 
-void Unit::Readin(istream& f, AList *facs)
+void Unit::Readin(istream& f, const std::vector<std::unique_ptr<Faction>>& factions)
 {
 	AString temp;
 	f >> ws >> temp;
@@ -217,7 +219,7 @@ void Unit::Readin(istream& f, AList *facs)
 	int i;
 	f >> i;
 
-	faction = GetFaction(facs, i);
+	faction = get_faction(factions, i);
 	f >> guard;
 	if (guard == GUARD_ADVANCE) guard = GUARD_NONE;
 	if (guard == GUARD_SET) guard = GUARD_GUARD;

--- a/unit.h
+++ b/unit.h
@@ -48,6 +48,8 @@ class UnitId;
 #include "object.h"
 #include <set>
 #include <string>
+#include <vector>
+#include <memory>
 
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
@@ -123,7 +125,7 @@ class Unit
 		void MakeWMon(char const *,int,int);
 
 		void Writeout(std::ostream& f);
-		void Readin(std::istream& f, AList *);
+		void Readin(std::istream& f, const std::vector<std::unique_ptr<Faction>>& factions);
 
 		AString SpoilsReport(void);
 		int CanGetSpoil(Item& i);

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -47,12 +47,8 @@ Faction *UnitTestHelper::create_faction(std::string name) {
 }
 
 Faction *UnitTestHelper::get_faction(int id) {
-    forlist(&game.factions) {
-        Faction *f = (Faction *)elem;
-        if (f->num != id) continue;
-        return f;
-    }
-    return nullptr;
+    // pass this on to the globally defined get_faction function
+    return ::get_faction(game.factions, id);
 }
 
 Unit *UnitTestHelper::get_first_unit(Faction *faction) {


### PR DESCRIPTION
This removes the use of Faction being an AListElem, and also the need for the secondary FactionPtr class, which solely existed to allow factions to be in multiple lists. Factions are now unique pointers managed by the game class.

Unique pointers in c++ are smart pointers that have exactly one copy. Unfortunately this means you cannot (except by passing around the raw pointer) or references to the unique pointer interlink things.

To make the code changes *less* I opted to leave most of the code passing around raw pointers, since those don't get allocated/deleted (if they did, we would have run into issues long ago!)  In the long long run, these should probably all move to being const refs to std::unique_ptr, but for now, what they are is fine.