### PR TITLE
Remove another use of AList

### DIFF
--- a/aregion.h
+++ b/aregion.h
@@ -109,7 +109,7 @@ class TerrainType
 
 extern TerrainType *TerrainDefs;
 
-class Location : public AListElem
+class Location
 {
 	public:
 		Unit *unit;
@@ -117,7 +117,7 @@ class Location : public AListElem
 		ARegion *region;
 };
 
-Location *GetUnit(AList *, int);
+Location *GetUnit(const std::vector<Location *>& list, int unit_id);
 
 int AGetName(int town, ARegion *r);
 char const *AGetNameString(int name);
@@ -130,7 +130,7 @@ class ARegionPtr : public AListElem
 
 ARegionPtr *GetRegion(AList *, int);
 
-class Farsight : public AListElem
+class Farsight
 {
 	public:
 		Farsight();
@@ -142,7 +142,7 @@ class Farsight : public AListElem
 		int exits_used[NDIRS];
 };
 
-Farsight *GetFarsight(AList *, Faction *);
+Farsight *GetFarsight(std::vector<Farsight *>& l, Faction *f);
 
 enum {
 	TOWN_VILLAGE,
@@ -217,7 +217,7 @@ class ARegion : public AListElem
 		Location *GetLocation(UnitId *, int);
 
 		void SetLoc(int, int, int);
-		int Present(Faction *);
+		bool Present(Faction *f);
 		std::set<Faction *> PresentFactions();
 		int GetObservation(Faction *, int);
 		int GetTrueSight(Faction *, int);
@@ -345,13 +345,13 @@ class ARegion : public AListElem
 		int phantasmal_entertainment;
 
 		ARegion *neighbors[NDIRS];
-		AList objects;
+		std::vector<Object *>objects;
 		std::map<int,int> newfleets;
 		int fleetalias;
 		std::vector<Unit *>hell; /* Where dead units go */
-		AList farsees;
+		std::vector<Farsight *> farsees;
 		// List of units which passed through the region
-		AList passers;
+		std::vector<Farsight *> passers;
 		std::vector<Production *> products;
 		std::vector<Market*> markets;
 		int xloc, yloc, zloc;

--- a/army.cpp
+++ b/army.cpp
@@ -667,7 +667,7 @@ void Soldier::Dead()
 	unit->SetMen(race,unit->GetMen(race) - 1);
 }
 
