### PR TITLE
Two more small bugfixes.

### DIFF
--- a/game.h
+++ b/game.h
@@ -586,6 +586,7 @@ private:
 	void Do1TeachOrder(ARegion *, Unit *);
 	void RunProduceOrders(ARegion *);
 	void RunIdleOrders(ARegion *);
+	int consume_production_inputs(Unit *u, int item, int maxproduced);
 	int ValidProd(Unit *, ARegion *, Production *);
 	int FindAttemptedProd(ARegion *, Production *);
 	void RunAProduction(ARegion *, Production *);

--- a/spells.cpp
+++ b/spells.cpp
@@ -1686,8 +1686,13 @@ int Game::RunTeleport(ARegion *r,Object *o,Unit *u)
 
 	// Presume they had to open the portal to see if target is ocean
 	if (TerrainDefs[tar->type].similar_type == R_OCEAN) {
-		u->error(string("CAST: ") + tar->Print().const_str() + " is an ocean.");
-		return 1;
+		// If the unit has enough capacity to swim in the ocean, let them teleport there.
+		// We use CanReallySwim rather than CanSwim because the latter also allows flying
+		// units which would break the 'flying units must end on land' rule.
+		if (!u->CanReallySwim()) {
+			u->error(string("CAST: ") + tar->Print().const_str() + " is ocean.");
+			return 1;
+		}
 	}
 	u->DiscardUnfinishedShips();
 	u->event("Teleports to " + string(tar->Print().const_str()) + ".", "spell");

--- a/unittest/produce_test.cpp
+++ b/unittest/produce_test.cpp
@@ -1,0 +1,88 @@
+#include "external/boost/ut.hpp"
+
+#include "game.h"
+#include "gamedata.h"
+#include "testhelper.hpp"
+
+// Because boost::ut has it's own concept of events, as does Game, we cannot just use do
+// using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
+// closure to make the user defined literals and all the other niceness available.
+namespace ut = boost::ut;
+
+// This suite will test various aspects of the Faction class in isolation.
+ut::suite<"Produce"> produce_suite = []
+{
+  using namespace ut;
+
+  "Producing an item with ORed inputs consumes personal items first"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+    helper.enable(UnitTestHelper::Type::ITEM, I_FOOD, true);
+    helper.enable(UnitTestHelper::Type::SKILL, S_COOKING, true);
+
+    std::string name = "Test Faction";
+    Faction *faction = helper.create_faction(name);
+    Unit *unit = helper.get_first_unit(faction);
+    unit->items.SetNum(I_LEADERS, 10); // 10 men so we can produce up to 10 meals/month
+    unit->Study(S_COOKING, 300); // study is total days, so this is 30 days per man.
+    unit->items.SetNum(I_LIVESTOCK, 5);
+
+    // We have another unit which has grain.  Bug was the grain would be used before the personal items
+    Unit *unit2 = helper.create_unit(faction, helper.get_region(0, 0, 0));
+    unit2->SetFlag(1, 2);
+    unit2->items.SetNum(I_LEADERS, 1);
+    unit2->items.SetNum(I_GRAIN, 10);
+
+    std::stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "produce 3 meal\n";
+    ss << "unit 3\n";
+    ss << "share 1\n";
+    helper.parse_orders(faction->num, ss);
+    helper.run_productions();
+
+    // Check the results after running the productions
+    expect(unit->items.GetNum(I_FOOD) == 3_i);
+    expect(unit->items.GetNum(I_LIVESTOCK) == 2_i); // 5 - 3 meals = 2 livestock left
+    expect(unit2->items.GetNum(I_GRAIN) == 10_i); // Grain should not be consumed since we used personal items first
+  };
+
+  "Producing an item with ORed inputs consumes shared items if personal items are insufficient"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+    helper.enable(UnitTestHelper::Type::ITEM, I_FOOD, true);
+    helper.enable(UnitTestHelper::Type::SKILL, S_COOKING, true);
+
+    std::string name = "Test Faction";
+    Faction *faction = helper.create_faction(name);
+    Unit *unit = helper.get_first_unit(faction);
+    unit->items.SetNum(I_LEADERS, 10); // 10 men so we can produce up to 10 meals/month
+    unit->Study(S_COOKING, 300); // study is total days, so this is 30 days per man.
+    unit->items.SetNum(I_LIVESTOCK, 5);
+
+    // We have another unit which has grain.  Bug was the grain would be used before the personal items
+    Unit *unit2 = helper.create_unit(faction, helper.get_region(0, 0, 0));
+    unit2->SetFlag(1, 2);
+    unit2->items.SetNum(I_LEADERS, 1);
+    unit2->items.SetNum(I_GRAIN, 10);
+
+    std::stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "produce 6 meal\n";
+    ss << "unit 3\n";
+    ss << "share 1\n";
+    helper.parse_orders(faction->num, ss);
+    helper.run_productions();
+
+    // Check the results after running the productions
+    expect(unit->items.GetNum(I_FOOD) == 6_i);
+    expect(unit->items.GetNum(I_LIVESTOCK) == 0_i); // no livestock left
+    expect(unit2->items.GetNum(I_GRAIN) == 9_i); // 1 grain used from shared.
+  };
+};

--- a/unittest/spell_test.cpp
+++ b/unittest/spell_test.cpp
@@ -99,4 +99,106 @@ ut::suite<"Spells"> spell_suite = []
     expect(count == 0_ul);
   };
 
