### PR TITLE
Update NO7 victory conditions to avoid delay of game tactics

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -2359,6 +2359,15 @@ ARegionArray *ARegionList::GetRegionArray(int level)
 	return(pRegionArrays[level]);
 }
 
+ARegionArray *ARegionList::get_first_region_array_of_type(int levelType) {
+	for (int i = 0; i < numLevels; i++) {
+		if (pRegionArrays[i]->levelType == levelType) {
+			return pRegionArrays[i];
+		}
+	}
+	return nullptr;
+}
+
 void ARegionList::CreateLevels(int n)
 {
 	numLevels = n;
@@ -3950,4 +3959,16 @@ int ARegionList::FindDistanceToNearestObject(int object_type, ARegion *start)
 		if (dist < min_dist) min_dist = dist;
 	}
 	return min_dist;
+}
+
+int ARegionList::find_distance_between_regions(ARegion *start, ARegion *end)
+{
+	if (start->zloc != end->zloc) {
+		return -1; // not on the same level
+	}
+
+	int w = start->level->x;
+	graphs::Location2D a = { start->xloc, start->yloc };
+	graphs::Location2D b = { end->xloc, end->yloc };
+	return cylDistance(a, b, w);
 }

--- a/aregion.h
+++ b/aregion.h
@@ -472,6 +472,7 @@ class ARegionList
 		int GetWeather(ARegion *pReg, int month);
 
 		ARegionArray *GetRegionArray(int level);
+		ARegionArray *get_first_region_array_of_type(int type);
 
 		int numberofgates;
 		int numLevels;
@@ -503,6 +504,7 @@ class ARegionList
 		ARegion *FindConnectedRegions(ARegion *r, ARegion *tail, int shaft);
 		ARegion *FindNearestStartingCity(ARegion *r, int *dir);
 		int FindDistanceToNearestObject(int object, ARegion *r);
+		int find_distance_between_regions(ARegion *start, ARegion *target);
 		void FixUnconnectedRegions();
 		void InitSetupGates(int level);
 		void FinalSetupGates();

--- a/game.cpp
+++ b/game.cpp
@@ -53,6 +53,7 @@ Game::Game()
 	ppUnits = 0;
 	maxppunits = 0;
 	events = new Events();
