### PR TITLE
Update NO7 victory conditions to avoid delay of game tactics

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -2552,6 +2552,15 @@ ARegionArray *ARegionList::GetRegionArray(int level)
 	return(pRegionArrays[level]);
 }
 
+ARegionArray *ARegionList::get_first_region_array_of_type(int levelType) {
+	for (int i = 0; i < numLevels; i++) {
+		if (pRegionArrays[i]->levelType == levelType) {
+			return pRegionArrays[i];
+		}
+	}
+	return nullptr;
+}
+
 void ARegionList::CreateLevels(int n)
 {
 	numLevels = n;
@@ -4137,4 +4146,16 @@ int ARegionList::FindDistanceToNearestObject(int object_type, ARegion *start)
 		if (dist < min_dist) min_dist = dist;
 	}
 	return min_dist;
+}
+
+int ARegionList::find_distance_between_regions(ARegion *start, ARegion *end)
+{
+	if (start->zloc != end->zloc) {
+		return -1; // not on the same level
+	}
+
+	int w = start->level->x;
+	graphs::Location2D a = { start->xloc, start->yloc };
+	graphs::Location2D b = { end->xloc, end->yloc };
+	return cylDistance(a, b, w);
 }

--- a/aregion.h
+++ b/aregion.h
@@ -186,7 +186,7 @@ class ARegion : public AListElem
 		ARegion();
 		//ARegion(int, int);
 		~ARegion();
-		
+
 		void Setup();
 		void ManualSetup(const RegionSetup& settings);
 
@@ -317,7 +317,7 @@ class ARegion : public AListElem
 		int wages;
 		int maxwages;
 		int wealth;
-		
+
 		/* Economy */
 		int habitat;
 		int development;
@@ -335,7 +335,7 @@ class ARegion : public AListElem
 		int emigrants;
 		// economic improvement
 		int improvement;
-		
+
 		/* Potential bonuses to economy */
 		int clearskies;
 		int earthlore;
@@ -446,10 +446,10 @@ class GeoMap
 		int GetVegetation(int, int);
 		int GetCulture(int, int);
 		void ApplyGeography(ARegionArray *pArr);
-		
+
 		int size, xscale, yscale, xoff, yoff;
 		map<long int,Geography> geomap;
-		
+
 };
 
 class ARegionList : public AList
@@ -475,6 +475,7 @@ class ARegionList : public AList
 		int GetWeather(ARegion *pReg, int month);
 
 		ARegionArray *GetRegionArray(int level);
+		ARegionArray *get_first_region_array_of_type(int type);
 
 		int numberofgates;
 		int numLevels;
@@ -500,6 +501,7 @@ class ARegionList : public AList
 		ARegion *FindConnectedRegions(ARegion *r, ARegion *tail, int shaft);
 		ARegion *FindNearestStartingCity(ARegion *r, int *dir);
 		int FindDistanceToNearestObject(int object, ARegion *r);
+		int find_distance_between_regions(ARegion *start, ARegion *target);
 		void FixUnconnectedRegions();
 		void InitSetupGates(int level);
 		void FinalSetupGates();
@@ -515,7 +517,7 @@ class ARegionList : public AList
 		void UnsetRace(ARegionArray *pRegs);
 		void RaceAnchors(ARegionArray *pRegs);
 		void GrowRaces(ARegionArray *pRegs);
-		
+
 		void TownStatistics();
 		void ResourcesStatistics();
 

--- a/game.cpp
+++ b/game.cpp
@@ -53,6 +53,7 @@ Game::Game()
 	ppUnits = 0;
 	maxppunits = 0;
 	events = new Events();
+	rulesetSpecificData = json::object();
 
 	if (Globals->FACTION_ACTIVITY == FactionActivityRules::DEFAULT)
 	{
@@ -384,14 +385,14 @@ int Game::NewGame()
 
 	if (Globals->LAIR_MONSTERS_EXIST)
 		CreateVMons();
-	
-	/*	
+
+	/*
 	if (Globals->PLAYER_ECONOMY) {
 		Equilibrate();
 	}
 	*/
-	
-	
+
+
 
 	return(1);
 }
@@ -577,7 +578,7 @@ int Game::WritePlayers()
 	f << "TurnNumber: " << TurnNumber() << "\n";
 	if (gameStatus == GAME_STATUS_UNINIT)
 		return(0);
-	
+
 	if (gameStatus == GAME_STATUS_NEW)
 		f << "GameStatus: New\n\n";
 	else if (gameStatus == GAME_STATUS_RUNNING)
@@ -1263,7 +1264,7 @@ void Game::WriteReport()
 	CountAllSpecialists();
 
 	size_t ** citems = nullptr;