+  "Unit which cannot swim cannot teleport to ocean"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    std::string name = "Test Faction";
+    Faction *faction = helper.create_faction(name);
+    ARegion *region = helper.get_region(1, 1, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    leader->Study(S_PATTERN, 90);
+    leader->Study(S_SPIRIT, 90);
+    leader->Study(S_FARSIGHT, 90);
+    leader->Study(S_GATE_LORE, 30);
+    leader->Study(S_TELEPORTATION, 30);
+
+    region->type = R_LAKE; // Use something that is similar_type to ocean
+
+    std::stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "cast teleportation REGION 1 1\n";
+    helper.parse_orders(faction->num, ss);
+    helper.activate_spell(S_TELEPORTATION, {
+        .region = region, .unit = leader, .object = nullptr, .val1 = 0, .val2 = 0
+    });
+
+    expect(leader->object->region != region); // The unit should not have teleported
+    expect(faction->errors.size() == 1_ul); // Expect an error to be generated
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Expect that we get an error message in the report.
+    auto count = json_report["errors"].size();
+    expect(count == 1_ul);
+    json error = json_report["errors"][0];
+    expect(error["message"] == "CAST: lake (1,1) in Testing Wilds is ocean.");
+    expect(error["unit"]["number"] == 2_i);
+  };
+
+  "Unit which can swim can teleport to ocean"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    std::string name = "Test Faction";
+    Faction *faction = helper.create_faction(name);
+    ARegion *region = helper.get_region(1, 1, 0);
+    Unit *leader = helper.get_first_unit(faction);
+    AString *tmp_name = new AString("My Leader");
+    leader->SetName(tmp_name);
+    leader->Study(S_PATTERN, 90);
+    leader->Study(S_SPIRIT, 90);
+    leader->Study(S_FARSIGHT, 90);
+    leader->Study(S_GATE_LORE, 30);
+    leader->Study(S_TELEPORTATION, 30);
+    leader->items.SetNum(I_MCARPET, 1); // Give the unit an item that allows swimming
+
+    region->type = R_LAKE; // Use something that is similar_type to ocean
+
+    std::stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    ss << "cast teleportation REGION 1 1\n";
+    helper.parse_orders(faction->num, ss);
+    helper.activate_spell(S_TELEPORTATION, {
+        .region = region, .unit = leader, .object = nullptr, .val1 = 0, .val2 = 0
+    });
+
+    // verify that the unit did teleport
+    expect(leader->object->region == region);
+    expect(faction->errors.size() == 0_ul); // No errors should be generated
+    expect(faction->events.size() == 1_ul); // Expect a teleportation event to be generated
+
+    helper.setup_reports();
+
+    // Generate just this single factions json object.
+    Game &game = helper.game_object();
+    json json_report;
+    faction->build_json_report(json_report, &game, nullptr);
+
+    // Expect that we get no errors in the report.
+    auto count = json_report["errors"].size();
+    expect(count == 0_ul);
+
+    // Check the events to ensure the teleportation was successful
+    auto events = json_report["events"];
+    expect(events.size() == 1_ul); // Expect a single event for the teleportation
+    json event = events[0];
+    expect(event["message"] == "Teleports to lake (1,1) in Testing Wilds."); // Check the message for correctness
+    expect(event["unit"]["number"] == 2_i); // Check the unit number in the even
+    expect(event["category"] == "spell"); // Check the category of the event
+  };
+
 };

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -137,6 +137,18 @@ void UnitTestHelper::collect_transported_goods() {
     game.CollectInterQMTransportItems();
 }
 
+void UnitTestHelper::run_month_orders() {
+    // This will run all month long orders, which includes study, production, build, etc.
+    game.RunMonthOrders();
+}
+
+void UnitTestHelper::run_productions() {
+    // This will run the production phase for all regions in the game.
+    for (auto &region : game.regions) {
+        game.RunProduceOrders(region); // This will run the produce orders for each region.
+    }
+}
+
 void UnitTestHelper::activate_spell(int spell, SpellTestHelper helper) {
     // This is a bit of a hack, but it's the easiest way to get the game object to run the spell, especially since
     // C++ doesn't have actual introspection/reflection and the spell executors take different arguments.   The intent

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -86,6 +86,10 @@ public:
     void run_annihilation();
     // Enable ruleset specific data for testing
     void set_ruleset_specific_data(const json &data);
+    // Run productions
+    void run_productions();
+    // Run all month orders for all factions.
+    void run_month_orders();
 
     // dummy
     int get_seed() { return getrandom(10000); };


### PR DESCRIPTION
- https://github.com/Atlantis-PBEM/Atlantis/issues/190
- https://github.com/Atlantis-PBEM/Atlantis/issues/175

This means that units which have innate swimming capacity (ie, a mage with a magic carpet) will now be able to cast teleport and teleport into an ocean hex if they so desire.  Similarly a unit with sufficient power and turtles, etc).

Also, production of ORinput items (currently the only one is 'MEAL', would consume items in preference of the way the inputs were listed, so if unit A had 5 livestock and cooking, and unit B had 5 grain, when unit A cooked, it would consume unit B's grain before unit A's livestock.

This code changes this and now unit A's items will be consumed in preference and the shared items from other units will only be touched if unit A has insufficient to produce the amount it's trying to produce.