+	rulesetSpecificData = json::object();
 
 	if (Globals->FACTION_ACTIVITY == FactionActivityRules::DEFAULT)
 	{

--- a/game.h
+++ b/game.h
@@ -34,6 +34,12 @@ class Game;
 #include "object.h"
 #include "events.h"
 
+#include "external/nlohmann/json.hpp"
+using json = nlohmann::json;
+
+#include <map>
+#include <string>
+
 #define CURRENT_ATL_VER MAKE_ATL_VER(5, 2, 5)
 
 class OrdersCheck
@@ -321,6 +327,11 @@ private:
 	int doExtraInit;
 
 	Events *events;
+
+	// We need some way to track game specific data that can be used globally
+	// (specifically added for testing of NO7 victory conditions, but generally
+	// useful).  I use json here so that it can store arbitrary data in a structured way.
+	json rulesetSpecificData;
 
 	//
 	// Parsing functions

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -3731,15 +3731,26 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 		f << enclose("p", true) << "Annihilate a region and the neighboring regions.  An annihilated region will be "
 		  << "converted into barren land, and all units and all structures except for shafts and anomalies in the "
 		  << "regions will be destroyed.  The neighboring regions will also be annihilated.  The region to be "
-		  << "annihilated must be specified by coordinates.  If the Z coordinate is not specified, it is assumed "
-		  << "to be on the same level as the unit issuing the order. This order may only be issued by a unit which "
-		  << "has access to the ANNIHILATE [ANNI] skill. This skill cannot target or affect regions which are "
-		  << "already barren, nor can it target the Nexus.\n";
+		  << "annihilated must be specified by coordinates.";
+
+		RangeType *rt = FindRange("rng_annihilate");
+		if (rt->flags & RangeType::RNG_SURFACE_ONLY) {
+			f << " The Z coordinate, if specified, is ignored as this skill may only target the surface.";
+		} else {
+			f << " If the Z coordinate is not specified, it is assumed to be on the same level as the unit "
+			  << "issuing the order.";
+		}
+		f << " This order may only be issued by a unit which has access to the ANNIHILATE [ANNI] skill. "
+		  << "This skill cannot target or affect regions which are already barren, nor can it target the Nexus.\n";
 		f << enclose("p", false);
 		f << enclose("p", true) << "Example:\n" << enclose("p", false);
 		f << example_start("Annihilate the region located at coordinates <5, 5> on the surface.")
-		  << "ANNIHILATE REGION 5 5 1\n"
-		  << example_end();
+		  << "ANNIHILATE REGION 5 5 1\n";
+		if (rt->flags & RangeType::RNG_SURFACE_ONLY) {
+		  f << " or\n"
+		  	<< "ANNIHILATE REGION 5 5\n";
+		}
+		f << example_end();
 	}
 
 	if (Globals->USE_WEAPON_ARMOR_COMMAND) {

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -43,28 +43,23 @@ using namespace std;
 #define QUEST_SPAWN_CHANCE		70
 #define MAX_DESTINATIONS		5
 
-// If this is set to true, then the game will end if a faction has > 50% of all cities in the game with their id
-// in the name.
-#define CITY_VOTE_WIN false
-// If this is true, then anomolies will be spawned after turn 50.  Game will end when all living factions are aligned
-// with the owner of the world-breaker monolith or all land has been destroyed.
-#define ANNIHILATION_WIN true
-
 int Game::SetupFaction( Faction *pFac )
 {
-
 	// Check if a faction can be started due to end game conditions
-	if (ANNIHILATION_WIN) {
-		// Find the center of the underworld
-		ARegionArray *underworld = regions.GetRegionArray(ARegionArray::LEVEL_UNDERWORLD);
-		ARegion *center = underworld->GetRegion(underworld->x / 2, underworld->y / 2);
-		// See if the monolith is active and owned.
-		for(const auto o : center->objects) {
-			if (o->type != O_ACTIVE_MONOLITH) continue;
-			if (o->GetOwner() != nullptr) {
-				return 0;
+	if(rulesetSpecificData.value("victory_type", "") == "annihilation") {
+		ARegionArray *surface = regions.get_first_region_array_of_type(ARegionArray::LEVEL_SURFACE);
+		ARegion *surface_center = surface->GetRegion(surface->x / 2, surface->y / 2);
+
+		int count = 0;
+		for (int i = 0; i < 6; i++) {
+			ARegion *r = surface_center->neighbors[i];
+			// search that region for an altar
+			for(const auto o : r->objects) {
+				if (o->type == O_EMPOWERED_ALTAR) count++;
 			}
 		}
+		// if all altars to the center are empowered, then factions cannot be started
+		if (count == 6) return 0;
 	}
 
 	pFac->unclaimed = Globals->START_MONEY + TurnNumber() * 300;
@@ -393,6 +388,125 @@ static void CreateQuest(ARegionList& regions, int monfaction)
 		quests.push_back(q);
 }
 
+// Just a quick function to count the number of empowered altars.
+int report_and_count_empowered_altars(ARegionList& regions, std::list<Faction *>& factions) {
+	ARegionArray *surface = regions.get_first_region_array_of_type(ARegionArray::LEVEL_SURFACE);
+	ARegion *surface_center = surface->GetRegion(surface->x / 2, surface->y / 2);
+
+	int count = 0;
+	for (int i = 0; i < 6; i++) {
+		ARegion *r = surface_center->neighbors[i];
+		// search that region for an altar
+		for(const auto o : r->objects) {
+			if (o->type == O_EMPOWERED_ALTAR) {
+				count++;
+				for(const auto f : factions) {
+					if (f->is_npc) continue;
+					f->event("The altar in " + string(r->ShortPrint().const_str()) + " is fully empowered.",
+						"anomaly", r);
+				}
+			}
+		}
+	}
+	return count;
+}
+
+void empower_random_altar(ARegionList& regions, std::list<Faction *>& factions) {
+	ARegionArray *surface = regions.get_first_region_array_of_type(ARegionArray::LEVEL_SURFACE);
+	ARegion *surface_center = surface->GetRegion(surface->x / 2, surface->y / 2);
+
+	std::vector<Object *> unempowered_altars;
+	for (int i = 0; i < 6; i++) {
+		ARegion *r = surface_center->neighbors[i];
+		// search that region for an altar
+		for(const auto o : r->objects) {
+			if (o->type == O_RITUAL_ALTAR) unempowered_altars.push_back(o);
+		}
+	}
+	// pick a random altar to empower
+	int num = getrandom(unempowered_altars.size());
+	Object *o = unempowered_altars[num];
+	o->type = O_EMPOWERED_ALTAR;
+	string name = string(ObjectDefs[O_EMPOWERED_ALTAR].name) + " [" + to_string(o->num) + "]";
+	o->name = new AString(name);
+	// notify all factions.
+	for(const auto f : factions) {
+		if (f->is_npc) continue;
+		f->event("The altar in " + string(o->region->ShortPrint().const_str()) + " is fully empowered.",
+			"anomaly", o->region);
+	}
+
+	// find all current anomalies and entities
+	std::vector<Object *> anomalies;
+	std::vector<Unit *> entities;
+	for(const auto r : regions) {
+		for(const auto o : r->objects) {
+			if (o->type == O_ENTITY_CAGE) anomalies.push_back(o);
+
+			for(const auto u : o->units) {
+				int i = u->items.GetNum(I_IMPRISONED_ENTITY);
+				for(int j = 0; j < i; j++) {
+					// put a unit in multiple times if it has multiple entities
+					entities.push_back(u);
+				}
+			}
+		}
+	}
+	if (anomalies.size() + entities.size() < unempowered_altars.size()) {
+		// We have unspawend entities and anomalies, so just return without removing one.
+		return;
+	}
+	// If we have any anomalies, remove the one farthest from the center.
+	if (anomalies.size() > 0) {
+		int max_dist = 0;
+		Object *far_anomaly = nullptr;
+		for (auto& anomaly : anomalies) {
+			int dist = regions.find_distance_between_regions(anomaly->region, surface_center);
+			if (dist > max_dist) {
+				max_dist = dist;
+				far_anomaly = anomaly;
+			}
+		}
+		if (far_anomaly) {
+			// remove the farthest anomaly
+			// Just in case, move any units in the anomaly.
+			for(const auto u : far_anomaly->units) u->MoveUnit(far_anomaly->region->GetDummy());
+
+			std::erase(far_anomaly->region->objects, far_anomaly);
+			delete far_anomaly;
+
+			// Notify any factions in that region that the anomaly has been removed.
+			auto reg_faction = far_anomaly->region->PresentFactions();
+			for(const auto f : reg_faction) {
+				if (f->is_npc) continue;
+				f->event("The anomaly in " + string(far_anomaly->region->ShortPrint().const_str()) + " vanishes.",
+					"anomaly", far_anomaly->region);
+			}
+			return;
+		}
+	}
+	// Ok, we couldn't remove any anomalies, so remove the farthest entity instead.
+	if (entities.size() > 0) {
+		int max_dist = 0;
+		Unit *far_entity = nullptr;
+		for (auto& entity : entities) {
+			int dist = regions.find_distance_between_regions(entity->object->region, surface_center);
+			if (dist > max_dist) {
+				max_dist = dist;
+				far_entity = entity;
+			}
+		}
+		if (far_entity) {
+			far_entity->items.SetNum(I_IMPRISONED_ENTITY, far_entity->items.GetNum(I_IMPRISONED_ENTITY) - 1);
+			far_entity->event(ItemString(I_IMPRISONED_ENTITY, 1) + " vanishes suddenly.", "anomaly");
+			return;
+		}
+	}
+	// We somehow got here without removing anything, so just return.
+	return;
+}
+
+
 int report_and_count_anomalies(ARegionList& regions, std::list<Faction *>& factions) {
 	int count = 0;
 	for(const auto r : regions) {
@@ -414,14 +528,6 @@ int report_and_count_entities(ARegionList& regions, std::list<Faction *>& factio
 	int count = 0;
 	for(const auto r : regions) {
 		for(const auto o : r->objects) {
-			if (o->type == O_EMPOWERED_ALTAR) {
-				count++;
-				for(const auto f : factions) {
-					if (f->is_npc) continue;
-					f->event("The altar in " + string(r->ShortPrint().const_str()) + " is fully empowered.",
-						"anomaly", r);
-				}
-			}
 			for(const auto u : o->units) {
 				if (u->items.GetNum(I_IMPRISONED_ENTITY) > 0) {
 					count += u->items.GetNum(I_IMPRISONED_ENTITY);
@@ -752,8 +858,7 @@ Faction *Game::CheckVictory()
 	}
 	for(const auto& q: questsWithProblems) quests.erase(q);
 
-	// Check for victory conditions based on the current game
-	if (CITY_VOTE_WIN) {
+	if(rulesetSpecificData.value("victory_type", "") == "city_vote") {
 		std::map <int, int> votes; // track votes per faction id
 		int total_cities = 0; // total cities possible for vote count
 
@@ -827,19 +932,31 @@ Faction *Game::CheckVictory()
 	}
 
 	// Check for victory conditions for the annihilation win
-	if (ANNIHILATION_WIN) {
+	if(rulesetSpecificData.value("victory_type", "") == "annihilation") {
 		// before turn 50 none of the end game code will be active.
 		if (TurnNumber() < 50) return nullptr;
+
+		int empowered_altars = report_and_count_empowered_altars(regions, factions);
+		// If we have hit turn 70, rather than spawning a new anomaly, we will activate a random altar and if
+		// needed, destroy a randomly chosen entity.
+		if (TurnNumber() >= 70 && empowered_altars < 6) {
+			empower_random_altar(regions, factions);
+			empowered_altars++;
+		}
+
+		int entities = report_and_count_entities(regions, factions);
+		int anomalies = report_and_count_anomalies(regions, factions);
+
+		int completed_entities = empowered_altars + entities;
 
 		// This function will count the number of entities in the game + number of activated altars.
 		// If this number is < 6, then we have a chance of spawning a new anomaly.  This chance starts at 10%
 		// for the first anomaly after turn 50 and then increases by 12% for each entity or active altar already
 		// existing.
-		int completed_entities = report_and_count_entities(regions, factions);
 		if (completed_entities < 6) {
 			int chance = 10 + (completed_entities * 12);
-			int anomalies = report_and_count_anomalies(regions, factions);
-			Awrite(AString("Endgame: entities: ") + completed_entities + ", anomalies: " + anomalies + ", chance: " + chance + "%");
+			Awrite(AString("Endgame: entities: ") + completed_entities + ", anomalies: " + anomalies +
+				", chance: " + chance + "%");
 			if (getrandom(100) < chance) {
 				// Okay, let's see if we can spawn a new entity
 				// If we can, see if we already have those anomalies and report them to all factions if so.
@@ -851,7 +968,7 @@ Faction *Game::CheckVictory()
 				// Ok, we can spawn a new anomaly.  Let's do it.
 				// We want a random land hex that is not a city and that does not have an anomaly and is not guarded.
 				ARegion *r = nullptr;
-				ARegionArray *surface = regions.GetRegionArray(ARegionArray::LEVEL_SURFACE);
+				ARegionArray *surface = regions.get_first_region_array_of_type(ARegionArray::LEVEL_SURFACE);
 				while (r == nullptr) {
 					r = (ARegion *)surface->GetRegion(getrandom(surface->x), getrandom(surface->y));
 					if (r == nullptr) continue;
@@ -908,25 +1025,37 @@ Faction *Game::CheckVictory()
 			if (o->type == O_ACTIVE_MONOLITH) {
 				Unit *owner = o->GetOwner();
 				// If noone owns the monolith, then noone can win.
-				if (!owner) return nullptr;
+				if (!owner) {
+					// If the monolith is unowned on turn 100 or later, the monsters win.
+					if (TurnNumber() < 100) return nullptr; // no winner yet
+					return GetFaction(factions, monfaction); // monsters win
+				}
 
 				winner = owner->faction;
 				break;
 			}
 		}
 
-		// Ok, we have a possible winner, check for all alive factions being allied with the winner and vice-versa.
-		bool all_allied = true;
-		for (const auto f : factions) {
+		// Ok, we have a possible winner, check for sufficient alive factions mutually allied to the monolith owner.
+		int allied_count = 0;
+		int total_factions = 0;
+		for(const auto f : factions) {
 			if (f->is_npc) continue;
 			if (f == winner) continue;
-			// This faction doesn't have the winner as an ally, so no win by allies
-			if (f->get_attitude(winner->num) != A_ALLY) { all_allied = false; break; }
-			// The winner doesn't have this faction as an ally, so no win by allies
-			if (winner->get_attitude(f->num) != A_ALLY) { all_allied = false; break; }
+			total_factions++;
+			// This faction is not allied to the monolith owner, so they don't count
+			if (f->get_attitude(winner->num) != A_ALLY) continue;
+			// The winner is not allied to this faction, so they don't count;
+			if (winner->get_attitude(f->num) != A_ALLY) continue;
+			allied_count++;
 		}
-		// We had everyone allied to the monolith owner, so they win.
-		if (all_allied) return winner;
+
+		int needed_percent = rulesetSpecificData.value("allied_percent", 100);
+		int current_percent = (allied_count * 100) / total_factions;
+		if (current_percent >= needed_percent) {
+			// We have enough factions allied to the monolith owner, so they win.
+			return winner;
+		}
 
 		// No winner yet, so check if the surface has been completely destroyed.
 		int total_surface = 0;
@@ -936,9 +1065,15 @@ Faction *Game::CheckVictory()
 			total_surface++;
 			if (TerrainDefs[r->type].flags & TerrainType::ANNIHILATED) total_annihilated++;
 		}
-		// The entire surface has not been destroyed, so no winner yet.
-		if (total_surface != total_annihilated) winner = nullptr;
-		return winner;
+
+		int needed_surface = rulesetSpecificData.value("annihilate_percent", 100);
+		int current_surface = (total_annihilated * 100) / total_surface;
+		if (current_surface >= needed_surface) {
+			// The surface has been sufficiently destroyed, so the monolith owner wins.
+			return winner;
+		}
+		// No winner yet, so clear the potential winner and return null.
+		winner = nullptr;
 	}
 
 	return winner;
@@ -1441,6 +1576,7 @@ void Game::ModifyTablesPerRuleset(void)
 	EnableObject(O_ACTIVE_MONOLITH);
 	EnableItem(I_IMPRISONED_ENTITY);
 	EnableSkill(S_ANNIHILATION);
+	ModifyRangeFlags("rng_annihilate", RangeType::RNG_SURFACE_ONLY | RangeType::RNG_CROSS_LEVELS);
 
 	// Weapon BM example
 
@@ -1450,11 +1586,23 @@ void Game::ModifyTablesPerRuleset(void)
 	// At the same time give SPEA bonus of 2 on attacka and 2 on defense vs. SWOR
 	// ModifyWeaponBonusMalus("SPEA", 0, "SWOR", 2, 2);
 
+	// set up game specific tracked data
+	rulesetSpecificData.clear();
+
+	// this set is for the NO7 annihilation win condition
+	rulesetSpecificData["victory_type"] = "annihilation";
+	rulesetSpecificData["allowed_annihilates"] = 3;
+	rulesetSpecificData["allied_percent"] = 50;
+	rulesetSpecificData["annihilate_percent"] = 10;
+	rulesetSpecificData["random_annihilates"] = true;
+
+	// this set is for the city vote win condition, not active for NO7
+	// rulesetSpecificData["victory_type"] = "city_vote";
 	return;
 }
 
-const char *ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin, ARegionList& regs) {
-	ARegionArray *surface = regs.GetRegionArray(ARegionArray::LEVEL_SURFACE);
+const char *ARegion::movement_forbidden_by_ruleset(Unit *u, ARegion *origin, ARegionList& regions) {
+	ARegionArray *surface = regions.get_first_region_array_of_type(ARegionArray::LEVEL_SURFACE);
 	ARegion *surface_center = surface->GetRegion(surface->x / 2, surface->y / 2);
 
 	ARegionArray *this_level = this->level;

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -3076,7 +3076,6 @@ void Game::ProcessAnnihilateOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	int x = -1;
 	int y = -1;
 	int z = unit->object->region->zloc;
-	RangeType *range = FindRange(SkillDefs[S_ANNIHILATION].range);
 
 	if (!token) {
 		parse_error(pCheck, unit, 0, "ANNIHILATE: No region specified.");
@@ -3105,7 +3104,13 @@ void Game::ProcessAnnihilateOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 	y = token->value();
 	delete token;
 
-	if (range && (range->flags & RangeType::RNG_CROSS_LEVELS)) {
+
+	RangeType *range = FindRange(SkillDefs[S_ANNIHILATION].range);
+	if (range->flags & RangeType::RNG_SURFACE_ONLY) {
+		z = (Globals->NEXUS_EXISTS ? 1 : 0);
+	}
+
+	if (range && (range->flags & RangeType::RNG_CROSS_LEVELS) && !(range->flags & RangeType::RNG_SURFACE_ONLY)) {
 		token = o->gettoken();
 		if (token) {
 			z = token->value();
@@ -3122,7 +3127,6 @@ void Game::ProcessAnnihilateOrder(Unit *unit, AString *o, OrdersCheck *pCheck)
 		order->xloc = x;
 		order->yloc = y;
 		order->zloc = z;
-		if (unit->annihilateorders) delete unit->annihilateorders;
-		unit->annihilateorders = order;
+		unit->annihilateorders.push_back(order);
 	}
 }

--- a/skillshows.cpp
+++ b/skillshows.cpp
@@ -1463,14 +1463,32 @@ AString *ShowSkill::Report(Faction *f) const
 			break;
 		case S_ANNIHILATION:
 			if (level > 1) break;
+			range = FindRange(SkillDefs[skill].range);
 			*str += "A unit with access to the Annihilation skill may destroy a region and all "
 				"surrounding regions.  Regions destroyed in this way will become barren.  All units "
 				"and structures except for shafts and anomalies in the region and the surrounding regions "
-				"will be destroyed as will production and cities.  This skill is only available to the unit "
-				"which controls the World-breaker Monolith.  To use this skill, the owner of the "
-				"World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z "
-				"coordinate is not specified, it will default to the same z coordinate as the region "
-				"containing the World-breaker Monolith.";
+				"will be destroyed as will production and cities.";
+			if (!(ObjectDefs[O_ACTIVE_MONOLITH].flags & ObjectType::DISABLED)) {
+				if (ObjectDefs[O_ACTIVE_MONOLITH].flags & ObjectType::GRANTSKILL) {
+					*str += " This skill is only available to the unit which controls the World-breaker Monolith. "
+						"To use this skill, the owner of the World-breaker Monolith ";
+				}
+			} else {
+				*str += " To use this skill, the unit ";
+			}
+			*str += "must issue the order ANNIHILATE REGION <x> <y>";
+			if (range && range->flags & RangeType::RNG_SURFACE_ONLY) {
+				*str += ".";
+			} else {
+				*str += " <z>. If the z coordinate is not specified, it will default to the same z coordinate as "
+					"the unit utilizing the skill.";
+			}
+
+			if (range && range->flags & RangeType::RNG_SURFACE_ONLY) {
+				*str += " This skill can only target a region on the surface of the world.";
+			} else {
+				*str += " This skill can target a region anywhere in the world.";
+			}
 			break;
 	}
 

--- a/snapshot-tests/neworigins_turns/turn_0/report.1
+++ b/snapshot-tests/neworigins_turns/turn_0/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_0/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_0/report.1.json
@@ -25874,7 +25874,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_1/report.1
+++ b/snapshot-tests/neworigins_turns/turn_1/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_1/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_1/report.1.json
@@ -25917,7 +25917,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_10/report.1
+++ b/snapshot-tests/neworigins_turns/turn_10/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_10/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_10/report.1.json
@@ -26311,7 +26311,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_11/report.1
+++ b/snapshot-tests/neworigins_turns/turn_11/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_11/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_11/report.1.json
@@ -26446,7 +26446,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_12/report.1
+++ b/snapshot-tests/neworigins_turns/turn_12/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_12/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_12/report.1.json
@@ -26740,7 +26740,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_13/report.1
+++ b/snapshot-tests/neworigins_turns/turn_13/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_13/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_13/report.1.json
@@ -26919,7 +26919,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_2/report.1
+++ b/snapshot-tests/neworigins_turns/turn_2/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_2/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_2/report.1.json
@@ -25994,7 +25994,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_3/report.1
+++ b/snapshot-tests/neworigins_turns/turn_3/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_3/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_3/report.1.json
@@ -26145,7 +26145,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_4/report.1
+++ b/snapshot-tests/neworigins_turns/turn_4/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_4/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_4/report.1.json
@@ -26230,7 +26230,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_5/report.1
+++ b/snapshot-tests/neworigins_turns/turn_5/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_5/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_5/report.1.json
@@ -26255,7 +26255,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_6/report.1
+++ b/snapshot-tests/neworigins_turns/turn_6/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_6/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_6/report.1.json
@@ -26280,7 +26280,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_7/report.1
+++ b/snapshot-tests/neworigins_turns/turn_7/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_7/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_7/report.1.json
@@ -26280,7 +26280,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_8/report.1
+++ b/snapshot-tests/neworigins_turns/turn_8/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_8/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_8/report.1.json
@@ -26221,7 +26221,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/neworigins_turns/turn_9/report.1
+++ b/snapshot-tests/neworigins_turns/turn_9/report.1
@@ -1731,14 +1731,12 @@ annihilation [ANNI] 1: A unit with access to the Annihilation skill
   may destroy a region and all surrounding regions.  Regions destroyed
   in this way will become barren.  All units and structures except for
   shafts and anomalies in the region and the surrounding regions will
-  be destroyed as will production and cities.  This skill is only
-  available to the unit which controls the World-breaker Monolith.  To
+  be destroyed as will production and cities. This skill is only
+  available to the unit which controls the World-breaker Monolith. To
   use this skill, the owner of the World-breaker Monolith must issue
-  the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is
-  not specified, it will default to the same z coordinate as the
-  region containing the World-breaker Monolith. This skill cannot be
-  studied via normal means. This skill cannot be taught to other
-  units.
+  the order ANNIHILATE REGION <x> <y>. This skill can only target a
+  region on the surface of the world. This skill cannot be studied via
+  normal means. This skill cannot be taught to other units.
 
 annihilation [ANNI] 2: This skill cannot be studied via normal means.
   This skill cannot be taught to other units.

--- a/snapshot-tests/neworigins_turns/turn_9/report.1.json
+++ b/snapshot-tests/neworigins_turns/turn_9/report.1.json
@@ -26266,7 +26266,7 @@
       "tag": "TRNS"
     },
     {
-      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities.  This skill is only available to the unit which controls the World-breaker Monolith.  To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y> <z>.   If the z coordinate is not specified, it will default to the same z coordinate as the region containing the World-breaker Monolith. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
+      "description": "A unit with access to the Annihilation skill may destroy a region and all surrounding regions.  Regions destroyed in this way will become barren.  All units and structures except for shafts and anomalies in the region and the surrounding regions will be destroyed as will production and cities. This skill is only available to the unit which controls the World-breaker Monolith. To use this skill, the owner of the World-breaker Monolith must issue the order ANNIHILATE REGION <x> <y>. This skill can only target a region on the surface of the world. This skill cannot be studied via normal means. This skill cannot be taught to other units.",
       "level": 1,
       "name": "annihilation",
       "tag": "ANNI"

--- a/snapshot-tests/rules/neworigins.html
+++ b/snapshot-tests/rules/neworigins.html
@@ -5337,11 +5337,11 @@ ADVANCE N 1 IN SE
       will be converted into barren land, and all units and all structures
       except for shafts and anomalies in the regions will be destroyed.  The
       neighboring regions will also be annihilated.  The region to be
-      annihilated must be specified by coordinates.  If the Z coordinate is
-      not specified, it is assumed to be on the same level as the unit issuing
-      the order. This order may only be issued by a unit which has access to
-      the ANNIHILATE [ANNI] skill. This skill cannot target or affect regions
-      which are already barren, nor can it target the Nexus.
+      annihilated must be specified by coordinates. The Z coordinate, if
+      specified, is ignored as this skill may only target the surface. This
+      order may only be issued by a unit which has access to the ANNIHILATE
+      [ANNI] skill. This skill cannot target or affect regions which are
+      already barren, nor can it target the Nexus.
     </p>
     <p>
       Example:
@@ -5354,6 +5354,8 @@ ADVANCE N 1 IN SE
     </p>
     <pre>
 ANNIHILATE REGION 5 5 1
+ or
+ANNIHILATE REGION 5 5
     </pre>
     <div class="rule">
       

--- a/unit.cpp
+++ b/unit.cpp
@@ -79,7 +79,6 @@ Unit::Unit()
 	monthorders = nullptr;
 	castorders = nullptr;
 	sacrificeorders = nullptr;
-	annihilateorders = nullptr;
 	teleportorders = nullptr;
 	joinorders = nullptr;
 	inTurnBlock = 0;
@@ -127,7 +126,6 @@ Unit::Unit(int seq, Faction *f, int a)
 	teleportorders = nullptr;
 	joinorders = nullptr;
 	sacrificeorders = nullptr;
-	annihilateorders = nullptr;
 	inTurnBlock = 0;
 	presentTaxing = 0;
 	presentMonthOrders = nullptr;

--- a/unit.h
+++ b/unit.h
@@ -47,6 +47,7 @@ class UnitId;
 #include "object.h"
 #include <set>
 #include <string>
+#include <list>
 
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
@@ -294,7 +295,7 @@ class Unit {
 		AttackOrder *attackorders;
 		EvictOrder *evictorders;
 		SacrificeOrder *sacrificeorders;
-		AnnihilateOrder *annihilateorders;
+		std::list<AnnihilateOrder *>annihilateorders;
 		ARegion *advancefrom;
 
 		std::list<ExchangeOrder *> exchangeorders;

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -175,3 +175,7 @@ void UnitTestHelper::enable(Type type, int id, bool enable) {
 void UnitTestHelper::maintain_units() {
     game.AssessMaintenance();
 }
+
+void UnitTestHelper::set_ruleset_specific_data(const json &data) {
+    game.rulesetSpecificData = data;
+}

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -84,6 +84,8 @@ public:
     void run_sacrifice();
     // Run annihilation orders
     void run_annihilation();
+    // Enable ruleset specific data for testing
+    void set_ruleset_specific_data(const json &data);
 
     // dummy
     int get_seed() { return getrandom(10000); };


### PR DESCRIPTION
There was some discussion about factions deliberately trying to stall the game into a never-ending state.  Changes have been made which should prevent that.

This also adds a facility that will hopefully get used more in the future to allow ruleset specific data to affect functions in the main game without needing to create duplicate overridden code.  See the rulesetSpecificData member of game, and the use of it in neworigins/extra.cpp and in the runorders.cpp for RunAnnihilationOrders