-	
+
 	if (Globals->FACTION_STATISTICS) {
 		citems = new size_t * [factionseq];
 		for (int i = 0; i < factionseq; i++)
@@ -1677,7 +1678,7 @@ int Game::AllowedTrades(Faction *pFac)
 int Game::AllowedMartial(Faction *pFac)
 {
 	int points = pFac->type[F_MARTIAL];
-	
+
 	if (points < 0) points = 0;
 	if (points > allowedMartialSize - 1) points = allowedMartialSize - 1;
 
@@ -1960,17 +1961,17 @@ void Game::CreateCityMon(ARegion *pReg, int percent, int needmage)
 	Unit *u = GetNewUnit(pFac);
 	Unit *u2;
 	AString *s = new AString("City Guard");
-	
+
 	/*
 	Awrite(AString("Begin setting up city guard in..."));
-		
+
 	AString temp = TerrainDefs[pReg->type].name;
 	temp += AString(" (") + pReg->xloc + "," + pReg->yloc;
 	temp += ")";
 	temp += AString(" in ") + *pReg->name;
 	Awrite(temp);
 	*/
-	
+
 	if ((Globals->LEADERS_EXIST) || (pReg->type == R_NEXUS)) {
 		/* standard Leader-type guards */
 		u->SetMen(I_LEADERS,num);
@@ -2004,8 +2005,8 @@ void Game::CreateCityMon(ARegion *pReg, int percent, int needmage)
 		u2->type = U_GUARD;
 		u2->guard = GUARD_GUARD;
 		u2->reveal = REVEAL_FACTION;
-	}			
-	
+	}
+
 	if (AC) {
 		if (Globals->START_CITY_GUARDS_PLATE) {
 			if (Globals->LEADERS_EXIST) u->items.SetNum(I_PLATEARMOR, num);
@@ -2090,20 +2091,20 @@ void Game::AdjustCityMon(ARegion *r, Unit *u)
 		}
 		if ((ItemDefs[i].type & IT_ARMOR)
 			&& (num > maxarmor)) {
-			armor = i;	
+			armor = i;
 			maxarmor = num;
 		}
 	}
 	int skill = S_COMBAT;
-	
+
 	if (weapon != -1) {
 		WeaponType *wp = FindWeapon(ItemDefs[weapon].abr);
 		if (FindSkill(wp->baseSkill) == FindSkill("XBOW")) skill = S_CROSSBOW;
 		if (FindSkill(wp->baseSkill) == FindSkill("LBOW")) skill = S_LONGBOW;
 	}
-	
+
 	int sl = u->GetRealSkill(skill);
-		
+
 	if (r->type == R_NEXUS || r->IsStartingCity()) {
 		towntype = TOWN_CITY;
 		AC = 1;
@@ -2203,7 +2204,7 @@ void Game::CountItems(size_t ** citems)
 int Game::CountItem (Faction * fac, int item)
 {
 	if (ItemDefs[item].type & IT_SHIP) return 0;
-	
+
 	size_t all = 0;
 	for (const auto& r : fac->present_regions) {
 		forlist(&r->objects) {

--- a/game.h
+++ b/game.h
@@ -35,6 +35,12 @@ class Game;
 #include "object.h"
 #include "events.h"
 
+#include "external/nlohmann/json.hpp"
+using json = nlohmann::json;
+
+#include <map>
+#include <string>
+
 #define CURRENT_ATL_VER MAKE_ATL_VER(5, 2, 5)
 
 class OrdersCheck
@@ -305,10 +311,10 @@ private:
 	// For our existing case, these are going to be used by the unit test framework to ensure a consistent
 	// run (by overriding the seeding of the random number generator).  In general, there should be *very*
 	// few of these hooks and they should exist for a very explicit purpose and be used with extreme care.
-	
+
 	// control the random number seed used for new game generation (by default it uses the existing
 	// seedrandomrandom function) which uses the current time.
-	std::function<void()> init_random_seed = seedrandomrandom; 
+	std::function<void()> init_random_seed = seedrandomrandom;
 
 	enum
 	{
@@ -324,6 +330,11 @@ private:
 	int doExtraInit;
 
 	Events *events;
+
+	// We need some way to track game specific data that can be used globally
+	// (specifically added for testing of NO7 victory conditions, but generally
+	// useful).  I use json here so that it can store arbitrary data in a structured way.
+	json rulesetSpecificData;
 
 	//
 	// Parsing functions

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -461,7 +461,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 
 	f << enclose("ul", true);
 	f << enclose("li", true) << url("#intro", "Introduction") << '\n' << enclose("li", false);
-	
+
 	f << enclose("li", true);
 	f << url("#playing", "Playing Atlantis") << '\n';
 	f << enclose("ul", true);
@@ -1251,7 +1251,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			  << "as the magical entry into Atlantis.";
 
 		} else {
-			f << "inside of the normal world of Atlantis, but " 
+			f << "inside of the normal world of Atlantis, but "
 			  << (Globals->MULTI_HEX_NEXUS ? "each contains " : "contains ")
 			  << "a starting city with all its benefits"
 			  << (Globals->GATES_EXIST ? ", including a gate" : "") << ". "
@@ -1285,7 +1285,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			if (Globals->START_CITIES_START_UNLIMITED) {
 				f << (!Globals->SAFE_START_CITIES && Globals->CITY_MONSTERS_EXIST
 				      ? "until someone conquers the guardsmen, "
-				      : "") 
+				      : "")
 				  << "there are unlimited amounts of many materials and men (though the prices are often quite high).";
 			} else {
 				f << "there are materials as well as a very large supply of men (though the prices are often quite high).";
@@ -1591,7 +1591,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			f << enclose("td align=\"center\"", true) << ItemDefs[i].weight/50 << '\n'  << enclose("td", false);
 			f << enclose("td align=\"center\"", true) << slevel << '\n'  << enclose("td", false);
 			f << enclose("tr", false);
-		}					
+		}
 		for (int i = 0; i < NOBJECTS; i++) {
 			if (ObjectDefs[i].flags & ObjectType::DISABLED) continue;
 			if (!ObjectIsShip(i)) continue;
@@ -1835,8 +1835,8 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			rate = study_rate(days, 0);
 			days += rate;
 			months5++;
-		}		
-		mlevel = GetLevelByDays(days);	
+		}
+		mlevel = GetLevelByDays(days);
 
 		f << enclose("p", true);
 		f << "To illustrate this, a unit would have to spend " << num_to_word(months2)
@@ -1849,7 +1849,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			  << "skill level 3 by studying without experience. ";
 		}
 		f << "The maximum skill level that is possible through continuous study only (i.e. no experience "
-		  << "involved) is " << num_to_word(mlevel) + ", " 
+		  << "involved) is " << num_to_word(mlevel) + ", "
 		  << (months5 > 36 ? "although it is hardly feasible without any experience at all, " : "")
 		  << "taking " << num_to_word(months5) << " months of studying to achieve. "
 		  << "Note that this assumes that the unit type is allowed to achieve this level at all "
@@ -1906,7 +1906,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		int level = 0;
 		int plevel = 0;
 		int next = study_rate(days, 0);
-		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next 
+		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next
 		  << ")</font>\n" << enclose("td", false);
 		for (int m = 0; m < 9; m++) {
 			days += study_rate(days, 0);
@@ -1928,7 +1928,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		level = 0;
 		plevel = 0;
 		next = study_rate(days, 30);
-		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next 
+		f << enclose("td", true) << "&nbsp;" << level << "&nbsp;<font size='-1'>(" << days << "+" << next
 		  << ")</font>\n" << enclose("td", false);
 		for (int m = 0; m < 9; m++) {
 			days += study_rate(days, 30);
@@ -1984,7 +1984,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	// a table of all skills/costs.
 	f << enclose("p", true) << "Most skills cost $" << SkillDefs[S_COMBAT].cost
 	  << " per person per month to study (in addition to normal maintenance costs).  The exceptions are ";
-	if (has_stea || has_obse) {		
+	if (has_stea || has_obse) {
 		f << (has_stea ? "Stealth" : "") << (has_stea && has_obse ? " and " : "") << (has_obse ? "Observation" : "")
 		  << " (" << (has_stea && has_obse ? "both of which cost $" : "which costs $") << SkillDefs[S_STEALTH].cost
 		  << "), ";
@@ -2127,7 +2127,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		if (!evenly_divisible) {
 			f << "Food value for a fractional maintenance cost still consumes the entire unit of food. ";
 		}
-		
+
 		if (Globals->UPKEEP_MINIMUM_FOOD > 0) {
 			f << "A unit must be given at least " << Globals->UPKEEP_MINIMUM_FOOD
 			  << " maintenance per man in the form of food. ";
@@ -2180,7 +2180,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << "were given above in the section on Movement, but many things were left out. Here is a table "
 	  << "giving some information about common items in Atlantis:\n"
 	  << enclose("p", false);
-	
+
 	f << anchor("tableiteminfo") << '\n';
 	f << enclose("center", true);
 	f << enclose("table border=\"1\"", true);
@@ -2252,7 +2252,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 					(wp->flags & WeaponType::RANGED) ||
 					(wp->flags & WeaponType::NEEDSKILL)) {
 				if (wp->flags & WeaponType::RANGED)
-					f << "Ranged weapon";			 			
+					f << "Ranged weapon";
 				else
 					f << "Weapon";
 				f << " which gives " << (wp->attackBonus > -1 ? "+" : "")
@@ -2340,7 +2340,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << " factions can issue " << url("#produce", "PRODUCE") << " orders however, regardless of skill levels.\n"
 		  << enclose("p", false);
 	}
-	
+
 	f << enclose("p", true) << "Items which increase production may increase production of advanced items in "
 	  << "addition to the basic items listed.  Some of them also increase production of other tools.  Read the skill "
 	  << "descriptions for details on which tools aid which production when not noted above.\n"
@@ -2431,7 +2431,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	}
 	f << enclose("table", false);
 	f << enclose("center", false);
-	
+
 	f << enclose("p", true) << "Size is the number of people that the building can shelter. Cost is both "
 	  << "the number of man-months of labor and the number of units of material required to complete the building.  ";
 	if (Globals->LIMITED_MAGES_PER_BUILDING) {
@@ -2648,7 +2648,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			f << enclose("td align=\"center\"", true) << ItemDefs[i].weight/50 << '\n' << enclose("td", false);
 			f << enclose("td align=\"center\"", true) << slevel << '\n' << enclose("td", false);
 			f << enclose("tr", false);
-		}					
+		}
 		for (int i = 0; i < NOBJECTS; i++) {
 			if (ObjectDefs[i].flags & ObjectType::DISABLED) continue;
 			if (!ObjectIsShip(i)) continue;
@@ -2674,7 +2674,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << "to complete the ship. The sailors are the number of skill levels of the Sailing skill that must be "
 		  << "aboard the ship (and issuing the " << url("#sail", "SAIL") << " order) in order for the ship to sail.\n"
 		  << enclose("p", false);
-		
+
 		f << enclose("p", true) << "When a ship is built, if its builder is already the owner of a fleet, then "
 		  << "the ship will be added to that fleet; otherwise a new fleet will be created to hold the ship.  A fleet "
 		  << "has the combined capacity and sailor requirement of its constituent vessels, and moves at the speed of "
@@ -2759,7 +2759,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << "the faction in question Friendly. Units on guard will also block " << url("#pillage", "PILLAGE")
 	  << " orders issued by other factions in the same region, regardless of your attitude towards the faction "
 	  << "in question, and they will attempt to prevent Unfriendly units from entering the region.  Only units "
-	  << "which are able to tax may be on guard.  Units on guard " 
+	  << "which are able to tax may be on guard.  Units on guard "
 	  << (has_stea ? " are always visible regardless of Stealth skill, and " : "")
 	  << "will be marked as being \"on guard\" in the region description.\n"
 	  << enclose("p", false);
@@ -2936,7 +2936,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 			  ? "these restrictions do "
 			  : "this restriction does ")
 		  << "not apply for sea combat, as "
-		  << (has_stea ? "units within a fleet are always visible" : "");		  
+		  << (has_stea ? "units within a fleet are always visible" : "");
 		if (!(SkillDefs[S_RIDING].flags & SkillType::DISABLED)) {
 			f << (has_stea ? ", and" : "") << " Riding does not play a part in combat on board fleets";
 		}
@@ -3112,7 +3112,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << "the battle is over, by any living healers on the winning side.\n"
 		  << enclose("p", false);
 	}
-	
+
 	f << enclose("p", true) << "Any items owned by dead combatants on the losing side have a 50% chance of being "
 	  << "found and collected by the winning side. Each item which is recovered is picked up by one of the "
 	  << "survivors able to carry it (see the " << url("#spoils", "SPOILS") << " command) at random, so the "
@@ -3705,7 +3705,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << example_start("Change your faction's email address to atlantis@rahul.net.")
 	  << "ADDRESS atlantis@rahul.net\n"
 	  << example_end();
-	
+
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
 	f << anchor("advance") << '\n';
 	f << enclose("h4", true) << "ADVANCE [dir] ...\n" << enclose("h4", false);
@@ -3731,15 +3731,26 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		f << enclose("p", true) << "Annihilate a region and the neighboring regions.  An annihilated region will be "
 		  << "converted into barren land, and all units and all structures except for shafts and anomalies in the "
 		  << "regions will be destroyed.  The neighboring regions will also be annihilated.  The region to be "
-		  << "annihilated must be specified by coordinates.  If the Z coordinate is not specified, it is assumed "
-		  << "to be on the same level as the unit issuing the order. This order may only be issued by a unit which "
-		  << "has access to the ANNIHILATE [ANNI] skill. This skill cannot target or affect regions which are "
-		  << "already barren, nor can it target the Nexus.\n";
+		  << "annihilated must be specified by coordinates.";
+
+		RangeType *rt = FindRange("rng_annihilate");
+		if (rt->flags & RangeType::RNG_SURFACE_ONLY) {
+			f << " The Z coordinate, if specified, is ignored as this skill may only target the surface.";
+		} else {
+			f << " If the Z coordinate is not specified, it is assumed to be on the same level as the unit "
+			  << "issuing the order.";
+		}
+		f << " This order may only be issued by a unit which has access to the ANNIHILATE [ANNI] skill. "
+		  << "This skill cannot target or affect regions which are already barren, nor can it target the Nexus.\n";
 		f << enclose("p", false);
 		f << enclose("p", true) << "Example:\n" << enclose("p", false);
 		f << example_start("Annihilate the region located at coordinates <5, 5> on the surface.")
-		  << "ANNIHILATE REGION 5 5 1\n"
-		  << example_end();
+		  << "ANNIHILATE REGION 5 5 1\n";
+		if (rt->flags & RangeType::RNG_SURFACE_ONLY) {
+		  f << " or\n"
+		  	<< "ANNIHILATE REGION 5 5\n";
+		}
+		f << example_end();
 	}
 
 	if (Globals->USE_WEAPON_ARMOR_COMMAND) {
@@ -3845,7 +3856,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << example_start("To help unit 5789 build a structure.")
 	  << "BUILD HELP 5789\n"
 	  << example_end();
-	
+
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
 	f << anchor("buy") << '\n';
 	f << enclose("h4", true) << "BUY [quantity] [item]\n" << enclose("h4", false);
@@ -3875,7 +3886,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		  << "BUY 5 barbarians\n"
 		  << example_end();
 	}
-	
+
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
 	f << anchor("cast") << '\n';
 	f << enclose("h4", true) << "CAST [skill] [arguments]\n" << enclose("h4", false);
@@ -4127,7 +4138,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("p", true) << "Form a new unit.  The newly created unit will be in your faction, in the same "
 	  << "region as the unit which formed it, and in the same structure if any.  It will start off, however, with "
 	  << "no people or items; you should, in the same month, issue orders to transfer people into the new unit, or "
-	  << "have it recruit members. The new unit will inherit its flags from the unit that forms it, such as "	
+	  << "have it recruit members. The new unit will inherit its flags from the unit that forms it, such as "
 	  << "avoiding, behind, revealing and sharing, with the exception of the guard and autotax flags.  If the new "
 	  << "unit wants to guard or automatically tax then those flags will have to be explicitly set in its orders.\n"
 	  << enclose("p", false);
@@ -4394,7 +4405,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("p", true) << "If multiple units are on one side in a battle, they must all have the NOAID flag on, "
 	  << "or they will receive aid from other hexes.\n"
 	  << enclose("p", false);
-	f << enclose("p", true) << "Example:\n" << enclose("p", false);	
+	f << enclose("p", true) << "Example:\n" << enclose("p", false);
 	f << example_start("Set a unit to receive no aid in battle.")
 	  << "NOAID 1\n"
 	  << example_end();
@@ -4588,7 +4599,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("p", true) << "Note that although this order affects the faction as a whole, it nevertheless needs "
 	  << "to be issued by an individual unit, and so the email containing the command to quit needs to include both "
 	  << "#atlantis and unit lines.\n"
-	  << enclose("p", false);	
+	  << enclose("p", false);
 	f << enclose("p", true) << "Example:\n" << enclose("p", false);
 	f << example_start("Quit the game for faction 27 if your password is foobar.")
 	  << "#atlantis 27 \"foobar\"\n"
@@ -4622,7 +4633,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << "affiliation (REVEAL FACTION), in the turn report, to all other factions in the region. "
 	  << (has_stea ? "Used to reveal high stealth scouts, should there be some reason to. " : "")
 	  << "REVEAL is used to cancel this.\n"
-	  << enclose("p", false);	
+	  << enclose("p", false);
 	f << enclose("p", true) << "Examples:\n" << enclose("p", false);
 	f << example_start("Show the unit to all factions.")
 	  << "REVEAL UNIT\n"

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -164,7 +164,7 @@ int ParseFactionType(AString *o, std::unordered_map<std::string, int> &type)
 
 	while(token) {
 		bool foundone = false;
-		
+
 		for (auto &ft : *FactionTypes) {
 			if (*token == ft.c_str()) {
 				delete token;
@@ -773,7 +773,7 @@ void Game::ProcessReshowOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 {
 	int sk, lvl, item, obj;
 	AString *token;
-	
+
 	token = o->gettoken();
 	if (!token) {
 		// LLS
@@ -1482,7 +1482,7 @@ void Game::ProcessPromoteOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 
 void Game::ProcessLeaveOrder(Unit *u, OrdersCheck *pCheck)
 {
-	if (!pCheck) {	
+	if (!pCheck) {
 		// if the unit isn't already trying to enter a building,
 		// then set it to leave.
 		if (u->enter == 0) u->enter = -1;
@@ -1517,7 +1517,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	// 'incomplete' for ships:
 	maxbuild = 0;
 	unit->build = 0;
-	
+
 	if (token) {
 		if (*token == "help") {
 			// "build help unitnum"
@@ -1543,14 +1543,14 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 				parse_error(pCheck, unit, 0, "BUILD: Not a valid object name.");
 				return;
 			}
-			
+
 			if (!pCheck) {
 				ARegion *reg = unit->object->region;
 				if (TerrainDefs[reg->type].similar_type == R_OCEAN){
 					unit->error("BUILD: Can't build in an ocean.");
 					return;
 				}
-				
+
 				if (ot < 0) {
 					/* Build SHIP item */
 					int st = abs(ot+1);
@@ -1569,7 +1569,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 					// ship, see how much work is left
 					if (unit->items.GetNum(st) > 0)
 						maxbuild = unit->items.GetNum(st);
-					// Don't create a fleet yet	
+					// Don't create a fleet yet
 				} else {
 					/* build standard OBJECT */
 					if (ObjectDefs[ot].flags & ObjectType::DISABLED) {
@@ -1605,7 +1605,7 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 						break;
 				}
 			}
-			
+
 			if (st == O_DUMMY) {
 				// Build whatever we happen to be in when
 				// we get to the build phase
@@ -1618,19 +1618,19 @@ void Game::ProcessBuildOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	}
 	// set neededtocomplete
 	if (maxbuild != 0) order->needtocomplete = maxbuild;
-	
-	
+
+
 	// Now do all of the generic bits...
 	// Check that the unit isn't doing anything else important
 	if (unit->monthorders ||
 			(Globals->TAX_PILLAGE_MONTH_LONG &&
-				((unit->taxing == TAX_TAX) || 
+				((unit->taxing == TAX_TAX) ||
 					(unit->taxing == TAX_PILLAGE)))) {
 		if (unit->monthorders) delete unit->monthorders;
 		string err = string("BUILD: Overwriting previous ") + (unit->inTurnBlock ? "DELAYED " : "") + "month-long order.";
 		parse_error(pCheck, unit, 0, err);
 	}
-	
+
 	// reset their taxation status if taxing is a month-long order
 	if (Globals->TAX_PILLAGE_MONTH_LONG) unit->taxing = TAX_NONE;
 	unit->monthorders = order;
@@ -1853,7 +1853,7 @@ void Game::ProcessStudyOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 		delete token;
 	} else
 		order->level = -1;
-	
+
 	if (u->monthorders ||
 		(Globals->TAX_PILLAGE_MONTH_LONG &&
 		 ((u->taxing == TAX_TAX) || (u->taxing == TAX_PILLAGE)))) {
@@ -2054,7 +2054,7 @@ AString *Game::ProcessTurnOrder(Unit *unit, istream& f, OrdersCheck *pCheck, int
 					if (!turnLast) {
 						parse_error(pCheck, unit, 0, "ENDTURN: without TURN.");
 					} else {
-						if (--turnDepth) 
+						if (--turnDepth)
 							tOrder->turnOrders.Add(new AString(saveorder));
 						turnLast = 0;
 					}
@@ -2364,7 +2364,7 @@ void Game::ProcessNameOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 		parse_error(pCheck, unit, 0, "NAME: No argument.");
 		return;
 	}
-	
+
 	if (*token == "faction") {
 		delete token;
 		token = o->gettoken();
@@ -2964,7 +2964,7 @@ void Game::ProcessTransportOrder(Unit *u, AString *o, OrdersCheck *pCheck)
 
 	if (!pCheck) {
 		TransportOrder *order = new TransportOrder;
-		// At this point we don't know that transport phase for the order but 
+		// At this point we don't know that transport phase for the order but
 		// we will set that later.
 		order->item = item;
 		order->target = tar;
@@ -3088,7 +3088,6 @@ void Game::ProcessAnnihilateOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	int x = -1;
 	int y = -1;
 	int z = unit->object->region->zloc;
-	RangeType *range = FindRange(SkillDefs[S_ANNIHILATION].range);
 
 	if (!token) {
 		parse_error(pCheck, unit, 0, "ANNIHILATE: No region specified.");
@@ -3117,7 +3116,13 @@ void Game::ProcessAnnihilateOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	y = token->value();
 	delete token;
 
-	if (range && (range->flags & RangeType::RNG_CROSS_LEVELS)) {
+
+	RangeType *range = FindRange(SkillDefs[S_ANNIHILATION].range);
+	if (range->flags & RangeType::RNG_SURFACE_ONLY) {
+		z = (Globals->NEXUS_EXISTS ? 1 : 0);
+	}
+
+	if (range && (range->flags & RangeType::RNG_CROSS_LEVELS) && !(range->flags & RangeType::RNG_SURFACE_ONLY)) {
 		token = o->gettoken();
 		if (token) {
 			z = token->value();
@@ -3134,7 +3139,6 @@ void Game::ProcessAnnihilateOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 		order->xloc = x;
 		order->yloc = y;
 		order->zloc = z;
-		if (unit->annihilateorders) delete unit->annihilateorders;
-		unit->annihilateorders = order;
+		unit->annihilateorders.push_back(order);
 	}
 }

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -3505,50 +3505,119 @@ void Game::RunAnnihilateOrders() {
 	// Annihilate will destroy the target hex and all surrounding hexes.  Already annihilated regions cannot be
 	// annihilated again.
 
+	bool only_surface = rulesetSpecificData.value("annihilate_surface_only", false);
+	int max_annihilates = rulesetSpecificData.value("allowed_annihilates", 1);
+
 	forlist((&regions)) {
 		ARegion *r = (ARegion *) elem;
 		forlist((&r->objects)) {
 			Object *obj = (Object *) elem;
 			forlist((&obj->units)) {
+				// How many annihilates is a unit allowed to do?
+				int allowed_annihilates = max_annihilates;
 				Unit *u = (Unit *) elem;
-				AnnihilateOrder *o = u->annihilateorders;
-				if (o == nullptr) continue;
 
-				// Check if the unit has access to the annihilate skill
 				if (u->GetSkill(S_ANNIHILATION) <= 0) {
+					if (u->annihilateorders.empty()) continue; // no annihilate orders
 					u->error("ANNIHILATE: Unit does not have access to the annihilate skill.");
+					u->annihilateorders.clear(); // clear the orders
 					continue;
 				}
 
-				// Ok we have a unit doing a valid annihilate order.
-				ARegion *target = regions.GetRegion(o->xloc, o->yloc, o->zloc);
-				if (target == nullptr) {
-					u->error("ANNIHILATE: Target region does not exist.");
-					continue;
-				}
-				// Check if the target is in range
-				RangeType *rt = FindRange("rng_annihilate");
-				// If the range for annihilation is changed, this code will need to be updated.  This really should
-				// be made better, but not today. (right now this has a range of 1000 and a cross level penalty of 0)
-				int dist = regions.GetPlanarDistance(r, target, rt->crossLevelPenalty, rt->rangeMult);
-				if (dist > rt->rangeMult) {
-					u->error("ANNIHILATE: Target region is out of range.");
-					continue;
+				while(allowed_annihilates > 0 && !u->annihilateorders.empty()) {
+					AnnihilateOrder *o = u->annihilateorders.front();
+					u->annihilateorders.pop_front();
+
+					// Ok we have a unit doing an annihilate order.
+					ARegion *target = regions.GetRegion(o->xloc, o->yloc, o->zloc);
+					if (target == nullptr) {
+						u->error("ANNIHILATE: Target region does not exist.");
+						continue;
+					}
+
+					// Check if the target is in range
+					RangeType *rt = FindRange("rng_annihilate");
+					int rtype = target->level->levelType;
+					if ((rt->flags & RangeType::RNG_SURFACE_ONLY) && (rtype  != ARegionArray::LEVEL_SURFACE)) {
+						u->error("ANNIHILATE: Target region is not on the surface.");
+						continue;
+					}
+
+					// If the range for annihilation is changed, this code will need to be updated.  This really should
+					// be made better, but not today. (right now this has a range of 1000 and a cross level penalty of 0)
+					int dist = regions.GetPlanarDistance(r, target, rt->crossLevelPenalty, rt->rangeMult);
+					if (dist > rt->rangeMult) {
+						u->error("ANNIHILATE: Target region is out of range.");
+						continue;
+					}
+
+					// Make sure the target isn't already annihilated
+					if (TerrainDefs[target->type].flags & TerrainType::ANNIHILATED) {
+						u->error("ANNIHILATE: Target region is already annihilated.");
+						continue;
+					}
+
+					// annihilate our neigbors
+					for (auto n = 0; n < NDIRS; n++) {
+						ARegion *neigh = target->neighbors[n];
+						if (neigh == nullptr) continue;
+						Do1Annihilate(neigh);
+					}
+					Do1Annihilate(target);
+
+					// lastly update that we cast one.
+					allowed_annihilates--;
 				}
 
-				// Make sure the target isn't already annihilated
-				if (TerrainDefs[target->type].flags & TerrainType::ANNIHILATED) {
-					u->error("ANNIHILATE: Target region is already annihilated.");
-					continue;
+				// If the unit didn't use all their annihilates, and we should do random ones, do them.
+				while(allowed_annihilates > 0) {
+					// pick a random region region to annihilate
+					ARegionArray *level = nullptr;
+					if (only_surface) {
+						level = regions.get_first_region_array_of_type(ARegionArray::LEVEL_SURFACE);
+					} else {
+						int zloc = getrandom(regions.numLevels);
+						level = regions.GetRegionArray(zloc);
+					}
+					// now, get a random region from that level that isn't our own.
+					if (level == nullptr) break;
+
+					ARegion *target = nullptr;
+					int tries = 0;
+					while(!target) {
+						if (tries++ > 25) break; // don't loop forever
+						target = level->GetRegion(getrandom(level->x), getrandom(level->y));
+						if (!target) continue; // no region there
+						if (target == r) { target = nullptr; continue; } // don't pick our own region
+						if (TerrainDefs[target->type].flags & TerrainType::ANNIHILATED) {
+							target = nullptr; // don't pick an already annihilated region
+						}
+					}
+					if (target == nullptr) break; // couldn't find a valid region
+
+					// Ok, we found a valid, non-annihilated region, blow it up.
+					for (auto n = 0; n < NDIRS; n++) {
+						ARegion *neigh = target->neighbors[n];
+						if (neigh == nullptr) continue;
+						Do1Annihilate(neigh);
+					}
+					Do1Annihilate(target);
+					// lastly update that we cast one.
+					allowed_annihilates--;
 				}
 
-				// annihilate our neigbors
-				for (auto n = 0; n < NDIRS; n++) {
-					ARegion *neigh = target->neighbors[n];
-					if (neigh == nullptr) continue;
-					Do1Annihilate(neigh);
+				// If the unit still has annihilate orders, keep them for next turn.
+				while(!u->annihilateorders.empty()) {
+					AnnihilateOrder *o = u->annihilateorders.front();
+					u->annihilateorders.pop_front();
+
+					TurnOrder *tOrder = new TurnOrder;
+					std::string order = "ANNIHILATE " + to_string(o->xloc) + " " + to_string(o->yloc) +
+						" " + to_string(o->zloc);
+					tOrder->repeating = 0;
+					tOrder->turnOrders.Add(new AString(order));
+					u->turnorders.Insert(tOrder);
 				}
-				Do1Annihilate(target);
 			}
 		}
 	}

--- a/skillshows.cpp
+++ b/skillshows.cpp
@@ -462,7 +462,7 @@ AString *ShowSkill::Report(Faction *f) const
 			if (Globals->APPRENTICES_EXIST) {
 				*str += " or ";
 				*str += Globals->APPRENTICE_NAME;
-			}				
+			}
 			*str += ", make a temporary Gate between two regions, and "
 				"send units from one region to another. In order to do this, "
 				"both mages (the caster, and the target mage) must have "
@@ -708,12 +708,12 @@ AString *ShowSkill::Report(Faction *f) const
 						"12 sailing skill points per skill level "
 						"of Summon Wind. ";
 				}
-					 
+
 				/*
 				*str += " If the mage is flying, he will receive 2 extra "
 					"movement points.";
 				*/
-				*str += "The effects of all such mages in a fleet are cumulative. ";	
+				*str += "The effects of all such mages in a fleet are cumulative. ";
 			}
 			break;
 		case S_SUMMON_STORM:
@@ -1463,14 +1463,32 @@ AString *ShowSkill::Report(Faction *f) const
 			break;
 		case S_ANNIHILATION:
 			if (level > 1) break;
+			range = FindRange(SkillDefs[skill].range);
 			*str += "A unit with access to the Annihilation skill may destroy a region and all "
 				"surrounding regions.  Regions destroyed in this way will become barren.  All units "
 				"and structures except for shafts and anomalies in the region and the surrounding regions "
-				"will be destroyed as will production and cities.  This skill is only available to the unit "
-				"which controls the World-breaker Monolith.  To use this skill, the owner of the "
-				"World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z "
-				"coordinate is not specified, it will default to the same z coordinate as the region "
-				"containing the World-breaker Monolith.";
+				"will be destroyed as will production and cities.";
+			if (!(ObjectDefs[O_ACTIVE_MONOLITH].flags & ObjectType::DISABLED)) {
+				if (ObjectDefs[O_ACTIVE_MONOLITH].flags & ObjectType::GRANTSKILL) {
+					*str += " This skill is only available to the unit which controls the World-breaker Monolith. "
+						"To use this skill, the owner of the World-breaker Monolith ";
+				}
+			} else {
+				*str += " To use this skill, the unit ";
+			}
+			*str += "must issue the order ANNIHILATE REGION <x> <y>";
+			if (range && range->flags & RangeType::RNG_SURFACE_ONLY) {
+				*str += ".";
+			} else {
+				*str += " <z>. If the z coordinate is not specified, it will default to the same z coordinate as "
+					"the unit utilizing the skill.";
+			}
+
+			if (range && range->flags & RangeType::RNG_SURFACE_ONLY) {
+				*str += " This skill can only target a region on the surface of the world.";
+			} else {
+				*str += " This skill can target a region anywhere in the world.";
+			}
 			break;
 	}
 
@@ -1584,7 +1602,7 @@ AString *ShowSkill::Report(Faction *f) const
 				temp2 += "] via magic";
 				count = 0;
 				for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(ItemDefs[i].mInput[0]); c++) {
-					if (ItemDefs[i].mInput[c].item == -1) continue;	
+					if (ItemDefs[i].mInput[c].item == -1) continue;
 					count++;
 				}
 				if (count > 0) {
@@ -1592,7 +1610,7 @@ AString *ShowSkill::Report(Faction *f) const
 					temp4 = "";
 					count = 0;
 					for (c = 0; c < sizeof(ItemDefs[i].mInput)/sizeof(ItemDefs[i].mInput[0]); c++) {
-						if (ItemDefs[i].mInput[c].item == -1) continue;	
+						if (ItemDefs[i].mInput[c].item == -1) continue;
 						if (!(temp4 == "")) {
 							if (count > 0)
 								temp2 += ", ";
@@ -1659,7 +1677,7 @@ AString *ShowSkill::Report(Faction *f) const
 					temp4 = "";
 					count = 0;
 					for (c = 0; c < sizeof(ItemDefs[i].pInput)/sizeof(ItemDefs[i].pInput[0]); c++) {
-						if (ItemDefs[i].pInput[c].item == -1) continue;	
+						if (ItemDefs[i].pInput[c].item == -1) continue;
 						if (!(temp4 == "")) {
 							if (count > 0)
 								temp1 += ", ";
@@ -1875,7 +1893,7 @@ AString *ShowSkill::Report(Faction *f) const
 		if (!(*str == "")) *str += " ";
 		*str += "This skill cannot be taught to other units.";
 	}
-	if ((Globals->SKILL_PRACTICE_AMOUNT > 0) && 
+	if ((Globals->SKILL_PRACTICE_AMOUNT > 0) &&
 			(SkillDefs[skill].flags & SkillType::NOEXP)) {
 		if (!(*str == "")) *str += " ";
 		*str += "This skill cannot be increased through experience.";

--- a/snapshot-tests/neworigins_turns/turn_0/report.1
+++ b/snapshot-tests/neworigins_turns/turn_0/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_0/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_0/report.1.json
@@ -25874,7 +25874,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_1/report.1
+++ b/snapshot-tests/neworigins_turns/turn_1/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_1/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_1/report.1.json
@@ -25917,7 +25917,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_10/report.1
+++ b/snapshot-tests/neworigins_turns/turn_10/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_10/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_10/report.1.json
@@ -26311,7 +26311,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_11/report.1
+++ b/snapshot-tests/neworigins_turns/turn_11/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_11/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_11/report.1.json
@@ -26446,7 +26446,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_12/report.1
+++ b/snapshot-tests/neworigins_turns/turn_12/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_12/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_12/report.1.json
@@ -26740,7 +26740,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_13/report.1
+++ b/snapshot-tests/neworigins_turns/turn_13/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_13/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_13/report.1.json
@@ -26919,7 +26919,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_2/report.1
+++ b/snapshot-tests/neworigins_turns/turn_2/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_2/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_2/report.1.json
@@ -25994,7 +25994,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_3/report.1
+++ b/snapshot-tests/neworigins_turns/turn_3/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_3/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_3/report.1.json
@@ -26145,7 +26145,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_4/report.1
+++ b/snapshot-tests/neworigins_turns/turn_4/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_4/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_4/report.1.json
@@ -26230,7 +26230,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_5/report.1
+++ b/snapshot-tests/neworigins_turns/turn_5/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_5/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_5/report.1.json
@@ -26255,7 +26255,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_6/report.1
+++ b/snapshot-tests/neworigins_turns/turn_6/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_6/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_6/report.1.json
@@ -26280,7 +26280,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_7/report.1
+++ b/snapshot-tests/neworigins_turns/turn_7/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_7/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_7/report.1.json
@@ -26280,7 +26280,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_8/report.1
+++ b/snapshot-tests/neworigins_turns/turn_8/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_8/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_8/report.1.json
@@ -26221,7 +26221,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_9/report.1
+++ b/snapshot-tests/neworigins_turns/turn_9/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_9/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_9/report.1.json
@@ -26266,7 +26266,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/rules/neworigins.html
+++ b/snapshot-tests/rules/neworigins.html
@@ -5337,11 +5337,11 @@ ADVANCE N 1 IN SE
       will be converted into barren land, and all units and all structures
       except for shafts and anomalies in the regions will be destroyed.  The
       neighboring regions will also be annihilated.  The region to be
-      annihilated must be specified by coordinates.  If the Z coordinate is
-      not specified, it is assumed to be on the same level as the unit issuing
-      the order. This order may only be issued by a unit which has access to
-      the ANNIHILATE [ANNI] skill. This skill cannot target or affect regions
-      which are already barren, nor can it target the Nexus.
+      annihilated must be specified by coordinates. The Z coordinate, if
+      specified, is ignored as this skill may only target the surface. This
+      order may only be issued by a unit which has access to the ANNIHILATE
+      [ANNI] skill. This skill cannot target or affect regions which are
+      already barren, nor can it target the Nexus.
     </p>
     <p>
       Example:
@@ -5354,6 +5354,8 @@ ADVANCE N 1 IN SE
     </p>
     <pre>
 ANNIHILATE REGION 5 5 1
+ or
+ANNIHILATE REGION 5 5
     </pre>
     <div class="rule">
       

--- a/unit.cpp
+++ b/unit.cpp
@@ -88,7 +88,6 @@ Unit::Unit()
 	monthorders = NULL;
 	castorders = NULL;
 	sacrificeorders = nullptr;
-	annihilateorders = nullptr;
 	teleportorders = NULL;
 	joinorders = NULL;
 	inTurnBlock = 0;
@@ -136,7 +135,6 @@ Unit::Unit(int seq, Faction *f, int a)
 	teleportorders = NULL;
 	joinorders = NULL;
 	sacrificeorders = nullptr;
-	annihilateorders = nullptr;
 	inTurnBlock = 0;
 	presentTaxing = 0;
 	presentMonthOrders = NULL;

--- a/unit.h
+++ b/unit.h
@@ -48,6 +48,7 @@ class UnitId;
 #include "object.h"
 #include <set>
 #include <string>
+#include <list>
 
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
@@ -141,7 +142,7 @@ class Unit : public AListElem
 		AString ReadyItem();
 		AString StudyableSkills();
 		AString * BattleReport(int);
-		
+
 		void ClearOrders();
 		void ClearCastOrders();
 		void DefaultOrders(Object *);
@@ -289,7 +290,7 @@ class Unit : public AListElem
 		AttackOrder *attackorders;
 		EvictOrder *evictorders;
 		SacrificeOrder *sacrificeorders;
-		AnnihilateOrder *annihilateorders;
+		std::list<AnnihilateOrder *>annihilateorders;
 		ARegion *advancefrom;
 
 		AList exchangeorders;

--- a/unittest/n07_victory_test.cpp
+++ b/unittest/n07_victory_test.cpp
@@ -563,4 +563,386 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     expect(region_rep.value("tax", 0) == 0_i);
   };
 
+  "Unit can cast multiple annihilates per turn"_test = []
+  {
+    UnitTestHelper helper;
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ACTIVE_MONOLITH, true);
+    helper.enable(UnitTestHelper::Type::ITEM, I_IMPRISONED_ENTITY, true);
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ENTITY_CAGE, true);
+    helper.enable(UnitTestHelper::Type::SKILL, S_ANNIHILATION, true);
+    helper.initialize_game();
+    helper.setup_turn();
+
+    json rulesetData = { {"allowed_annihilates", 2}};
+    helper.set_ruleset_specific_data(rulesetData);
+
+    string name("Test Faction");
+    Faction *faction = helper.create_faction(name);
+    // Since this is such a tightly defined world, we know this is legal
+    ARegion *region = helper.get_region(0, 0, 0);
+    ARegion *region2 = helper.get_region(1, 1, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    region2->type = R_BARREN;
+    helper.create_building(region2, nullptr, O_ACTIVE_MONOLITH);
+    helper.create_building(region, nullptr, O_ENTITY_CAGE);
+    Unit *second = helper.create_unit(faction, region);
+    second->items.SetNum(I_LEADERS, 10);
+    helper.create_building(region, second, O_TOWER);
+
+    // Try to use annihilate
+    stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "move se 1\n";
+    ss << "annihilate region 0, 0, 0\n";
+    ss << "annihilate region 1, 3, 0\n";
+    helper.parse_orders(faction->num, ss);
+    helper.move_units();
+    helper.run_annihilation();
+
+    expect(faction->errors.size() == 0_ul);
+    expect(faction->events.size() == 6_ul);
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Validate we get the messages we expect for the faction
+    json events = json_report["events"];
+    expect(events.size() == 6_ul);
+    json event = events[0];
+    expect(event["message"] == "Walks from plain (0,0) in Testing Wilds to barren (1,1) in Testing Wilds.");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[1];
+    expect(event["message"] == "Enters Building [1].");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[2];
+    expect(event["message"] == "forest (0,2) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[3];
+    expect(event["message"] == "plain (0,0) in Testing Wilds, contains Basictown [city] has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[4];
+    expect(event["message"] == "Is annihilated.");
+    expect(event["category"] == "annihilate");
+    expect(event["unit"]["number"] == 3_i);
+    event = events[5];
+    expect(event["message"] == "desert (1,3) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+
+    // load the gm faction report
+    json gm_report;
+    Faction *gm_faction = helper.get_faction(1);
+    gm_faction->build_json_report(gm_report, &game, nullptr);
+
+    // Verify that everything in region 0,0,0 is gone except the shaft and the anomaly.
+    json region_rep = gm_report["regions"][0];
+    expect(region_rep["terrain"] == "barren");
+    expect(region_rep["structures"].size() == 2_ul);
+    expect(region_rep["structures"][0]["type"] == "Shaft");
+    expect(region_rep["structures"][1]["type"] == "Mystical Anomaly");
+    // verify that markets, products and all units are gone.
+    expect(region_rep["markets"]["for_sale"].size() == 0_ul);
+    expect(region_rep["markets"]["wanted"].size() == 0_ul);
+    expect(region_rep["products"].size() == 0_ul);
+    expect(region_rep["units"].size() == 0_ul);
+    expect(region_rep["structures"][0]["units"].size() == 0_ul);
+    expect(region_rep["structures"][1]["units"].size() == 0_ul);
+    expect(region_rep["wages"]["amount"] == 0_i);
+    expect(region_rep["wages"].value("max", 0) == 0_i);
+    expect(region_rep["population"].empty());
+    expect(region_rep.value("tax", 0) == 0_i);
+  };
+
+  "If a unit casts 0 annihilates, random ones fire"_test = []
+  {
+    UnitTestHelper helper;
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ACTIVE_MONOLITH, true);
+    helper.enable(UnitTestHelper::Type::ITEM, I_IMPRISONED_ENTITY, true);
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ENTITY_CAGE, true);
+    helper.enable(UnitTestHelper::Type::SKILL, S_ANNIHILATION, true);
+    helper.initialize_game();
+    helper.setup_turn();
+
+    json rulesetData = { {"allowed_annihilates", 2}, {"random_annihilates", true}};
+    helper.set_ruleset_specific_data(rulesetData);
+
+    string name("Test Faction");
+    Faction *faction = helper.create_faction(name);
+    // Since this is such a tightly defined world, we know this is legal
+    ARegion *region = helper.get_region(0, 0, 0);
+    ARegion *region2 = helper.get_region(1, 1, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    region2->type = R_BARREN;
+    helper.create_building(region2, nullptr, O_ACTIVE_MONOLITH);
+    helper.create_building(region, nullptr, O_ENTITY_CAGE);
+    Unit *second = helper.create_unit(faction, region);
+    second->items.SetNum(I_LEADERS, 10);
+    helper.create_building(region, second, O_TOWER);
+
+    // Try to use annihilate
+    stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "move se 1\n";
+    helper.parse_orders(faction->num, ss);
+    helper.move_units();
+    helper.run_annihilation();
+
+    expect(faction->errors.size() == 0_ul);
+    expect(faction->events.size() == 6_ul);
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Validate we get the messages we expect for the faction
+    json events = json_report["events"];
+    expect(events.size() == 6_ul);
+    json event = events[0];
+    expect(event["message"] == "Walks from plain (0,0) in Testing Wilds to barren (1,1) in Testing Wilds.");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[1];
+    expect(event["message"] == "Enters Building [1].");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[2];
+    expect(event["message"] == "forest (0,2) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[3];
+    expect(event["message"] == "desert (1,3) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[4];
+    expect(event["message"] == "plain (0,0) in Testing Wilds, contains Basictown [city] has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[5];
+    expect(event["message"] == "Is annihilated.");
+    expect(event["category"] == "annihilate");
+    expect(event["unit"]["number"] == 3_i);
+
+    // load the gm faction report
+    json gm_report;
+    Faction *gm_faction = helper.get_faction(1);
+    gm_faction->build_json_report(gm_report, &game, nullptr);
+
+    // Verify that everything in region 0,0,0 is gone except the shaft and the anomaly.
+    json region_rep = gm_report["regions"][0];
+    expect(region_rep["terrain"] == "barren");
+    expect(region_rep["structures"].size() == 2_ul);
+    expect(region_rep["structures"][0]["type"] == "Shaft");
+    expect(region_rep["structures"][1]["type"] == "Mystical Anomaly");
+    // verify that markets, products and all units are gone.
+    expect(region_rep["markets"]["for_sale"].size() == 0_ul);
+    expect(region_rep["markets"]["wanted"].size() == 0_ul);
+    expect(region_rep["products"].size() == 0_ul);
+    expect(region_rep["units"].size() == 0_ul);
+    expect(region_rep["structures"][0]["units"].size() == 0_ul);
+    expect(region_rep["structures"][1]["units"].size() == 0_ul);
+    expect(region_rep["wages"]["amount"] == 0_i);
+    expect(region_rep["wages"].value("max", 0) == 0_i);
+    expect(region_rep["population"].empty());
+    expect(region_rep.value("tax", 0) == 0_i);
+  };
+
+  "If a unit casts 1 annihilates, random ones fire"_test = []
+  {
+    UnitTestHelper helper;
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ACTIVE_MONOLITH, true);
+    helper.enable(UnitTestHelper::Type::ITEM, I_IMPRISONED_ENTITY, true);
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ENTITY_CAGE, true);
+    helper.enable(UnitTestHelper::Type::SKILL, S_ANNIHILATION, true);
+    helper.initialize_game();
+    helper.setup_turn();
+
+    json rulesetData = { {"allowed_annihilates", 2}, {"random_annihilates", true}};
+    helper.set_ruleset_specific_data(rulesetData);
+
+    string name("Test Faction");
+    Faction *faction = helper.create_faction(name);
+    // Since this is such a tightly defined world, we know this is legal
+    ARegion *region = helper.get_region(0, 0, 0);
+    ARegion *region2 = helper.get_region(1, 1, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    region2->type = R_BARREN;
+    helper.create_building(region2, nullptr, O_ACTIVE_MONOLITH);
+    helper.create_building(region, nullptr, O_ENTITY_CAGE);
+    Unit *second = helper.create_unit(faction, region);
+    second->items.SetNum(I_LEADERS, 10);
+    helper.create_building(region, second, O_TOWER);
+
+    // Try to use annihilate
+    stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "move se 1\n";
+    ss << "annihilate region 0, 0, 0\n";
+    ss << "annihilate region 1, 3, 0\n";
+    helper.parse_orders(faction->num, ss);
+    helper.move_units();
+    helper.run_annihilation();
+
+    expect(faction->errors.size() == 0_ul);
+    expect(faction->events.size() == 6_ul);
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Validate we get the messages we expect for the faction
+    json events = json_report["events"];
+    expect(events.size() == 6_ul);
+    json event = events[0];
+    expect(event["message"] == "Walks from plain (0,0) in Testing Wilds to barren (1,1) in Testing Wilds.");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[1];
+    expect(event["message"] == "Enters Building [1].");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[2];
+    expect(event["message"] == "forest (0,2) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[3];
+    expect(event["message"] == "plain (0,0) in Testing Wilds, contains Basictown [city] has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[4];
+    expect(event["message"] == "Is annihilated.");
+    expect(event["category"] == "annihilate");
+    expect(event["unit"]["number"] == 3_i);
+    event = events[5];
+    expect(event["message"] == "desert (1,3) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+
+    // load the gm faction report
+    json gm_report;
+    Faction *gm_faction = helper.get_faction(1);
+    gm_faction->build_json_report(gm_report, &game, nullptr);
+
+    // Verify that everything in region 0,0,0 is gone except the shaft and the anomaly.
+    json region_rep = gm_report["regions"][0];
+    expect(region_rep["terrain"] == "barren");
+    expect(region_rep["structures"].size() == 2_ul);
+    expect(region_rep["structures"][0]["type"] == "Shaft");
+    expect(region_rep["structures"][1]["type"] == "Mystical Anomaly");
+    // verify that markets, products and all units are gone.
+    expect(region_rep["markets"]["for_sale"].size() == 0_ul);
+    expect(region_rep["markets"]["wanted"].size() == 0_ul);
+    expect(region_rep["products"].size() == 0_ul);
+    expect(region_rep["units"].size() == 0_ul);
+    expect(region_rep["structures"][0]["units"].size() == 0_ul);
+    expect(region_rep["structures"][1]["units"].size() == 0_ul);
+    expect(region_rep["wages"]["amount"] == 0_i);
+    expect(region_rep["wages"].value("max", 0) == 0_i);
+    expect(region_rep["population"].empty());
+    expect(region_rep.value("tax", 0) == 0_i);
+
+  };
+
+  "If a unit casts 2 annihilates, 1 unsuccessful, random ones fire"_test = []
+  {
+    UnitTestHelper helper;
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ACTIVE_MONOLITH, true);
+    helper.enable(UnitTestHelper::Type::ITEM, I_IMPRISONED_ENTITY, true);
+    helper.enable(UnitTestHelper::Type::OBJECT, O_ENTITY_CAGE, true);
+    helper.enable(UnitTestHelper::Type::SKILL, S_ANNIHILATION, true);
+    helper.initialize_game();
+    helper.setup_turn();
+
+    json rulesetData = { {"allowed_annihilates", 2}, {"random_annihilates", true}};
+    helper.set_ruleset_specific_data(rulesetData);
+
+    string name("Test Faction");
+    Faction *faction = helper.create_faction(name);
+    // Since this is such a tightly defined world, we know this is legal
+    ARegion *region = helper.get_region(0, 0, 0);
+    ARegion *region2 = helper.get_region(1, 1, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    region2->type = R_BARREN;
+    helper.create_building(region2, nullptr, O_ACTIVE_MONOLITH);
+    helper.create_building(region, nullptr, O_ENTITY_CAGE);
+    Unit *second = helper.create_unit(faction, region);
+    second->items.SetNum(I_LEADERS, 10);
+    helper.create_building(region, second, O_TOWER);
+
+    // Try to use annihilate
+    stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "move se 1\n";
+    ss << "annihilate region 0, 0, 0\n";
+    ss << "annihilate region 1, 3, 0\n";
+    helper.parse_orders(faction->num, ss);
+    helper.move_units();
+    helper.run_annihilation();
+
+    expect(faction->errors.size() == 0_ul);
+    expect(faction->events.size() == 6_ul);
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Validate we get the messages we expect for the faction
+    json events = json_report["events"];
+    expect(events.size() == 6_ul);
+    json event = events[0];
+    expect(event["message"] == "Walks from plain (0,0) in Testing Wilds to barren (1,1) in Testing Wilds.");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[1];
+    expect(event["message"] == "Enters Building [1].");
+    expect(event["unit"]["number"] == 2_i);
+    event = events[2];
+    expect(event["message"] == "forest (0,2) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[3];
+    expect(event["message"] == "plain (0,0) in Testing Wilds, contains Basictown [city] has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+    event = events[4];
+    expect(event["message"] == "Is annihilated.");
+    expect(event["category"] == "annihilate");
+    expect(event["unit"]["number"] == 3_i);
+    event = events[5];
+    expect(event["message"] == "desert (1,3) in Testing Wilds has been utterly annihilated.");
+    expect(event["category"] == "annihilate");
+
+    // load the gm faction report
+    json gm_report;
+    Faction *gm_faction = helper.get_faction(1);
+    gm_faction->build_json_report(gm_report, &game, nullptr);
+
+    // Verify that everything in region 0,0,0 is gone except the shaft and the anomaly.
+    json region_rep = gm_report["regions"][0];
+    expect(region_rep["terrain"] == "barren");
+    expect(region_rep["structures"].size() == 2_ul);
+    expect(region_rep["structures"][0]["type"] == "Shaft");
+    expect(region_rep["structures"][1]["type"] == "Mystical Anomaly");
+    // verify that markets, products and all units are gone.
+    expect(region_rep["markets"]["for_sale"].size() == 0_ul);
+    expect(region_rep["markets"]["wanted"].size() == 0_ul);
+    expect(region_rep["products"].size() == 0_ul);
+    expect(region_rep["units"].size() == 0_ul);
+    expect(region_rep["structures"][0]["units"].size() == 0_ul);
+    expect(region_rep["structures"][1]["units"].size() == 0_ul);
+    expect(region_rep["wages"]["amount"] == 0_i);
+    expect(region_rep["wages"].value("max", 0) == 0_i);
+    expect(region_rep["population"].empty());
+    expect(region_rep.value("tax", 0) == 0_i);
+  };
 };

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -73,7 +73,7 @@ Unit *UnitTestHelper::create_unit(Faction *faction, ARegion *region) {
 void UnitTestHelper::create_fleet(ARegion *region, Unit *owner, int ship_type, int ship_count) {
     for (auto i = 0; i < ship_count; i++)
         game.CreateShip(region, owner, ship_type);
- 
+
 }
 
 void UnitTestHelper::create_building(ARegion *region, Unit *owner, int building_type) {
@@ -169,4 +169,8 @@ void UnitTestHelper::enable(Type type, int id, bool enable) {
 
 void UnitTestHelper::maintain_units() {
     game.AssessMaintenance();
+}
+
+void UnitTestHelper::set_ruleset_specific_data(const json &data) {
+    game.rulesetSpecificData = data;
 }

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -52,7 +52,7 @@ public:
     ARegion *get_region(int x, int y, int level);
     // Get all regions
     ARegionList *get_regions() { return &game.regions; }
-    // get the game month 
+    // get the game month
     int get_month() { return game.month; }
     // Find the first unit for a given faction
     Unit *get_first_unit(Faction *faction);
@@ -80,6 +80,8 @@ public:
     void run_sacrifice();
     // Run annihilation orders
     void run_annihilation();
+    // Enable ruleset specific data for testing
+    void set_ruleset_specific_data(const json &data);
 
     // dummy
     int get_seed() { return getrandom(10000); };


### PR DESCRIPTION
There was some discussion about factions deliberately trying to stall the game into a never-ending state.  Changes have been made which should prevent that.

This also adds a facility that will hopefully get used more in the future to allow ruleset specific data to affect functions in the main game without needing to create duplicate overridden code.  See the rulesetSpecificData member of game, and the use of it in neworigins/extra.cpp and in the runorders.cpp for RunAnnihilationOrders