-Army::Army(Unit *ldr, AList *locs, int regtype, int ass)
+Army::Army(Unit *ldr, std::vector<Location *>& locs, int regtype, int ass)
 {
 	stats = ArmyStats();
 
@@ -685,8 +685,8 @@ Army::Army(Unit *ldr, AList *locs, int regtype, int ass)
 		count = 1;
 		ldr->losses = 0;
 	} else {
-		forlist(locs) {
-			Unit * u = ((Location *) elem)->unit;
+		for(const auto l : locs) {
+			Unit * u = l->unit;
 			count += u->GetSoldiers();
 			u->losses = 0;
 			int temp = u->GetAttribute("tactics");
@@ -711,11 +711,11 @@ Army::Army(Unit *ldr, AList *locs, int regtype, int ass)
 	int x = 0;
 	int y = count;
 
-	forlist(locs) {
-		Unit * u = ((Location *) elem)->unit;
+	for(const auto l : locs) {
+		Unit * u = l->unit;
 		stats.TrackUnit(u);
 
-		Object * obj = ((Location *) elem)->obj;
+		Object * obj = l->obj;
 		if (ass) {
 			for(auto it: u->items) {
 				ItemType& item = ItemDefs[it.type];

--- a/army.h
+++ b/army.h
@@ -39,6 +39,9 @@ class Army;
 #include "helper.h"
 #include "skills.h"
 
+// external declaration of Location
+class Location;
+
 WeaponBonusMalus* GetWeaponBonusMalus(WeaponType *, WeaponType *);
 
 struct AttackStat {
@@ -168,7 +171,7 @@ public:
 class Army
 {
 	public:
-		Army(Unit *,AList *,int,int = 0);
+		Army(Unit *ldr, std::vector<Location *>& locs, int regtype, int ass = 0);
 		~Army();
 
 		void WriteLosses(Battle *b);

--- a/basic/map.cpp
+++ b/basic/map.cpp
@@ -89,7 +89,7 @@ void ARegionList::CreateAbyssLevel(int level, char const *name)
 	o->type = O_BKEEP;
 	o->incomplete = 0;
 	o->inner = -1;
-	lair->objects.Add(o);
+	lair->objects.push_back(o);
 }
 
 
@@ -1080,7 +1080,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = temp->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(reg);
 	o->num = temp->buildingseq++;
@@ -1088,7 +1088,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	temp->objects.Add(o);
+	temp->objects.push_back(o);
 }
 
 void ARegionList::MakeShaftLinks(int levelFrom, int levelTo, int odds)
@@ -1152,7 +1152,7 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 								o->type = O_GATEWAY;
 								o->incomplete = 0;
 								o->inner = reg->num;
-								AC->objects.Add(o);
+								AC->objects.push_back(o);
 							}
 						}
 				}

--- a/battle.h
+++ b/battle.h
@@ -29,7 +29,6 @@
 class Battle;
 
 #include "astring.h"
-#include "alist.h"
 #include "army.h"
 #include "items.h"
 #include "events.h"
@@ -37,6 +36,9 @@ class Battle;
 
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
+
+// External decl of Location
+class Location;
 
 enum {
 	ASS_NONE,
@@ -51,7 +53,7 @@ enum {
 	BATTLE_DRAW
 };
 
-class Battle : public AListElem
+class Battle
 {
 	public:
 		Battle();
@@ -60,26 +62,27 @@ class Battle : public AListElem
 		void build_json_report(json &j, Faction *fac);
 		void AddLine(const AString &);
 
-		int Run(Events* events, ARegion *, Unit *, AList *, Unit *, AList *, int ass,
-				ARegionList *pRegs);
+		int Run(
+			Events *events, ARegion *region, Unit *att, std::vector<Location *>& atts, Unit *tar,
+			std::vector<Location *>& defs, int ass, ARegionList *pRegs
+		);
 		void FreeRound(Army *,Army *, int ass = 0);
 		void NormalRound(int,Army *,Army *);
 		void DoAttack(int round, Soldier *a, Army *attackers, Army *def,
 				int behind, int ass = 0, bool canAttackBehind = false, bool canAttackFromBehind = false);
 
-		void GetSpoils(AList *loser, ItemList& spoils, int assasination);
+		void GetSpoils(std::vector<Location *>& losers, ItemList& spoils, int assasination);
 
 		//
 		// These functions should be implemented in specials.cpp
 		//
 		void UpdateShields(Army *);
-		void DoSpecialAttack( int round, Soldier *a, Army *attackers,
-				Army *def, int behind, int canattackback);
+		void DoSpecialAttack(int round, Soldier *a, Army *attackers, Army *def, int behind, int canattackback);
 
-		void WriteSides(ARegion *,Unit *,Unit *,AList *,AList *,int,
-				ARegionList *pRegs );
-
-		// void WriteBattleStats(ArmyStats *);
+		void WriteSides(
+			ARegion *r, Unit *att, Unit *tar, std::vector<Location *>& atts,
+			std::vector<Location *>& defs, int ass, ARegionList *pRegs
+		);
 
 		int assassination;
 		Faction * attacker; /* Only matters in the case of an assassination */

--- a/economy.cpp
+++ b/economy.cpp
@@ -840,13 +840,19 @@ void ARegion::AddTown(int size, AString * name)
 	SetTownType(size);
 	SetupCityMarket();
 	/* remove all lairs */
-	forlist(&objects) {
-		Object *obj = (Object *) elem;
-		if (obj->type == O_DUMMY) continue;
+	for(auto it = objects.begin(); it != objects.end(); ) {
+		Object *obj = *it;
+		if (obj->type == O_DUMMY) {
+			++it;
+			continue;
+		}
 		if ((ObjectDefs[obj->type].monster != -1) && (!(ObjectDefs[obj->type].flags & ObjectType::CANENTER))) {
 			obj->units.clear();
-			objects.Remove(obj);
+			it = objects.erase(it);
+			delete obj;
+			continue;
 		}
+		++it;
 	}
 }
 
@@ -1074,8 +1080,7 @@ void ARegion::UpdateProducts()
 
 		if (prod->itemtype == I_SILVER && prod->skill == -1) continue;
 
-		forlist (&objects) {
-			Object *o = (Object *) elem;
+		for(const auto o : objects) {
 			if (o->incomplete < 1 &&
 					ObjectDefs[o->type].productionAided == prod->itemtype) {
 				lastbonus /= 2;
@@ -1131,8 +1136,7 @@ int ARegion::TownHabitat()
 	int temple = 0;
 	int caravan = 0;
 	int fort = 0;
-	forlist(&objects) {
-		Object *obj = (Object *) elem;
+	for(const auto obj : objects) {
 		if (ObjectDefs[obj->type].protect > fort) fort = ObjectDefs[obj->type].protect;
 		if (ItemDefs[ObjectDefs[obj->type].productionAided].type & IT_FOOD) farm++;
 		if (ObjectDefs[obj->type].productionAided == I_SILVER) inn++;
@@ -1634,9 +1638,8 @@ void ARegion::PostTurn(ARegionList *pRegs)
 	earthlore = 0;
 	clearskies = 0;
 
-	forlist(&objects) {
-		Object *o = (Object *) elem;
-		for(auto u: o->units) {
+	for(const auto o : objects) {
+		for(const auto u: o->units) {
 			u->PostTurn(this);
 		}
 	}

--- a/edit.cpp
+++ b/edit.cpp
@@ -8,6 +8,7 @@
 #include "unit.h"
 #include "astring.h"
 #include "gamedata.h"
+#include <type_traits>
 
 int Game::EditGame(int *pSaveGame)
 {
@@ -161,8 +162,7 @@ void Game::EditGameRegionObjects( ARegion *pReg )
 		Awrite( "" );
 		int i = 0;
 		AString temp = AString("");
-		forlist (&(pReg->objects)) {
-			Object * obj = (Object *)elem;
+		for(const auto obj : pReg->objects) {
 			temp = AString ((AString(i) + ". " + *obj->name + " : " + ObjectDefs[obj->type].name));
 //			if (Globals->HEXSIDE_TERRAIN && obj->hexside>-1) temp += AString( AString(" (side:") + DirectionAbrs[obj->hexside] + ").");
 			Awrite(temp);
@@ -237,7 +237,7 @@ void Game::EditGameRegionObjects( ARegion *pReg )
 						o->num = pReg->buildingseq++;
 						o->name = new AString(AString("Building") + " [" + o->num + "]");
 					}
-					pReg->objects.Add(o);
+					pReg->objects.push_back(o);
 				}
 				// delete object
 				else if (*pToken == "d") {
@@ -249,17 +249,14 @@ void Game::EditGameRegionObjects( ARegion *pReg )
 						break;
 					}
 
-					int index = pToken->value();
-					if ( (index < 0) || (index >= pReg->objects.Num()) ) { //modified minimum to <0 to allow deleting object 0. 030824 BS
+					size_t index = pToken->value();
+					if ( (index < 0) || (index >= pReg->objects.size()) ) { //modified minimum to <0 to allow deleting object 0. 030824 BS
 						Awrite( "Incorrect index." );
 						break;
 					}
 					SAFE_DELETE( pToken );
 
-					int i = 0;
-					AListElem *tmp = pReg->objects.First();
-					for (i = 0; i < index; i++) tmp = pReg->objects.Next(tmp);
-					pReg->objects.Remove(tmp);
+					pReg->objects.erase(pReg->objects.begin() + index);
 				}
 	//hexside change
 	/*			else if (*pToken == "h") {
@@ -397,8 +394,8 @@ void Game::EditGameRegionObjects( ARegion *pReg )
 						break;
 					}
 
-					int index = pToken->value();
-					if ( (index < 1) || (index >= pReg->objects.Num()) ) {
+					size_t index = pToken->value();
+					if ( (index < 1) || (index >= pReg->objects.size()) ) {
 						Awrite( "Incorrect index." );
 						break;
 					}
@@ -410,10 +407,7 @@ void Game::EditGameRegionObjects( ARegion *pReg )
 						break;
 					}
 
-					int i = 0;
-					Object *tmp = (Object *)pReg->objects.First();
-					for (i = 0; i < index; i++) tmp = (Object *)pReg->objects.Next(tmp);
-
+					Object *tmp = pReg->objects[index];
 					AString * newname = pToken->getlegal();
 					SAFE_DELETE(pToken);
 					if (newname) {

--- a/events.cpp
+++ b/events.cpp
@@ -182,29 +182,18 @@ void populateForitifcationLandmark(std::vector<Landmark> &landmarks, ARegion *re
     int protect = 0;
     Object *building = NULL;
 
-    forlist (&reg->objects) {
-        auto obj = (Object *) elem;
+    for(const auto obj: reg->objects) {
         ObjectType& type = ObjectDefs[obj->type];
 
-		if (type.flags & ObjectType::GROUP) {
-			continue;
-		}
-
-		if (obj->IsFleet()) {
-			continue;
-		}
-
-        if (protect >= type.protect) {
-            continue;
-        }
+		if (type.flags & ObjectType::GROUP) continue;
+		if (obj->IsFleet()) continue;
+        if (protect >= type.protect) continue;
 
         protect = type.protect;
         building = obj;
     }
 
-    if (!building) {
-        return;
-    }
+    if (!building) return;
 
     std::string name = building->name->Str();
     std::string title = std::string(ObjectDefs[building->type].name) + " " + name;

--- a/faction.cpp
+++ b/faction.cpp
@@ -642,9 +642,8 @@ int Faction::CanCatch(ARegion *r, Unit *t)
 
 	int def = t->GetDefenseRiding();
 
-	forlist(&r->objects) {
-		Object *o = (Object *) elem;
-		for(auto u: o->units) {
+	for(const auto o : r->objects) {
+		for(const auto u: o->units) {
 			if (u == t && o->type != O_DUMMY) return 1;
 			if (u->faction == this && u->GetAttackRiding() >= def) return 1;
 		}
@@ -666,11 +665,10 @@ int Faction::CanSee(ARegion* r, Unit* u, int practice)
 	int retval = 0;
 	if (u->reveal == REVEAL_UNIT) retval = 1;
 	if (u->guard == GUARD_GUARD) retval = 1;
-	forlist((&r->objects)) {
-		Object* obj = (Object *) elem;
+	for(const auto obj : r->objects) {
 		int dummy = 0;
 		if (obj->type == O_DUMMY) dummy = 1;
-		for(auto temp: obj->units) {
+		for(const auto temp: obj->units) {
 			if (u == temp && dummy == 0) retval = 1;
 
 			// penalty of 2 to stealth if assassinating and 1 if stealing

--- a/fracas/map.cpp
+++ b/fracas/map.cpp
@@ -89,7 +89,7 @@ void ARegionList::CreateAbyssLevel(int level, char const *name)
 	o->type = O_BKEEP;
 	o->incomplete = 0;
 	o->inner = -1;
-	lair->objects.Add(o);
+	lair->objects.push_back(o);
 }
 
 
@@ -1080,7 +1080,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = temp->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(reg);
 	o->num = temp->buildingseq++;
@@ -1088,7 +1088,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	temp->objects.Add(o);
+	temp->objects.push_back(o);
 }
 
 void ARegionList::MakeShaftLinks(int levelFrom, int levelTo, int odds)

--- a/game.cpp
+++ b/game.cpp
@@ -93,9 +93,8 @@ void Game::DefaultWorkOrder()
 	forlist(&regions) {
 		ARegion *r = (ARegion *) elem;
 		if (r->type == R_NEXUS) continue;
-		forlist(&r->objects) {
-			Object *o = (Object *) elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				if (u->monthorders || u->faction->is_npc ||
 						(Globals->TAX_PILLAGE_MONTH_LONG &&
 						 u->taxing != TAX_NONE))
@@ -126,8 +125,7 @@ AString Game::GetXtraMap(ARegion *reg,int type)
 			i = reg->CountWMons();
 			return (i ? ((AString) i) : (AString(" ")));
 		case 2:
-			forlist(&reg->objects) {
-				Object *o = (Object *) elem;
+			for(const auto o : reg->objects) {
 				if (!(ObjectDefs[o->type].flags & ObjectType::CANENTER)) {
 					if (o->units.size() > 0) {
 						return "*";
@@ -283,8 +281,7 @@ int Game::ViewMap(const AString & typestr,const AString & mapfile)
 			if (pArr->levelType == ARegionArray::LEVEL_NEXUS) {
 				if (!Globals->START_CITIES_EXIST) {
 					ARegion *nexus = pArr->GetRegion(0, 0);
-					forlist(&nexus->objects) {
-						Object *o = (Object *) elem;
+					for(const auto o : nexus->objects) {
 						if (o->inner != -1) {
 							start_regions.push_back(regions.GetRegion(o->inner));
 						}
@@ -771,9 +768,8 @@ Unit *Game::ParseGMUnit(AString *tag, Faction *pFac)
 		int gma = p.value();
 		forlist(&regions) {
 			ARegion *reg = (ARegion *)elem;
-			forlist(&reg->objects) {
-				Object *obj = (Object *)elem;
-				for(auto u: obj->units) {
+			for(const auto obj : reg->objects) {
+				for(const auto u: obj->units) {
 					if (u->faction->num == pFac->num && u->gm_alias == gma) {
 						return u;
 					}
@@ -1175,9 +1171,8 @@ void Game::ClearOrders(Faction *f)
 {
 	forlist(&regions) {
 		ARegion *r = (ARegion *) elem;
-		forlist(&r->objects) {
-			Object *o = (Object *) elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				if (u->faction == f) {
 					u->ClearOrders();
 				}
@@ -1211,23 +1206,17 @@ void Game::MakeFactionReportLists()
 		fill(facs.begin(), facs.end(), nullptr);
 
 		ARegion *reg = (ARegion *) elem;
-		forlist(&reg->farsees) {
-			Faction *fac = ((Farsight *) elem)->faction;
+		for(const auto far : reg->farsees) {
+			Faction *fac = far->faction;
 			facs[fac->num] = fac;
 		}
-		{
-			forlist(&reg->passers) {
-				Faction *fac = ((Farsight *)elem)->faction;
-				facs[fac->num] = fac;
-			}
+		for(const auto pass: reg->passers) {
+			Faction *fac = pass->faction;
+			facs[fac->num] = fac;
 		}
-		{
-			forlist(&reg->objects) {
-				Object *obj = (Object *) elem;
-
-				for(auto unit: obj->units) {
-					facs[unit->faction->num] = unit->faction;
-				}
+		for(const auto obj : reg->objects) {
+			for(const auto unit: obj->units) {
+				facs[unit->faction->num] = unit->faction;
 			}
 		}
 
@@ -1308,9 +1297,9 @@ void Game::DeleteDeadFactions()
 		if (!((*it)->is_npc) && !((*it)->exists)) {
 			deadFactionIds.insert((*it)->num);
 			it = factions.erase(it);
-		} else {
-			++it;
+			continue;
 		}
+		++it;
 	}
 
 	// Make sure all other factions remove attitudes towards dead factions
@@ -1354,9 +1343,8 @@ void Game::SetupUnitSeq()
 	int max = 0;
 	forlist(&regions) {
 		ARegion *r = (ARegion *)elem;
-		forlist(&r->objects) {
-			Object *o = (Object *)elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				if (u && u->num > max) max = u->num;
 			}
 		}
@@ -1379,9 +1367,8 @@ void Game::SetupUnitNums()
 
 	forlist(&regions) {
 		ARegion *r = (ARegion *) elem;
-		forlist(&r->objects) {
-			Object *o = (Object *) elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				i = u->num;
 				if ((i > 0) && (i < maxppunits)) {
 					if (!ppUnits[i])
@@ -1449,9 +1436,8 @@ void Game::CountAllSpecialists()
 	}
 	forlist(&regions) {
 		ARegion *r = (ARegion *) elem;
-		forlist(&r->objects) {
-			Object *o = (Object *) elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				if (u->type == U_MAGE) u->faction->nummages++;
 				if (u->GetSkill(S_QUARTERMASTER)) u->faction->numqms++;
 				if (u->GetSkill(S_TACTICS) == 5) u->faction->numtacts++;
@@ -1504,9 +1490,8 @@ int Game::CountMages(Faction *pFac)
 	int i = 0;
 	forlist(&regions) {
 		ARegion *r = (ARegion *) elem;
-		forlist(&r->objects) {
-			Object *o = (Object *) elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				if (u->faction == pFac && u->type == U_MAGE) i++;
 			}
 		}
@@ -1519,9 +1504,8 @@ int Game::CountQuarterMasters(Faction *pFac)
 	int i = 0;
 	forlist(&regions) {
 		ARegion *r = (ARegion *)elem;
-		forlist(&r->objects) {
-			Object *o = (Object *)elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				if (u->faction == pFac && u->GetSkill(S_QUARTERMASTER)) i++;
 			}
 		}
@@ -1534,9 +1518,8 @@ int Game::CountTacticians(Faction *pFac)
 	int i = 0;
 	forlist(&regions) {
 		ARegion *r = (ARegion *)elem;
-		forlist(&r->objects) {
-			Object *o = (Object *)elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				if (u->faction == pFac && u->GetSkill(S_TACTICS) == 5) i++;
 			}
 		}
@@ -1549,8 +1532,7 @@ int Game::CountApprentices(Faction *pFac)
 	int i = 0;
 	forlist(&regions) {
 		ARegion *r = (ARegion *)elem;
-		forlist(&r->objects) {
-			Object *o = (Object *)elem;
+		for(const auto o : r->objects) {
 			for(auto u: o->units) {
 				if (u->faction == pFac && u->type == U_APPRENTICE) i++;
 			}
@@ -1987,9 +1969,8 @@ void Game::AdjustCityMons(ARegion *r)
 {
 	int needguard = 1;
 	int needmage = 1;
-	forlist(&r->objects) {
-		Object *o = (Object *) elem;
-		for(auto u: o->units) {
+	for(const auto o : r->objects) {
+		for(const auto u: o->units) {
 			if (u->type == U_GUARD || u->type == U_GUARDMAGE) {
 				AdjustCityMon(r, u);
 				/* Don't create new city guards if we have some */
@@ -2140,10 +2121,9 @@ int Game::CountItem(const Faction *fac, int item)
 	if (ItemDefs[item].type & IT_SHIP) return 0;
 
 	size_t all = 0;
-	for (const auto& r : fac->present_regions) {
-		forlist(&r->objects) {
-			Object * obj = (Object *) elem;
-			for(auto unit: obj->units) {
+	for (const auto r : fac->present_regions) {
+		for(const auto obj : r->objects) {
+			for(const auto unit: obj->units) {
 				if (unit->faction == fac)
 					all += unit->items.GetNum(item);
 			}

--- a/game.h
+++ b/game.h
@@ -525,7 +525,7 @@ private:
 	void DoAutoAttacks();
 	void DoAdvanceAttack(ARegion *, Unit *);
 	void DoAutoAttack(ARegion *, Unit *);
-	void DoMovementAttacks(AList *);
+	void DoMovementAttacks(std::vector<Location *>& locs);
 	void DoMovementAttack(ARegion *, Unit *);
 	void DoAutoAttackOn(ARegion *, Unit *);
 	void RemoveEmptyObjects();
@@ -610,12 +610,14 @@ private:
 	int KillDead(Location *, Battle *, int, int);
 	int RunBattle(ARegion *r, Unit *attacker, Unit *target, bool ass = false, bool adv = false);
 	void GetSides(
-		ARegion *r, std::set<Faction *> afacs, std::set<Faction *> dfacs, AList& atts,
-		AList& defs, Unit *att, Unit *tar, bool ass = false, bool adv = false
+		ARegion *r, std::set<Faction *> afacs, std::set<Faction *> dfacs,
+		std::vector<Location *>& atts,
+		std::vector<Location *>& defs, Unit *att, Unit *tar, bool ass = false, bool adv = false
 	);
 	bool CanAttack(ARegion *r, std::set<Faction *> afacs, Unit *u);
 	void GetAFacs(
-		ARegion *r, Unit *att, Unit *tar, std::set<Faction *>& dfacs, std::set<Faction *>& afacs, AList &atts
+		ARegion *r, Unit *att, Unit *tar, std::set<Faction *>& dfacs,
+		std::set<Faction *>& afacs, std::vector<Location *> &atts
 	);
 	void GetDFacs(ARegion *r, Unit *t, std::set<Faction *>& facs);
 

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -111,7 +111,6 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 {
 	int d, count, temple, i, j, clash;
 	ARegion *r;
-	Object *o;
 	AString rname;
 	map <string, int> temples;
 	map <string, int>::iterator it;
@@ -139,9 +138,8 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				continue;
 			if (!r->visited)
 				continue;
-			forlist(&r->objects) {
-				o = (Object *) elem;
-				for(auto u: o->units) {
+			for(const auto o : r->objects) {
+				for(const auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						count++;
 					}
@@ -158,13 +156,11 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				continue;
 			if (!r->visited)
 				continue;
-			forlist(&r->objects) {
-				o = (Object *) elem;
-				for(auto u: o->units) {
+			for(const auto o : r->objects) {
+				for(const auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						if (!d--) {
 							q->target = u->num;
-
 						}
 					}
 				}
@@ -234,8 +230,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				// This looks like a null operation, but
 				// actually forces the map<> element creation
 				temples[stlstr];
-				forlist(&r->objects) {
-					o = (Object *) elem;
+				for(const auto o : r->objects) {
 					if (o->type == temple) {
 						temples[stlstr]++;
 					}
@@ -368,9 +363,8 @@ Faction *Game::CheckVictory()
 				uvRegions[stlstr]++;
 			}
 		}
-		forlist(&r->objects) {
-			o = (Object *) elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				intersection.clear();
 				set_intersection(u->visited.begin(),
 					u->visited.end(),
@@ -569,9 +563,8 @@ Faction *Game::CheckVictory()
 		reliccount = 0;
 		forlist(&regions) {
 			r = (ARegion *) elem;
-			forlist(&r->objects) {
-				o = (Object *) elem;
-				for(auto u: o->units) {
+			for(const auto o : r->objects) {
+				for(const auto u: o->units) {
 					if (u->faction == f.get()) {
 						reliccount += u->items.GetNum(I_RELICOFGRACE);
 					}
@@ -591,12 +584,11 @@ Faction *Game::CheckVictory()
 			magiclevels = 0;
 			forlist(&regions) {
 				r = (ARegion *) elem;
-				forlist(&r->objects) {
-					o = (Object *) elem;
+				for(const auto o : r->objects) {
 					// To avoid invalidating the iterator, we'll collect the units that would get removed
 					// and then remove them at the end.
 					std::vector<Unit *> unitsToErase;
-					for(auto u: o->units) {
+					for(const auto u: o->units) {
 						if (u->faction == f.get()) {
 							units++;
 							for(auto item: u->items) {
@@ -764,8 +756,7 @@ Faction *Game::CheckVictory()
 
 	forlist_reuse(&regions) {
 		r = (ARegion *) elem;
-		forlist(&r->objects) {
-			o = (Object *) elem;
+		for(const auto o : r->objects) {
 			if (o->type == O_BKEEP) {
 				if (!o->incomplete) {
 					// You didn't think this was a

--- a/havilah/map.cpp
+++ b/havilah/map.cpp
@@ -89,7 +89,7 @@ void ARegionList::CreateAbyssLevel(int level, char const *name)
 	o->type = O_BKEEP;
 	o->incomplete = 0;
 	o->inner = -1;
-	lair->objects.Add(o);
+	lair->objects.push_back(o);
 }
 
 
@@ -1088,7 +1088,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = temp->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(temp);
 	o->num = temp->buildingseq++;
@@ -1096,7 +1096,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	temp->objects.Add(o);
+	temp->objects.push_back(o);
 }
 
 void ARegionList::MakeShaftLinks(int levelFrom, int levelTo, int odds)
@@ -1160,7 +1160,7 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 								o->type = O_GATEWAY;
 								o->incomplete = 0;
 								o->inner = reg->num;
-								AC->objects.Add(o);
+								AC->objects.push_back(o);
 							}
 						}
 				}
@@ -1305,7 +1305,7 @@ void ARegionList::FixUnconnectedRegions()
 						o->type = O_SHAFT;
 						o->incomplete = 0;
 						o->inner = r->num;
-						n->objects.Add(o);
+						n->objects.push_back(o);
 
 						o = new Object(r);
 						o->num = r->buildingseq++;
@@ -1313,7 +1313,7 @@ void ARegionList::FixUnconnectedRegions()
 						o->type = O_SHAFT;
 						o->incomplete = 0;
 						o->inner = n->num;
-						r->objects.Add(o);
+						r->objects.push_back(o);
 					}
 				}
 				if (!n) {

--- a/items.h
+++ b/items.h
@@ -29,7 +29,6 @@ class Item;
 class ItemType;
 
 #include "gamedefs.h"
-#include "alist.h"
 #include "astring.h"
 #include <vector>
 #include <string>

--- a/kingdoms/map.cpp
+++ b/kingdoms/map.cpp
@@ -229,7 +229,7 @@ void ARegionList::CreateAbyssLevel(int level, char const *name)
 	o->type = O_BKEEP;
 	o->incomplete = 0;
 	o->inner = -1;
-	lair->objects.Add(o);
+	lair->objects.push_back(o);
 }
 
 
@@ -1515,7 +1515,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = temp->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(reg);
 	o->num = temp->buildingseq++;
@@ -1523,7 +1523,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	temp->objects.Add(o);
+	temp->objects.push_back(o);
 }
 
 void ARegionList::MakeShaftLinks(int levelFrom, int levelTo, int odds)

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -59,8 +59,7 @@ int Game::SetupFaction( Faction *pFac )
 		ARegionArray *underworld = regions.GetRegionArray(ARegionArray::LEVEL_UNDERWORLD);
 		ARegion *center = underworld->GetRegion(underworld->x / 2, underworld->y / 2);
 		// See if the monolith is active and owned.
-		forlist(&center->objects) {
-			Object *o = (Object *)elem;
+		for(const auto o : center->objects) {
 			if (o->type != O_ACTIVE_MONOLITH) continue;
 			if (o->GetOwner() != nullptr) {
 				return 0;
@@ -146,7 +145,6 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 {
 	int d, count, temple, i, j, clash, reward_count;
 	ARegion *r;
-	Object *o;
 	AString rname;
 	map <string, int> temples;
 	map <string, int>::iterator it;
@@ -217,9 +215,8 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 			// No need to check if quests do not require exploration
 			if (!r->visited && QUEST_EXPLORATION_PERCENT != 0)
 				continue;
-			forlist(&r->objects) {
-				o = (Object *) elem;
-				for(auto u: o->units) {
+			for(const auto o : r->objects) {
+				for(const auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						count++;
 					}
@@ -237,9 +234,8 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 			// No need to check if quests do not require exploration
 			if (!r->visited && QUEST_EXPLORATION_PERCENT != 0)
 				continue;
-			forlist(&r->objects) {
-				o = (Object *) elem;
-				for(auto u: o->units) {
+			for(const auto o : r->objects) {
+				for(const auto u: o->units) {
 					if (u->faction->num == monfaction) {
 						if (!d--) {
 							q->target = u->num;
@@ -315,8 +311,7 @@ static void CreateQuest(ARegionList *regions, int monfaction)
 				// This looks like a null operation, but
 				// actually forces the map<> element creation
 				temples[stlstr];
-				forlist(&r->objects) {
-					o = (Object *) elem;
+				for(const auto o : r->objects) {
 					if (o->type == temple) {
 						temples[stlstr]++;
 					}
@@ -416,8 +411,7 @@ int report_and_count_anomalies(ARegionList *regions, const std::vector<std::uniq
 	int count = 0;
 	forlist(regions) {
 		ARegion *r = (ARegion *)elem;
-		forlist(&r->objects) {
-			Object *o = (Object *)elem;
+		for(const auto o : r->objects) {
 			if (o->type == O_ENTITY_CAGE) {
 				count++;
 				for(const auto& f : factions) {
@@ -435,12 +429,11 @@ int count_entities(ARegionList *regions) {
 	int count = 0;
 	forlist(regions) {
 		ARegion *r = (ARegion *)elem;
-		forlist(&r->objects) {
-			Object *o = (Object *)elem;
+		for(const auto o : r->objects) {
 			if (o->type == O_EMPOWERED_ALTAR) {
 				count++;
 			}
-			for(auto u: o->units) {
+			for(const auto u: o->units) {
 				if (u->items.GetNum(I_IMPRISONED_ENTITY) > 0) {
 					count += u->items.GetNum(I_IMPRISONED_ENTITY);
 				}
@@ -488,9 +481,8 @@ Faction *Game::CheckVictory()
 				uvRegions[stlstr]++;
 			}
 		}
-		forlist(&r->objects) {
-			o = (Object *) elem;
-			for(auto u: o->units) {
+		for(const auto o : r->objects) {
+			for(const auto u: o->units) {
 				intersection.clear();
 				set_intersection(u->visited.begin(),
 					u->visited.end(),
@@ -882,8 +874,7 @@ Faction *Game::CheckVictory()
 						continue;
 					}
 					// Make sure it doesn't already have an anomaly
-					forlist(&r->objects) {
-						Object *o = (Object *)elem;
+					for(const auto o : r->objects) {
 						if (o->type == O_ENTITY_CAGE) {
 							r = nullptr;
 							break;
@@ -901,7 +892,7 @@ Faction *Game::CheckVictory()
 				if (ob.flags & ObjectType::SACRIFICE) {
 					o->incomplete = -(ob.sacrifice_amount);
 				}
-				r->objects.Add(o);
+				r->objects.push_back(o);
 				// Now tell all the factions about it.
 				for(const auto& f : factions) {
 					if (f->is_npc) continue;
@@ -923,8 +914,7 @@ Faction *Game::CheckVictory()
 		// FInd the owner of the monolith.
 		ARegionArray *underworld = regions.GetRegionArray(ARegionArray::LEVEL_UNDERWORLD);
 		ARegion *center = underworld->GetRegion(underworld->x / 2, underworld->y / 2);
-		forlist(&center->objects) {
-			Object *o = (Object *)elem;
+		for(const auto o : center->objects) {
 			if (o->type == O_ACTIVE_MONOLITH) {
 				Unit *owner = o->GetOwner();
 				// If noone owns the monolith, then noone can win.
@@ -1488,8 +1478,7 @@ const char *ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin, ARe
 		for (int i = 0; i < 6; i++) {
 			ARegion *r = surface_center->neighbors[i];
 			// search that region for an altar
-			forlist(&r->objects) {
-				Object *o = (Object *)elem;
+			for(const auto o : r->objects) {
 				if (o->type == O_EMPOWERED_ALTAR) {
 					count++;
 				}

--- a/neworigins/map.cpp
+++ b/neworigins/map.cpp
@@ -1689,7 +1689,7 @@ void ARegionList::CreateAbyssLevel(int level, char const *name)
 	o->type = O_BKEEP;
 	o->incomplete = 0;
 	o->inner = -1;
-	lair->objects.Add(o);
+	lair->objects.push_back(o);
 }
 
 
@@ -1887,7 +1887,7 @@ void ARegionList::CreateIslandRingLevel(int level, int xSize, int ySize, char co
 			o->name = new AString(altar_name);
 			o->type = O_RITUAL_ALTAR;
 			o->incomplete = -(ObjectDefs[O_RITUAL_ALTAR].sacrifice_amount);
-			n->objects.Add(o);
+			n->objects.push_back(o);
 		}
 	}
 	FinalSetup(pRegionArrays[level]);
@@ -1939,7 +1939,7 @@ void ARegionList::CreateUnderworldRingLevel(int level, int xSize, int ySize, cha
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = center->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(center);
 	o->num = center->buildingseq++;
@@ -1947,7 +1947,7 @@ void ARegionList::CreateUnderworldRingLevel(int level, int xSize, int ySize, cha
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	center->objects.Add(o);
+	center->objects.push_back(o);
 
 	// Put the monolith in the underworld center
 	o = new Object(reg);
@@ -1956,7 +1956,7 @@ void ARegionList::CreateUnderworldRingLevel(int level, int xSize, int ySize, cha
 	o->name = new AString(monolith_name);
 	o->type = O_DORMANT_MONOLITH;
 	o->incomplete = -(ObjectDefs[O_DORMANT_MONOLITH].sacrifice_amount);
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	FinalSetup(pRegionArrays[level]);
 
@@ -2921,7 +2921,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom, ARegionArray *pTo
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = temp->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(temp);
 	o->num = temp->buildingseq++;
@@ -2929,7 +2929,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom, ARegionArray *pTo
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	temp->objects.Add(o);
+	temp->objects.push_back(o);
 }
 
 void ARegionList::MakeShaftLinks(int levelFrom, int levelTo, int odds)
@@ -3036,7 +3036,7 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 					o->type = O_GATEWAY;
 					o->incomplete = 0;
 					o->inner = dests[type]->num;
-					AC->objects.Add(o);
+					AC->objects.push_back(o);
 				}
 			}
 		}
@@ -3180,7 +3180,7 @@ void ARegionList::FixUnconnectedRegions()
 						o->type = O_SHAFT;
 						o->incomplete = 0;
 						o->inner = r->num;
-						n->objects.Add(o);
+						n->objects.push_back(o);
 
 						o = new Object(r);
 						o->num = r->buildingseq++;
@@ -3188,7 +3188,7 @@ void ARegionList::FixUnconnectedRegions()
 						o->type = O_SHAFT;
 						o->incomplete = 0;
 						o->inner = n->num;
-						r->objects.Add(o);
+						r->objects.push_back(o);
 					}
 				}
 				if (!n) {

--- a/npc.cpp
+++ b/npc.cpp
@@ -147,8 +147,7 @@ void Game::GrowLMons(int rate)
 		//
 		if (r->IsGuarded()) continue;
 
-		forlist(&r->objects) {
-			Object *obj = (Object *) elem;
+		for(const auto obj : r->objects) {
 			if (obj->units.size()) continue;
 			int montype = ObjectDefs[obj->type].monster;
 			int grow=!(ObjectDefs[obj->type].flags&ObjectType::NOMONSTERGROWTH);

--- a/object.cpp
+++ b/object.cpp
@@ -391,9 +391,9 @@ void Object::SetPrevDir(int newdir)
 
 void Object::MoveObject(ARegion *toreg)
 {
-	region->objects.Remove(this);
+	std::erase(region->objects, this);
 	region = toreg;
-	toreg->objects.Add(this);
+	toreg->objects.push_back(this);
 }
 
 int Object::IsRoad()

--- a/object.h
+++ b/object.h
@@ -28,7 +28,6 @@
 
 class Object;
 
-#include "alist.h"
 #include "gamedefs.h"
 #include "faction.h"
 #include "items.h"
@@ -106,7 +105,7 @@ struct ShowObject {
 	int obj;
 };
 
-class Object : public AListElem
+class Object
 {
 	public:
 		Object(ARegion *region);

--- a/quests.cpp
+++ b/quests.cpp
@@ -241,8 +241,7 @@ int QuestList::check_visit_target(ARegion *r, Unit *u, std::string *quest_reward
 	for(auto q: quests) {
 		if (q->type != Quest::VISIT) continue;
 		if (!q->destinations.count(r->name->Str())) continue;
-		forlist(&r->objects) {
-			Object *o = (Object *) elem;
+		for(const auto o : r->objects) {
 			if (o->type == q->building) {
 				u->visited.insert(r->name->Str());
 				intersection.clear();

--- a/quests.h
+++ b/quests.h
@@ -26,7 +26,6 @@
 #ifndef QUEST_CLASS
 #define QUEST_CLASS
 
-#include "alist.h"
 #include "astring.h"
 #include "unit.h"
 #include "items.h"

--- a/standard/extra.cpp
+++ b/standard/extra.cpp
@@ -99,27 +99,18 @@ Faction *Game::CheckVictory()
 {
 	forlist(&regions) {
 		ARegion *region = (ARegion *)elem;
-		forlist(&region->objects) {
-			Object *obj = (Object *)elem;
-			if (obj->type != O_BKEEP){
-				continue;
-			}
-			if (obj->units.size()){
-				return NULL;
-			}
+		for(const auto obj : region->objects) {
+			if (obj->type != O_BKEEP) continue;
+			if (obj->units.size()) return nullptr;
 			// Now see find the first faction guarding the region
-			forlist(&region->objects) {
-				Object *o = region->GetDummy();
-				for(auto u: o->units) {
-					if (u->guard == GUARD_GUARD){
-						return u->faction;
-					}
-				}
+			Object *o = region->GetDummy();
+			for(const auto u: o->units) {
+				if (u->guard == GUARD_GUARD) return u->faction;
 			}
 			break;
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 void Game::ModifyTablesPerRuleset(void)

--- a/standard/map.cpp
+++ b/standard/map.cpp
@@ -89,7 +89,7 @@ void ARegionList::CreateAbyssLevel(int level, char const *name)
 	o->type = O_BKEEP;
 	o->incomplete = 0;
 	o->inner = -1;
-	lair->objects.Add(o);
+	lair->objects.push_back(o);
 }
 
 
@@ -1067,7 +1067,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = temp->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(reg);
 	o->num = temp->buildingseq++;
@@ -1075,7 +1075,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom,
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	temp->objects.Add(o);
+	temp->objects.push_back(o);
 }
 
 void ARegionList::MakeShaftLinks(int levelFrom, int levelTo, int odds)
@@ -1139,7 +1139,7 @@ void ARegionList::SetACNeighbors(int levelSrc, int levelTo, int maxX, int maxY)
 								o->type = O_GATEWAY;
 								o->incomplete = 0;
 								o->inner = reg->num;
-								AC->objects.Add(o);
+								AC->objects.push_back(o);
 							}
 						}
 				}

--- a/standard/monsters.cpp
+++ b/standard/monsters.cpp
@@ -36,8 +36,7 @@ void Game::CreateVMons()
 
 	forlist(&regions) {
 		ARegion * r = (ARegion *) elem;
-		forlist(&r->objects) {
-			Object * obj = (Object *) elem;
+		for(const auto obj : r->objects) {
 			if (obj->type != O_BKEEP) continue;
 			Faction *monfac = get_faction(factions, 2);
 			Unit *u = GetNewUnit( monfac, 0 );
@@ -53,10 +52,9 @@ void Game::GrowVMons()
 
 	forlist(&regions) {
 		ARegion *r = (ARegion *)elem;
-		forlist(&r->objects) {
-			Object *obj = (Object *)elem;
+		for(const auto obj : r->objects) {
 			if (obj->type != O_BKEEP) continue;
-			for(auto u: obj->units) {
+			for(const auto u: obj->units) {
 				int men = u->GetMen(I_BALROG) + 2;
 				if (men > 200) men = 200;
 				u->items.SetNum(I_BALROG, men);

--- a/unit.cpp
+++ b/unit.cpp
@@ -1077,11 +1077,9 @@ int Unit::GetSharedNum(int item)
 	if (ItemDefs[item].type & IT_MAN)
 		return items.GetNum(item);
 
-	forlist((&object->region->objects)) {
-		Object *obj = (Object *) elem;
-		for(auto u: obj->units) {
-			if ((u->num == num) ||
-			(u->faction == faction && u->GetFlag(FLAG_SHARING)))
+	for(const auto obj : object->region->objects) {
+		for(const auto u: obj->units) {
+			if ((u->num == num) || (u->faction == faction && u->GetFlag(FLAG_SHARING)))
 				count += u->items.GetNum(item);
 		}
 	}
@@ -1100,9 +1098,8 @@ void Unit::ConsumeShared(int item, int needed)
 	if (needed == 0) return;
 
 	// We still need more, so look for whomever is able to share with us
-	forlist((&object->region->objects)) {
-		Object *obj = (Object *) elem;
-		for(auto u: obj->units) {
+	for(const auto obj : object->region->objects) {
+		for(const auto u: obj->units) {
 			if (u->faction == faction && u->GetFlag(FLAG_SHARING)) {
 				amount = u->items.GetNum(item);
 				if (amount < 1) continue;

--- a/unit.h
+++ b/unit.h
@@ -40,7 +40,6 @@ class Unit;
 class UnitId;
 
 #include "faction.h"
-#include "alist.h"
 #include "gameio.h"
 #include "orders.h"
 #include "skills.h"
@@ -112,6 +111,10 @@ class UnitId {
 		int unitnum; /* if 0, it is a new unit */
 		int alias;
 		int faction;
+
+		inline bool operator==(const UnitId& other) const {
+			return (this->unitnum == other.unitnum && this->alias == other.alias && this->faction == other.faction);
+		}
 };
 
 class Unit

--- a/unittest/map.cpp
+++ b/unittest/map.cpp
@@ -81,9 +81,9 @@ void ARegionList::MakeRegions(int level, int xSize, int ySize)
 				// Some initial values; these will get reset
 				//
 				reg->type = -1;
-				reg->race = -1;  
-				reg->wages = -1; 
-				
+				reg->race = -1;
+				reg->wages = -1;
+
 				reg->level = arr;
 				Add(reg);
 				arr->SetRegion(x, y, reg);
@@ -183,7 +183,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom, ARegionArray *pTo
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = toReg->num;
-	reg->objects.Add(o);
+	reg->objects.push_back(o);
 
 	o = new Object(toReg);
 	o->num = toReg->buildingseq++;
@@ -191,7 +191,7 @@ void ARegionList::MakeShaft(ARegion *reg, ARegionArray *pFrom, ARegionArray *pTo
 	o->type = O_SHAFT;
 	o->incomplete = 0;
 	o->inner = reg->num;
-	toReg->objects.Add(o);
+	toReg->objects.push_back(o);
 }
 
 void ARegionList::MakeShaftLinks(int levelFrom, int levelTo, int odds) {

--- a/unittest/n07_victory_test.cpp
+++ b/unittest/n07_victory_test.cpp
@@ -511,7 +511,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.run_annihilation();
 
     expect(faction->errors.size() == 0_ul);
-    expect(faction->events.size() == 6_ul);
+    expect(faction->events.size() == 5_ul);
 
     helper.setup_reports();
 
@@ -522,7 +522,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
 
     // Validate we get the messages we expect for the faction
     json events = json_report["events"];
-    expect(events.size() == 6_ul);
+    expect(events.size() == 5_ul);
     json event = events[0];
     expect(event["message"] == "Walks from plain (0,0) in Testing Wilds to barren (1,1) in Testing Wilds.");
     expect(event["unit"]["number"] == 2_i);
@@ -530,18 +530,15 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     expect(event["message"] == "Enters Building [1].");
     expect(event["unit"]["number"] == 2_i);
     event = events[2];
-    expect(event["message"] == "plain (0,0) in Testing Wilds, contains Basictown [city] has been utterly annihilated.");
+    expect(event["message"] == "forest (0,2) in Testing Wilds has been utterly annihilated.");
     expect(event["category"] == "annihilate");
     event = events[3];
+    expect(event["message"] == "plain (0,0) in Testing Wilds, contains Basictown [city] has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[4];
     expect(event["message"] == "Is annihilated.");
     expect(event["category"] == "annihilate");
     expect(event["unit"]["number"] == 3_i);
-    event = events[4];
-    expect(event["message"] == "forest (0,2) in Testing Wilds has been utterly annihilated.");
-    expect(event["category"] == "annihilate");
-    event = events[5];
-    expect(event["message"] == "desert (1,3) in Testing Wilds has been utterly annihilated.");
-    expect(event["category"] == "annihilate");
 
     // load the gm faction report
     json gm_report;

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -78,7 +78,7 @@ void UnitTestHelper::create_building(ARegion *region, Unit *owner, int building_
     obj->num = region->buildingseq++;
     std::string name = "Building [" + std::to_string(obj->num) + "]";
     obj->name = new AString(name);
-    region->objects.Add(obj);
+    region->objects.push_back(obj);
     ObjectType ob = ObjectDefs[building_type];
     if (ob.flags & ObjectType::SACRIFICE) {
         // set up the items sacrifice needed


### PR DESCRIPTION
This makes Object no longer a child of AListElem and thus no longer using AList.  It also removes this from a couple of other classes (Location and Farsight) which were trivial.

As part of this, discovered some bugs in handling of other AList removals which would have crashed in the future (unit moves while iterating the lists was a big one).