### PR TITLE
Add merged BUY/SELL orders and BUILD COMPLETE orders.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 120
+
+# Prefer single quotes for languages that support it
+quote_type = single
 
 [*.md]
 max_line_length = off
@@ -16,8 +20,29 @@ trim_trailing_whitespace = false
 [package.json]
 indent_size = 2
 
-[*.yaml]
+[*.{yaml,yml}]
 indent_size = 2
 
-[*.yml]
+# C/C++ specific settings
+[*.{c,cpp,h,hpp}]
+# K&R style bracing for control structures, Allman for classes/structs
+# Note: Most editors need custom config beyond EditorConfig for this
+curly_bracket_next_line = false
+spaces_around_operators = true
+spaces_around_brackets = false
+# int *ptr style (pointer with variable)
+# int& ref style (reference with type)
+# Note: These are hints - many editors need language-specific settings
+
+# JavaScript/TypeScript settings
+[*.{js,ts}]
+quote_type = single
+curly_bracket_next_line = false
+spaces_around_operators = true
+spaces_around_brackets = false
+# Enable trailing commas where supported
+trailing_comma = true
+
+# JSON files
+[*.json]
 indent_size = 2

--- a/astring.cpp
+++ b/astring.cpp
@@ -273,7 +273,7 @@ AString *AString::StripWhite()
 	return( new AString( &str[ place ] ));
 }
 
-int AString::getat()
+bool AString::getat()
 {
 	int place = 0;
 	while (place < len && (str[place] == ' ' || str[place] == '\t'))
@@ -281,9 +281,9 @@ int AString::getat()
 	if (place >= len) return 0;
 	if (str[place] == '@') {
 		str[place] = ' ';
-		return 1;
+		return true;
 	}
-	return 0;
+	return false;
 }
 
 char islegal(char c)

--- a/astring.h
+++ b/astring.h
@@ -60,7 +60,7 @@ public:
 	int Len();
 
 	AString *gettoken();
-	int getat();
+	bool getat();
 	AString *getlegal();
 	AString *stripnumber();
 	AString *Trunc(int, int back=30);

--- a/external/boost/ut.hpp
+++ b/external/boost/ut.hpp
@@ -5,20 +5,23 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#if defined(__cpp_modules) && !defined(BOOST_UT_DISABLE_MODULE)
-export module boost.ut;
-export import std;
+#if defined(BOOST_UT_CXX_MODULES)
 #define BOOST_UT_EXPORT export
 #else
 #pragma once
 #define BOOST_UT_EXPORT
 #endif
 
-#if __has_include(<iso646.h>)
-#include <iso646.h>  // and, or, not, ...
+#if !defined(BOOST_UT_CXX_MODULES)
+#include <version>
 #endif
 
-#include <version>
+#if defined(_MSC_VER)
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+#endif
 // Before libc++ 17 had experimental support for format and it required a
 // special build flag. Currently libc++ has not implemented all C++20 chrono
 // improvements. Therefore doesn't define __cpp_lib_format, instead query the
@@ -51,7 +54,7 @@ export import std;
 #elif not defined(__cpp_static_assert)
 #error "[Boost::ext].UT requires support for static assert";
 #else
-#define BOOST_UT_VERSION 2'0'0
+#define BOOST_UT_VERSION 2'3'1
 
 #if defined(__has_builtin) and defined(__GNUC__) and (__GNUC__ < 10) and \
     not defined(__clang__)
@@ -66,24 +69,26 @@ export import std;
 #define __has_builtin(...) __has_##__VA_ARGS__
 #endif
 
+#if !defined(BOOST_UT_CXX_MODULES)
 #include <algorithm>
 #include <array>
 #include <chrono>
 #include <concepts>
 #include <cstdint>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <sstream>
 #include <stack>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
 #include <vector>
-#include <fstream>
 #if __has_include(<unistd.h>) and __has_include(<sys/wait.h>)
 #include <sys/wait.h>
 #include <unistd.h>
@@ -98,12 +103,13 @@ export import std;
 #if __has_include(<source_location>)
 #include <source_location>
 #endif
+#endif // cxx modules
 
-struct _unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct {
+struct unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_ {
 };
 
 BOOST_UT_EXPORT
-namespace boost::inline ext::ut::inline v2_0_0 {
+namespace boost::inline ext::ut::inline v2_3_1 {
 namespace utility {
 template <class>
 class function;
@@ -231,22 +237,28 @@ template <class T = std::string_view, class TDelim>
   }
   return output;
 }
-constexpr auto regex_match(const char *str, const char *pattern) -> bool {
-  if (*pattern == '\0' && *str == '\0') return true;
-  if (*pattern == '\0' && *str != '\0') return false;
-  if (*str == '\0' && *pattern != '\0') return false;
+constexpr auto regex_match(const char* str, const char* pattern) -> bool {
+  if (*pattern == '\0' && *str == '\0') {
+    return true;
+  }
+  if (*pattern == '\0' && *str != '\0') {
+    return false;
+  }
+  if (*str == '\0' && *pattern != '\0') {
+    return false;
+  }
   if (*pattern == '.') {
-    return regex_match(str+1, pattern+1);
+    return regex_match(str + 1, pattern + 1);
   }
   if (*pattern == *str) {
-    return regex_match(str+1, pattern+1);
+    return regex_match(str + 1, pattern + 1);
   }
   return false;
 }
 }  // namespace utility
 
 namespace reflection {
-#if defined(__cpp_lib_source_location)
+#if defined(__cpp_lib_source_location) && !defined(_LIBCPP_APPLE_CLANG_VER)
 using source_location = std::source_location;
 #else
 class source_location {
@@ -274,7 +286,7 @@ class source_location {
 namespace detail {
 template <typename TargetType>
 [[nodiscard]] constexpr auto get_template_function_name_use_type()
-    -> const std::string_view {
+    -> std::string_view {
 // for over compiler need over macros
 #if defined(_MSC_VER) && !defined(__clang__)
   return {&__FUNCSIG__[0], sizeof(__FUNCSIG__)};
@@ -286,40 +298,40 @@ template <typename TargetType>
 // decay allows you to highlight a cleaner name
 template <typename TargetType>
 [[nodiscard]] constexpr auto get_template_function_name_use_decay_type()
-    -> const std::string_view {
+    -> std::string_view {
   return get_template_function_name_use_type<std::decay_t<TargetType>>();
 }
 
 inline constexpr const std::string_view raw_type_name =
     get_template_function_name_use_decay_type<
-        _unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct>();
+        unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_>();
 
 inline constexpr const std::size_t raw_length = raw_type_name.length();
 inline constexpr const std::string_view need_name =
 #if defined(_MSC_VER) and not defined(__clang__)
     "struct "
-    "_unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct";
+    "unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_";
 #else
-    "_unique_name_for_auto_detect_prefix_and_suffix_lenght_0123456789_struct";
+    "unique_name_for_auto_detect_prefix_and_suffix_length_0123456789_struct_";
 #endif
 inline constexpr const std::size_t need_length = need_name.length();
 static_assert(need_length <= raw_length,
-              "Auto find prefix and suffix lenght broken error 1");
+              "Auto find prefix and suffix length broken error 1");
 inline constexpr const std::size_t prefix_length =
     raw_type_name.find(need_name);
 static_assert(prefix_length != std::string_view::npos,
-              "Auto find prefix and suffix lenght broken error 2");
+              "Auto find prefix and suffix length broken error 2");
 static_assert(prefix_length <= raw_length,
-              "Auto find prefix and suffix lenght broken error 3");
-inline constexpr const std::size_t tail_lenght = raw_length - prefix_length;
-static_assert(need_length <= tail_lenght,
-              "Auto find prefix and suffix lenght broken error 4");
-inline constexpr const std::size_t suffix_length = tail_lenght - need_length;
+              "Auto find prefix and suffix length broken error 3");
+inline constexpr const std::size_t tail_length = raw_length - prefix_length;
+static_assert(need_length <= tail_length,
+              "Auto find prefix and suffix length broken error 4");
+inline constexpr const std::size_t suffix_length = tail_length - need_length;
 
 }  // namespace detail
 
 template <typename TargetType>
-[[nodiscard]] constexpr auto type_name() -> const std::string_view {
+[[nodiscard]] constexpr auto type_name() -> std::string_view {
   const std::string_view raw_type_name =
       detail::get_template_function_name_use_type<TargetType>();
   const std::size_t end = raw_type_name.length() - detail::suffix_length;
@@ -330,7 +342,7 @@ template <typename TargetType>
 
 // decay allows you to highlight a cleaner name
 template <typename TargetType>
-[[nodiscard]] constexpr auto decay_type_name() -> const std::string_view {
+[[nodiscard]] constexpr auto decay_type_name() -> std::string_view {
   const std::string_view raw_type_name =
       detail::get_template_function_name_use_decay_type<TargetType>();
   const std::size_t end = raw_type_name.length() - detail::suffix_length;
@@ -454,32 +466,12 @@ struct function_traits<R (T::*)(TArgs...) const> {
   using args = list<TArgs...>;
 };
 
-template <class T>
-T&& declval();
-template <class... Ts, class TExpr>
-constexpr auto is_valid(TExpr expr)
-    -> decltype(expr(declval<Ts...>()), bool()) {
-  return true;
-}
-template <class...>
-constexpr auto is_valid(...) -> bool {
-  return false;
-}
-
-template <class T>
-inline constexpr auto is_container_v =
-    is_valid<T>([](auto t) -> decltype(t.begin(), t.end(), void()) {});
-
-template <class T>
-inline constexpr auto has_user_print = is_valid<T>(
-    [](auto t) -> decltype(void(declval<std::ostringstream&>() << t)) {});
-
 template <class T, class = void>
 struct has_static_member_object_value : std::false_type {};
 
 template <class T>
-struct has_static_member_object_value<T,
-                                      std::void_t<decltype(declval<T>().value)>>
+struct has_static_member_object_value<
+    T, std::void_t<decltype(std::declval<T>().value)>>
     : std::bool_constant<!std::is_member_pointer_v<decltype(&T::value)> &&
                          !std::is_function_v<decltype(T::value)>> {};
 
@@ -492,7 +484,7 @@ struct has_static_member_object_epsilon : std::false_type {};
 
 template <class T>
 struct has_static_member_object_epsilon<
-    T, std::void_t<decltype(declval<T>().epsilon)>>
+    T, std::void_t<decltype(std::declval<T>().epsilon)>>
     : std::bool_constant<!std::is_member_pointer_v<decltype(&T::epsilon)> &&
                          !std::is_function_v<decltype(T::epsilon)>> {};
 
@@ -500,41 +492,20 @@ template <class T>
 inline constexpr bool has_static_member_object_epsilon_v =
     has_static_member_object_epsilon<T>::value;
 
-template <class T>
-inline constexpr auto is_floating_point_v = false;
-template <>
-inline constexpr auto is_floating_point_v<float> = true;
-template <>
-inline constexpr auto is_floating_point_v<double> = true;
-template <>
-inline constexpr auto is_floating_point_v<long double> = true;
-
-#if defined(__clang__) or defined(_MSC_VER)
-template <class From, class To>
-inline constexpr auto is_convertible_v = __is_convertible_to(From, To);
-#else
-template <class From, class To>
-constexpr auto is_convertible(int) -> decltype(bool(To(declval<From>()))) {
-  return true;
-}
-template <class...>
-constexpr auto is_convertible(...) {
-  return false;
-}
-template <class From, class To>
-constexpr auto is_convertible_v = is_convertible<From, To>(0);
-#endif
-
-template <bool>
-struct requires_ {};
-template <>
-struct requires_<true> {
-  using type = int;
-};
-
-template <bool Cond>
-using requires_t = typename requires_<Cond>::type;
 }  // namespace type_traits
+
+namespace concepts {
+
+// std::convertible_to also requires implicit conversion to work
+// See https://stackoverflow.com/a/76547623
+template <class From, class To>
+concept explicitly_convertible_to =
+    requires { static_cast<To>(std::declval<From>()); };
+
+template <class T>
+concept ostreamable = requires(std::ostringstream& os, T t) { os << t; };
+
+}  // namespace concepts
 
 template <typename CharT, std::size_t SIZE>
 struct fixed_string {
@@ -542,8 +513,11 @@ struct fixed_string {
   CharT _data[N + 1] = {};
 
   constexpr explicit(false) fixed_string(const CharT (&str)[N + 1]) noexcept {
-    if constexpr (N != 0)
-      for (std::size_t i = 0; i < N; ++i) _data[i] = str[i];
+    if constexpr (N != 0) {
+      for (std::size_t i = 0; i < N; ++i) {
+        _data[i] = str[i];
+      }
+    }
   }
 
   [[nodiscard]] constexpr std::size_t size() const noexcept { return N; }
@@ -573,6 +547,10 @@ fixed_string(const CharT (&str)[N]) -> fixed_string<CharT, N - 1>;
 struct none {};
 
 namespace events {
+struct run_begin {
+  int argc{};
+  const char** argv{};
+};
 struct test_begin {
   std::string_view type{};
   std::string_view name{};
@@ -591,7 +569,7 @@ struct suite_end {
 template <class Test, class TArg = none>
 struct test {
   std::string_view type{};
-  std::string_view name{};
+  std::string name{};  /// might be dynamic
   std::vector<std::string_view> tag{};
   reflection::source_location location{};
   TArg arg{};
@@ -678,7 +656,7 @@ struct log {
 };
 template <class TMsg = std::string_view>
 log(TMsg) -> log<TMsg>;
-struct fatal_assertion {};
+struct fatal_assertion : std::exception {};
 struct exception {
   const char* msg{};
   [[nodiscard]] auto what() const -> const char* { return msg; }
@@ -694,7 +672,7 @@ struct fatal_;
 
 struct fatal {
   template <class T>
-  [[nodiscard]] inline auto operator()(const T& t) const {
+  [[nodiscard]] auto operator()(const T& t) const {
     return detail::fatal_{t};
   }
 };
@@ -715,22 +693,22 @@ struct cfg {
 #endif
 
   static inline std::string executable_name = "unknown executable";
-  static inline std::string query_pattern = "";        // <- done
-  static inline bool invert_query_pattern = false;     // <- done
-  static inline std::string query_regex_pattern = "";  // <- done
-  static inline bool show_help = false;                // <- done
-  static inline bool show_tests = false;               // <- done
-  static inline bool list_tags = false;                // <- done
-  static inline bool show_successful_tests = false;    // <- done
-  static inline std::string output_filename = "";
+  static inline std::string query_pattern;           // <- done
+  static inline bool invert_query_pattern = false;   // <- done
+  static inline std::string query_regex_pattern;     // <- done
+  static inline bool show_help = false;              // <- done
+  static inline bool show_tests = false;             // <- done
+  static inline bool list_tags = false;              // <- done
+  static inline bool show_successful_tests = false;  // <- done
+  static inline std::string output_filename;
   static inline std::string use_reporter = "console";  // <- done
-  static inline std::string suite_name = "";
+  static inline std::string suite_name;
   static inline bool abort_early = false;  // <- done
   static inline std::size_t abort_after_n_failures =
       std::numeric_limits<std::size_t>::max();  // <- done
   static inline bool show_duration = false;     // <- done
   static inline std::size_t show_min_duration = 0;
-  static inline std::string input_filename = "";
+  static inline std::string input_filename;
   static inline bool show_test_names = false;  // <- done
   static inline bool show_reporters = false;   // <- done
   static inline std::string sort_order = "decl";
@@ -796,29 +774,41 @@ struct cfg {
     std::cout << "version:        " << BOOST_UT_VERSION << std::endl;
   }
 
-  static inline void parse(int argc, const char* argv[]) {
-    const std::size_t n_args = static_cast<std::size_t>(argc);
-    if (n_args > 0 && argv != nullptr) {
+  static void parse_arg_with_fallback(int argc, const char* argv[]) {
+    //int before call main
+    if (argc > 0 && argv != nullptr) {
       cfg::largc = argc;
       cfg::largv = argv;
+    }
+    else
+    {
+      cfg::largc = 0;
+      cfg::largv = nullptr;
+    }
+    parse(cfg::largc, cfg::largv);
+  }
+
+  static void parse(int argc, const char* argv[]) {
+    const std::size_t n_args = argc > 0 ? static_cast<std::size_t>(argc) : 0U;
+    if (n_args > 0 && argv != nullptr) {
       executable_name = argv[0];
     }
     query_pattern = "";
     bool found_first_option = false;
-    for (auto i = 1U; i < n_args; i++) {
+    for (auto i = 1U; i < n_args && argv != nullptr; i++) {
       std::string cmd(argv[i]);
       auto cmd_option = find_arg(cmd);
       if (!cmd_option.has_value()) {
         if (found_first_option) {
-          std::cerr << "unknown option: '" << argv[i] << "' run:" << std::endl;
-          std::cerr << "'" << argv[0] << " --help'" << std::endl;
+          std::cerr << "unknown option: '" << cmd << "' run:" << std::endl;
+          std::cerr << "'" << executable_name << " --help'" << std::endl;
           std::cerr << "for additional help" << std::endl;
           std::exit(-1);
         } else {
           if (i > 1U) {
             query_pattern.append(" ");
           }
-          query_pattern.append(argv[i]);
+          query_pattern.append(cmd);
         }
         continue;
       }
@@ -839,7 +829,7 @@ struct cfg {
         // parse size argument
         std::size_t last;
         std::string argument(argv[i]);
-        std::size_t val = std::stoull(argument, &last);
+        auto val = static_cast<std::size_t>(std::stoull(argument, &last));
         if (last != argument.length()) {
           std::cerr << "cannot parse option of " << argv[i - 1] << " "
                     << argv[i] << std::endl;
@@ -901,6 +891,7 @@ template <class T>
 template <class T>
 struct type_ : op {
   template <class TOther>
+  // NOLINTNEXTLINE(readability-const-return-type)
   [[nodiscard]] constexpr auto operator()(const TOther&) const
       -> const type_<TOther> {
     return {};
@@ -936,9 +927,8 @@ struct value : op {
   T value_{};
 };
 
-template <class T>
-struct value<T, type_traits::requires_t<type_traits::is_floating_point_v<T>>>
-    : op {
+template <std::floating_point T>
+struct value<T> : op {
   using value_type = T;
   static inline auto epsilon = T{};
 
@@ -1008,7 +998,7 @@ struct eq_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
-            return TLhs::value == TRhs::value;
+            return lhs.value == rhs.value;
           } else if constexpr (type_traits::has_static_member_object_epsilon_v<
                                    TLhs> and
                                type_traits::has_static_member_object_epsilon_v<
@@ -1073,7 +1063,7 @@ struct neq_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
-            return TLhs::value != TRhs::value;
+            return lhs.value != rhs.value;
           } else if constexpr (type_traits::has_static_member_object_epsilon_v<
                                    TLhs> and
                                type_traits::has_static_member_object_epsilon_v<
@@ -1108,7 +1098,7 @@ struct gt_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
-            return TLhs::value > TRhs::value;
+            return lhs.value > rhs.value;
           } else {
             return get(lhs_) > get(rhs_);
           }
@@ -1131,7 +1121,7 @@ struct ge_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
-            return TLhs::value >= TRhs::value;
+            return lhs.value >= rhs.value;
           } else {
             return get(lhs_) >= get(rhs_);
           }
@@ -1154,11 +1144,18 @@ struct lt_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
+#if defined(_MSC_VER) && !defined(__clang__)
+            // for some reason, accessing the static member via :: does not compile on MSVC,
+            // and the next line does not compile on clang, so we have to use the ifdef here
+            return lhs.value < rhs.value;
+#else
             return TLhs::value < TRhs::value;
+#endif
           } else {
             return get(lhs_) < get(rhs_);
           }
-        }()} {}
+        }()} {
+  }
 
   [[nodiscard]] constexpr operator bool() const { return value_; }
   [[nodiscard]] constexpr auto lhs() const { return get(lhs_); }
@@ -1178,7 +1175,7 @@ struct le_ : op {
 
           if constexpr (type_traits::has_static_member_object_value_v<TLhs> and
                         type_traits::has_static_member_object_value_v<TRhs>) {
-            return TLhs::value <= TRhs::value;
+            return lhs.value <= rhs.value;
           } else {
             return get(lhs_) <= get(rhs_);
           }
@@ -1318,7 +1315,18 @@ struct aborts_ : op {
 
 namespace type_traits {
 template <class T>
-inline constexpr auto is_op_v = __is_base_of(detail::op, T);
+concept is_op = std::derived_from<T, detail::op>;
+
+template <typename T, typename = void>
+struct is_stream_insertable : std::false_type {};
+
+template <typename T>
+struct is_stream_insertable<
+    T, std::void_t<decltype(std::declval<std::ostream&>()
+                            << detail::get(std::declval<T>()))>>
+    : std::true_type {};
+template <typename T>
+inline constexpr bool is_stream_insertable_v = is_stream_insertable<T>::value;
 }  // namespace type_traits
 
 struct colors {
@@ -1329,7 +1337,7 @@ struct colors {
 };
 
 class printer {
-  [[nodiscard]] inline auto color(const bool cond) {
+  [[nodiscard]] auto color(const bool cond) {
     return cond ? colors_.pass : colors_.fail;
   }
 
@@ -1343,9 +1351,8 @@ class printer {
     return *this;
   }
 
-  template <class T,
-            type_traits::requires_t<not type_traits::has_user_print<T> and
-                                    type_traits::is_container_v<T>> = 0>
+  template <class T>
+    requires std::ranges::range<T> && (!concepts::ostreamable<T>)
   auto& operator<<(T&& t) {
     *this << '{';
     auto first = true;
@@ -1472,6 +1479,8 @@ class reporter {
     printer_ = static_cast<TPrinter&&>(printer);
   }
 
+  auto on(events::run_begin) -> void {}
+
   auto on(events::test_begin test_begin) -> void {
     printer_ << "Running \"" << test_begin.name << "\"...";
     fails_ = asserts_.fail;
@@ -1530,7 +1539,7 @@ class reporter {
     ++asserts_.fail;
   }
 
-  auto on(events::fatal_assertion) -> void {}
+  auto on(const events::fatal_assertion&) -> void {}
 
   auto on(events::summary) -> void {
     if (tests_.fail or asserts_.fail) {
@@ -1581,7 +1590,7 @@ class reporter_junit {
   using clock_ref = std::chrono::high_resolution_clock;
   using timePoint = std::chrono::time_point<clock_ref>;
   using timeDiff = std::chrono::milliseconds;
-  enum class ReportType { CONSOLE, JUNIT } report_type_;
+  enum class ReportType : std::uint8_t { CONSOLE, JUNIT } report_type_;
   static constexpr ReportType CONSOLE = ReportType::CONSOLE;
   static constexpr ReportType JUNIT = ReportType::JUNIT;
 
@@ -1675,8 +1684,11 @@ class reporter_junit {
   constexpr auto operator=(TPrinter printer) {
     printer_ = static_cast<TPrinter&&>(printer);
   }
-  reporter_junit() : lcout_(std::cout.rdbuf()) {
-    ::boost::ut::detail::cfg::parse(detail::cfg::largc, detail::cfg::largv);
+  reporter_junit() : lcout_(std::cout.rdbuf()) {}
+  ~reporter_junit() { std::cout.rdbuf(cout_save); }
+
+  auto on(events::run_begin run) {
+    ::boost::ut::detail::cfg::parse_arg_with_fallback(run.argc, run.argv);
 
     if (detail::cfg::show_reporters) {
       std::cout << "available reporter:\n";
@@ -1696,7 +1708,6 @@ class reporter_junit {
       std::cout.rdbuf(ss_out_.rdbuf());
     }
   }
-  ~reporter_junit() { std::cout.rdbuf(cout_save); }
 
   auto on(events::suite_begin suite) -> void {
     while (active_test_.size() > 0) {
@@ -1719,8 +1730,9 @@ class reporter_junit {
 
     if (report_type_ == CONSOLE) {
       ss_out_ << "\n";
-      ss_out_ << std::string(2 * active_test_.size() - 2, ' ');
-      ss_out_ << "Running test \"" << test_event.name << "\"... ";
+      ss_out_ << std::string((2 * active_test_.size()) - 2, ' ');
+      ss_out_ << "Running " << test_event.type << " \"" << test_event.name
+              << "\"... ";
     }
   }
 
@@ -1734,7 +1746,7 @@ class reporter_junit {
         if (detail::cfg::show_successful_tests) {
           if (!active_scope_->nested_tests->empty()) {
             ss_out_ << "\n";
-            ss_out_ << std::string(2 * active_test_.size() - 2, ' ');
+            ss_out_ << std::string((2 * active_test_.size()) - 2, ' ');
             ss_out_ << "Running test \"" << test_event.name << "\" - ";
           }
           ss_out_ << color_.pass << "PASSED" << color_.none;
@@ -1763,9 +1775,9 @@ class reporter_junit {
       active_scope_->status = "SKIPPED";
       active_scope_->skipped += 1;
       if (report_type_ == CONSOLE) {
-        lcout_ << '\n' << std::string(2 * active_test_.size() - 2, ' ');
+        lcout_ << '\n' << std::string((2 * active_test_.size()) - 2, ' ');
         lcout_ << "Running \"" << test_event.name << "\"... ";
-        lcout_ << color_.skip << "SKIPPED" << color_.none;
+        lcout_ << color_.skip << "SKIPPED" << color_.none << '\n';
       }
       reset_printer();
       pop_scope(test_event.name);
@@ -1789,7 +1801,7 @@ class reporter_junit {
       active_scope_->report_string += color_.none;
     }
     if (report_type_ == CONSOLE) {
-      lcout_ << std::string(2 * active_test_.size() - 2, ' ');
+      lcout_ << std::string((2 * active_test_.size()) - 2, ' ');
       lcout_ << "Running test \"" << active_test_.top() << "\"... ";
       lcout_ << color_.fail << "FAILED" << color_.none;
       print_duration(lcout_);
@@ -1836,22 +1848,24 @@ class reporter_junit {
     }
   }
 
-  auto on(events::fatal_assertion) -> void { active_scope_->fails++; }
+  auto on(const events::fatal_assertion&) -> void { active_scope_->fails++; }
 
   auto on(events::summary) -> void {
     std::cout.flush();
     std::cout.rdbuf(cout_save);
     std::ofstream maybe_of;
-    if (detail::cfg::output_filename != "") { maybe_of = std::ofstream(detail::cfg::output_filename); }
+    if (detail::cfg::output_filename != "") {
+      maybe_of = std::ofstream(detail::cfg::output_filename);
+    }
 
     if (report_type_ == JUNIT) {
-      print_junit_summary(detail::cfg::output_filename != "" ? maybe_of : std::cout);
+      print_junit_summary(detail::cfg::output_filename != "" ? maybe_of
+                                                             : std::cout);
       return;
     }
     print_console_summary(
-      detail::cfg::output_filename != "" ? maybe_of : std::cout,
-      detail::cfg::output_filename != "" ? maybe_of : std::cerr
-    );
+        detail::cfg::output_filename != "" ? maybe_of : std::cout,
+        detail::cfg::output_filename != "" ? maybe_of : std::cerr);
   }
 
  protected:
@@ -1867,13 +1881,14 @@ class reporter_junit {
     }
   }
 
-  void print_console_summary(std::ostream &out_stream, std::ostream &err_stream) {
+  void print_console_summary(std::ostream& out_stream,
+                             std::ostream& err_stream) {
     for (const auto& [suite_name, suite_result] : results_) {
       if (suite_result.fails) {
         err_stream
             << "\n========================================================"
                "=======================\n"
-            << "Suite " << suite_name  //
+            << "Suite " << suite_name << '\n'  //
             << "tests:   " << (suite_result.n_tests) << " | " << color_.fail
             << suite_result.fails << " failed" << color_.none << '\n'
             << "asserts: " << (suite_result.assertions) << " | "
@@ -1883,9 +1898,9 @@ class reporter_junit {
         std::cerr << std::endl;
       } else {
         out_stream << color_.pass << "Suite '" << suite_name
-                  << "': all tests passed" << color_.none << " ("
-                  << suite_result.assertions << " asserts in "
-                  << suite_result.n_tests << " tests)\n";
+                   << "': all tests passed" << color_.none << " ("
+                   << suite_result.assertions << " asserts in "
+                   << suite_result.n_tests << " tests)\n";
 
         if (suite_result.skipped) {
           std::cout << suite_result.skipped << " tests skipped\n";
@@ -1896,9 +1911,10 @@ class reporter_junit {
     }
   }
 
-  void print_junit_summary(std::ostream &stream) {
+  void print_junit_summary(std::ostream& stream) {
     // aggregate results
-    size_t n_tests=0, n_fails=0;
+    size_t n_tests = 0;
+    size_t n_fails = 0;
     double total_time = 0.0;
     auto suite_time = [](auto const& suite_result) {
       std::int64_t time_ms =
@@ -1916,11 +1932,11 @@ class reporter_junit {
     // mock junit output:
     stream << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
     stream << "<testsuites";
-      stream << " name=\"all\"";
-      stream << " tests=\"" << n_tests << '\"';
-      stream << " failures=\"" << n_fails << '\"';
-      stream << " time=\"" << total_time << '\"';
-      stream << ">\n";
+    stream << " name=\"all\"";
+    stream << " tests=\"" << n_tests << '\"';
+    stream << " failures=\"" << n_fails << '\"';
+    stream << " time=\"" << total_time << '\"';
+    stream << ">\n";
 
     for (const auto& [suite_name, suite_result] : results_) {
       stream << "<testsuite";
@@ -1938,8 +1954,8 @@ class reporter_junit {
     }
     stream << "</testsuites>";
   }
-  void print_result(std::ostream &stream, const std::string& suite_name, std::string indent,
-                    const test_result& parent) {
+  void print_result(std::ostream& stream, const std::string& suite_name,
+                    const std::string& indent, const test_result& parent) {
     for (const auto& [name, result] : *parent.nested_tests) {
       stream << indent;
       stream << "<testcase classname=\"" << result.suite_name << '\"';
@@ -1952,8 +1968,7 @@ class reporter_junit {
           std::chrono::duration_cast<std::chrono::milliseconds>(
               result.run_stop - result.run_start)
               .count();
-      stream << " time=\"" << (static_cast<double>(time_ms) / 1000.0)
-                << "\"";
+      stream << " time=\"" << (static_cast<double>(time_ms) / 1000.0) << "\"";
       stream << " status=\"" << result.status << '\"';
       if (result.report_string.empty() && result.nested_tests->empty()) {
         stream << " />\n";
@@ -1981,6 +1996,8 @@ struct options {
 
 struct run_cfg {
   bool report_errors{false};
+  int argc{0};
+  const char** argv{nullptr};
 };
 
 template <class TReporter = reporter<printer>, auto MaxPathSize = 16>
@@ -2123,7 +2140,7 @@ class runner {
       }
 #endif
 
-      if (not --level_) {
+      if (not--level_) {
         reporter_.on(events::test_end{.type = test.type, .name = test.name});
       } else {  // N.B. prev. only root-level tests were signalled on finish
         if constexpr (requires {
@@ -2184,6 +2201,7 @@ class runner {
 
   [[nodiscard]] auto run(run_cfg rc = {}) -> bool {
     run_ = true;
+    reporter_.on(events::run_begin{.argc = rc.argc, .argv = rc.argv});
     for (const auto& [suite, suite_name] : suites_) {
       // add reporter in/out
       if constexpr (requires { reporter_.on(events::suite_begin{}); }) {
@@ -2259,7 +2277,7 @@ struct test {
   template <class... Ts>
   constexpr auto operator=(test_location<void (*)()> _test) {
     on<Ts...>(events::test<void (*)()>{.type = type,
-                                       .name = name,
+                                       .name = std::string{name},
                                        .tag = tag,
                                        .location = _test.location,
                                        .arg = none{},
@@ -2267,13 +2285,11 @@ struct test {
     return _test.test;
   }
 
-  template <class Test,
-            type_traits::requires_t<
-                not type_traits::is_convertible_v<Test, void (*)()>> = 0>
-  constexpr auto operator=(Test _test) ->
-      typename type_traits::identity<Test, decltype(_test())>::type {
+  template <class Test>
+    requires std::invocable<Test> && (!std::convertible_to<Test, void (*)()>)
+  constexpr auto operator=(Test _test) {
     on<Test>(events::test<Test>{.type = type,
-                                .name = name,
+                                .name = std::string{name},
                                 .tag = tag,
                                 .location = {},
                                 .arg = none{},
@@ -2281,16 +2297,17 @@ struct test {
     return _test;
   }
 
-  constexpr auto operator=(void (*_test)(std::string_view)) const {
-    return _test(name);
+  constexpr void operator=(void (*_test)(std::string_view,
+                                         std::string_view)) const {
+    _test(type, name);
   }
 
-  template <class Test,
-            type_traits::requires_t<not type_traits::is_convertible_v<
-                Test, void (*)(std::string_view)>> = 0>
-  constexpr auto operator=(Test _test)
-      -> decltype(_test(type_traits::declval<std::string_view>())) {
-    return _test(name);
+  template <class Test>
+    requires std::invocable<Test, std::string_view, std::string_view> &&
+             (!std::convertible_to<Test, void (*)(std::string_view,
+                                                  std::string_view)>)
+  constexpr auto operator=(Test _test) {
+    return _test(type, name);
   }
 };
 
@@ -2595,6 +2612,43 @@ constexpr auto operator""_b(const char* name, decltype(sizeof("")) size) {
 }
 }  // namespace literals
 
+[[nodiscard]] constexpr auto get_ordinal_suffix(int number) {
+  // See https://stackoverflow.com/a/13627586
+  const auto last_digit = number % 10;
+  const auto last_two_digits = number % 100;
+  if (last_digit == 1 && last_two_digits != 11) {
+    return "st";
+  }
+  if (last_digit == 2 && last_two_digits != 12) {
+    return "nd";
+  }
+  if (last_digit == 3 && last_two_digits != 13) {
+    return "rd";
+  }
+  return "th";
+};
+
+template <class TArg>
+inline std::string format_test_parameter([[maybe_unused]] const TArg& arg,
+                                         const int counter) {
+  return std::to_string(counter) + get_ordinal_suffix(counter) + " parameter";
+}
+
+template <class F>
+  requires(std::integral<F> || std::floating_point<F>) &&
+          (!std::same_as<F, bool>)
+inline std::string
+    format_test_parameter(const F& arg, [[maybe_unused]] const int counter) {
+  std::ostringstream oss;
+  oss << arg;
+  return oss.str();
+}
+
+inline std::string format_test_parameter(const bool& arg,
+                                         [[maybe_unused]] const int counter) {
+  return arg ? "true" : "false";
+}
+
 namespace operators {
 [[nodiscard]] constexpr auto operator==(std::string_view lhs,
                                         std::string_view rhs) {
@@ -2606,73 +2660,66 @@ namespace operators {
   return detail::neq_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_container_v<T>> = 0>
+template <std::ranges::range T>
 [[nodiscard]] constexpr auto operator==(T&& lhs, T&& rhs) {
   return detail::eq_{static_cast<T&&>(lhs), static_cast<T&&>(rhs)};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_container_v<T>> = 0>
+template <std::ranges::range T>
 [[nodiscard]] constexpr auto operator!=(T&& lhs, T&& rhs) {
   return detail::neq_{static_cast<T&&>(lhs), static_cast<T&&>(rhs)};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator==(const TLhs& lhs, const TRhs& rhs) {
   return detail::eq_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator!=(const TLhs& lhs, const TRhs& rhs) {
   return detail::neq_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator>(const TLhs& lhs, const TRhs& rhs) {
   return detail::gt_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator>=(const TLhs& lhs, const TRhs& rhs) {
   return detail::ge_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator<(const TLhs& lhs, const TRhs& rhs) {
   return detail::lt_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator<=(const TLhs& lhs, const TRhs& rhs) {
   return detail::le_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator and(const TLhs& lhs, const TRhs& rhs) {
   return detail::and_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 [[nodiscard]] constexpr auto operator or(const TLhs& lhs, const TRhs& rhs) {
   return detail::or_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 [[nodiscard]] constexpr auto operator not(const T& t) {
   return detail::not_{t};
 }
@@ -2693,7 +2740,8 @@ template <class Test>
 
 [[nodiscard]] inline auto operator/(const detail::tag& lhs,
                                     const detail::tag& rhs) {
-  std::vector<std::string_view> tag{};
+  std::vector<std::string_view> tag;
+  tag.reserve(lhs.name.size() + rhs.name.size());
   for (const auto& name : lhs.name) {
     tag.push_back(name);
   }
@@ -2703,34 +2751,49 @@ template <class Test>
   return detail::tag{tag};
 }
 
-template <class F, class T,
-          type_traits::requires_t<type_traits::is_container_v<T>> = 0>
+template <class F, class T>
+  requires std::ranges::range<T>
 [[nodiscard]] constexpr auto operator|(const F& f, const T& t) {
-  return [f, t](const auto name) {
-    for (const auto& arg : t) {
-      detail::on<F>(events::test<F, typename T::value_type>{.type = "test",
-                                                            .name = name,
-                                                            .tag = {},
-                                                            .location = {},
-                                                            .arg = arg,
-                                                            .run = f});
+  return [f, t](std::string_view type, std::string_view name) {
+    for (int counter = 1; const auto& arg : t) {
+      detail::on<F>(events::test<F, decltype(arg)>{
+          .type = type,
+          .name = std::string{name} + " (" +
+                  format_test_parameter(arg, counter) + ")",
+          .tag = {},
+          .location = {},
+          .arg = arg,
+          .run = f});
+      ++counter;
     }
   };
 }
 
-template <
-    class F, template <class...> class T, class... Ts,
-    type_traits::requires_t<not type_traits::is_container_v<T<Ts...>>> = 0>
+template <class F, template <class...> class T, class... Ts>
+  requires(!std::ranges::range<T<Ts...>>)
 [[nodiscard]] constexpr auto operator|(const F& f, const T<Ts...>& t) {
-  return [f, t](const auto name) {
+  constexpr auto unique_name = []<class TArg>(std::string_view name,
+                                              const TArg& arg, int& counter) {
+    auto ret = std::string{name} + " (";
+    if (std::invocable<F, TArg>) {
+      ret += format_test_parameter(arg, counter) + ", ";
+    }
+    ret += std::string(reflection::type_name<TArg>()) + ")";
+    ++counter;
+    return ret;
+  };
+
+  return [f, t, unique_name](std::string_view type, std::string_view name) {
+    int counter = 1;
     apply(
-        [f, name](const auto&... args) {
-          (detail::on<F>(events::test<F, Ts>{.type = "test",
-                                             .name = name,
-                                             .tag = {},
-                                             .location = {},
-                                             .arg = args,
-                                             .run = f}),
+        [=, &counter](const auto&... args) {
+          (detail::on<F>(events::test<F, Ts>{
+               .type = type,
+               .name = unique_name.template operator()<Ts>(name, args, counter),
+               .tag = {},
+               .location = {},
+               .arg = args,
+               .run = f}),
            ...);
         },
         t);
@@ -2742,11 +2805,11 @@ namespace terse {
 #pragma clang diagnostic ignored "-Wunused-comparison"
 #endif
 
-[[maybe_unused]] constexpr struct {
+[[maybe_unused]] constexpr struct placeholder_gcc_t {
 } _t;
 
 template <class T>
-constexpr auto operator%(const T& t, const decltype(_t)&) {
+constexpr auto operator%(const T& t, const placeholder_gcc_t&) {
   return detail::value<T>{t};
 }
 
@@ -2762,7 +2825,8 @@ inline auto operator>>(const T& t,
   return fatal_{t};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator==(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using eq_t = detail::eq_<T, detail::value_location<typename T::value_type>>;
@@ -2774,7 +2838,8 @@ constexpr auto operator==(
   return eq_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator==(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using eq_t = detail::eq_<detail::value_location<typename T::value_type>, T>;
@@ -2786,7 +2851,8 @@ constexpr auto operator==(
   return eq_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator!=(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using neq_t = detail::neq_<T, detail::value_location<typename T::value_type>>;
@@ -2798,7 +2864,8 @@ constexpr auto operator!=(
   return neq_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator!=(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using neq_t = detail::neq_<detail::value_location<typename T::value_type>, T>;
@@ -2810,7 +2877,8 @@ constexpr auto operator!=(
   return neq_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator>(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using gt_t = detail::gt_<T, detail::value_location<typename T::value_type>>;
@@ -2822,7 +2890,8 @@ constexpr auto operator>(
   return gt_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator>(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using gt_t = detail::gt_<detail::value_location<typename T::value_type>, T>;
@@ -2834,7 +2903,8 @@ constexpr auto operator>(
   return gt_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator>=(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using ge_t = detail::ge_<T, detail::value_location<typename T::value_type>>;
@@ -2846,7 +2916,8 @@ constexpr auto operator>=(
   return ge_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator>=(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using ge_t = detail::ge_<detail::value_location<typename T::value_type>, T>;
@@ -2858,7 +2929,8 @@ constexpr auto operator>=(
   return ge_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator<(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using lt_t = detail::lt_<T, detail::value_location<typename T::value_type>>;
@@ -2870,7 +2942,8 @@ constexpr auto operator<(
   return lt_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator<(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using lt_t = detail::lt_<detail::value_location<typename T::value_type>, T>;
@@ -2882,7 +2955,8 @@ constexpr auto operator<(
   return lt_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator<=(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {
   using le_t = detail::le_<T, detail::value_location<typename T::value_type>>;
@@ -2894,7 +2968,8 @@ constexpr auto operator<=(
   return le_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator<=(
     const detail::value_location<typename T::value_type>& lhs, const T& rhs) {
   using le_t = detail::le_<detail::value_location<typename T::value_type>, T>;
@@ -2906,9 +2981,8 @@ constexpr auto operator<=(
   return le_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 constexpr auto operator and(const TLhs& lhs, const TRhs& rhs) {
   using and_t = detail::and_<typename TLhs::type, typename TRhs::type>;
   struct and_ : and_t, detail::log {
@@ -2919,9 +2993,8 @@ constexpr auto operator and(const TLhs& lhs, const TRhs& rhs) {
   return and_{lhs, rhs};
 }
 
-template <class TLhs, class TRhs,
-          type_traits::requires_t<type_traits::is_op_v<TLhs> or
-                                  type_traits::is_op_v<TRhs>> = 0>
+template <class TLhs, class TRhs>
+  requires type_traits::is_op<TLhs> || type_traits::is_op<TRhs>
 constexpr auto operator or(const TLhs& lhs, const TRhs& rhs) {
   using or_t = detail::or_<typename TLhs::type, typename TRhs::type>;
   struct or_ : or_t, detail::log {
@@ -2932,7 +3005,8 @@ constexpr auto operator or(const TLhs& lhs, const TRhs& rhs) {
   return or_{lhs, rhs};
 }
 
-template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
+template <class T>
+  requires type_traits::is_op<T>
 constexpr auto operator not(const T& t) {
   using not_t = detail::not_<typename T::type>;
   struct not_ : not_t, detail::log {
@@ -2946,9 +3020,9 @@ constexpr auto operator not(const T& t) {
 }  // namespace terse
 }  // namespace operators
 
-template <class TExpr, type_traits::requires_t<
-                           type_traits::is_op_v<TExpr> or
-                           type_traits::is_convertible_v<TExpr, bool>> = 0>
+template <class TExpr>
+  requires type_traits::is_op<TExpr> ||
+           concepts::explicitly_convertible_to<TExpr, bool>
 constexpr auto expect(const TExpr& expr,
                       const reflection::source_location& sl =
                           reflection::source_location::current()) {
@@ -3044,31 +3118,45 @@ template <class T = void>
 [[maybe_unused]] constexpr auto type = detail::type_<T>();
 
 template <class TLhs, class TRhs>
+  requires type_traits::is_stream_insertable_v<TLhs> &&
+           type_traits::is_stream_insertable_v<TRhs>
 [[nodiscard]] constexpr auto eq(const TLhs& lhs, const TRhs& rhs) {
   return detail::eq_{lhs, rhs};
 }
 template <class TLhs, class TRhs, class TEpsilon>
+  requires type_traits::is_stream_insertable_v<TLhs> &&
+           type_traits::is_stream_insertable_v<TRhs>
 [[nodiscard]] constexpr auto approx(const TLhs& lhs, const TRhs& rhs,
                                     const TEpsilon& epsilon) {
   return detail::approx_{lhs, rhs, epsilon};
 }
 template <class TLhs, class TRhs>
+  requires type_traits::is_stream_insertable_v<TLhs> &&
+           type_traits::is_stream_insertable_v<TRhs>
 [[nodiscard]] constexpr auto neq(const TLhs& lhs, const TRhs& rhs) {
   return detail::neq_{lhs, rhs};
 }
 template <class TLhs, class TRhs>
+  requires type_traits::is_stream_insertable_v<TLhs> &&
+           type_traits::is_stream_insertable_v<TRhs>
 [[nodiscard]] constexpr auto gt(const TLhs& lhs, const TRhs& rhs) {
   return detail::gt_{lhs, rhs};
 }
 template <class TLhs, class TRhs>
+  requires type_traits::is_stream_insertable_v<TLhs> &&
+           type_traits::is_stream_insertable_v<TRhs>
 [[nodiscard]] constexpr auto ge(const TLhs& lhs, const TRhs& rhs) {
   return detail::ge_{lhs, rhs};
 }
 template <class TLhs, class TRhs>
+  requires type_traits::is_stream_insertable_v<TLhs> &&
+           type_traits::is_stream_insertable_v<TRhs>
 [[nodiscard]] constexpr auto lt(const TLhs& lhs, const TRhs& rhs) {
   return detail::lt_{lhs, rhs};
 }
 template <class TLhs, class TRhs>
+  requires type_traits::is_stream_insertable_v<TLhs> &&
+           type_traits::is_stream_insertable_v<TRhs>
 [[nodiscard]] constexpr auto le(const TLhs& lhs, const TRhs& rhs) {
   return detail::le_{lhs, rhs};
 }
@@ -3269,17 +3357,22 @@ using operators::operator not;
 using operators::operator|;
 using operators::operator/;
 using operators::operator>>;
-}  // namespace boost::inline ext::ut::inline v2_0_0
+}  // namespace boost::inline ext::ut::inline v2_3_1
 
 #if (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)) && \
     !defined(__EMSCRIPTEN__)
-__attribute__((constructor)) inline void cmd_line_args(int argc,
-                                                       const char* argv[]) {
+__attribute__((constructor(101))) inline void cmd_line_args(
+    int argc, const char* argv[]) {
   ::boost::ut::detail::cfg::largc = argc;
   ::boost::ut::detail::cfg::largv = argv;
 }
 #else
 // For MSVC, largc/largv are initialized with __argc/__argv
+#endif
+
+#if defined(_MSC_VER)
+#pragma pop_macro("min")
+#pragma pop_macro("max")
 #endif
 
 #endif

--- a/external/nlohmann/json.hpp
+++ b/external/nlohmann/json.hpp
@@ -1,9 +1,9 @@
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 /****************************************************************************\
@@ -27,7 +27,6 @@
 #endif  // JSON_NO_IO
 #include <iterator> // random_access_iterator_tag
 #include <memory> // unique_ptr
-#include <numeric> // accumulate
 #include <string> // string, stoi, to_string
 #include <utility> // declval, forward, move, pair, swap
 #include <vector> // vector
@@ -35,10 +34,10 @@
 // #include <nlohmann/adl_serializer.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -48,10 +47,10 @@
 // #include <nlohmann/detail/abi_macros.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -60,7 +59,7 @@
 
 #ifndef JSON_SKIP_LIBRARY_VERSION_CHECK
     #if defined(NLOHMANN_JSON_VERSION_MAJOR) && defined(NLOHMANN_JSON_VERSION_MINOR) && defined(NLOHMANN_JSON_VERSION_PATCH)
-        #if NLOHMANN_JSON_VERSION_MAJOR != 3 || NLOHMANN_JSON_VERSION_MINOR != 11 || NLOHMANN_JSON_VERSION_PATCH != 2
+        #if NLOHMANN_JSON_VERSION_MAJOR != 3 || NLOHMANN_JSON_VERSION_MINOR != 11 || NLOHMANN_JSON_VERSION_PATCH != 3
             #warning "Already included a different version of the library!"
         #endif
     #endif
@@ -68,7 +67,7 @@
 
 #define NLOHMANN_JSON_VERSION_MAJOR 3   // NOLINT(modernize-macro-to-enum)
 #define NLOHMANN_JSON_VERSION_MINOR 11  // NOLINT(modernize-macro-to-enum)
-#define NLOHMANN_JSON_VERSION_PATCH 2   // NOLINT(modernize-macro-to-enum)
+#define NLOHMANN_JSON_VERSION_PATCH 3   // NOLINT(modernize-macro-to-enum)
 
 #ifndef JSON_DIAGNOSTICS
     #define JSON_DIAGNOSTICS 0
@@ -150,10 +149,10 @@
 // #include <nlohmann/detail/conversions/from_json.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -173,16 +172,19 @@
 // #include <nlohmann/detail/exceptions.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
 
 #include <cstddef> // nullptr_t
 #include <exception> // exception
+#if JSON_DIAGNOSTICS
+    #include <numeric> // accumulate
+#endif
 #include <stdexcept> // runtime_error
 #include <string> // to_string
 #include <vector> // vector
@@ -190,10 +192,10 @@
 // #include <nlohmann/detail/value_t.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -206,10 +208,10 @@
 // #include <nlohmann/detail/macro_scope.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -218,10 +220,10 @@
 // #include <nlohmann/detail/meta/detected.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -231,10 +233,10 @@
 // #include <nlohmann/detail/meta/void_t.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -318,10 +320,10 @@ NLOHMANN_JSON_NAMESPACE_END
 
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-FileCopyrightText: 2016-2021 Evan Nemerson <evan@nemerson.com>
 // SPDX-License-Identifier: MIT
 
@@ -2483,6 +2485,14 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     #endif
 #endif
 
+#ifndef JSON_HAS_STATIC_RTTI
+    #if !defined(_HAS_STATIC_RTTI) || _HAS_STATIC_RTTI != 0
+        #define JSON_HAS_STATIC_RTTI 1
+    #else
+        #define JSON_HAS_STATIC_RTTI 0
+    #endif
+#endif
+
 #ifdef JSON_HAS_CPP_17
     #define JSON_INLINE_VARIABLE inline
 #else
@@ -2590,12 +2600,13 @@ JSON_HEDLEY_DIAGNOSTIC_POP
              class NumberUnsignedType, class NumberFloatType,              \
              template<typename> class AllocatorType,                       \
              template<typename, typename = void> class JSONSerializer,     \
-             class BinaryType>
+             class BinaryType,                                             \
+             class CustomBaseClass>
 
 #define NLOHMANN_BASIC_JSON_TPL                                            \
     basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
     NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
-    AllocatorType, JSONSerializer, BinaryType>
+    AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>
 
 // Macros to simplify conversion from/to types
 
@@ -2745,7 +2756,10 @@ JSON_HEDLEY_DIAGNOSTIC_POP
 
 #define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj{}; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
 
 /*!
 @brief macro
@@ -2756,10 +2770,12 @@ JSON_HEDLEY_DIAGNOSTIC_POP
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
     inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
 
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
+
 #define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
     inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { Type nlohmann_json_default_obj; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
-
+    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj{}; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
 
 // inspired from https://stackoverflow.com/a/26745591
 // allows to call any std function as if (e.g. with begin):
@@ -2923,10 +2939,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/string_escape.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -2998,10 +3014,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/input/position_t.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -3040,10 +3056,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/meta/cpp_future.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-FileCopyrightText: 2018 The Abseil Authors
 // SPDX-License-Identifier: MIT
 
@@ -3214,10 +3230,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/meta/type_traits.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -3226,14 +3242,15 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
 #include <tuple> // tuple
+#include <string> // char_traits
 
 // #include <nlohmann/detail/iterators/iterator_traits.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -3298,10 +3315,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/meta/call_std/begin.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -3318,10 +3335,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/meta/call_std/end.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -3342,10 +3359,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/json_fwd.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
@@ -3389,7 +3406,8 @@ NLOHMANN_JSON_NAMESPACE_END
     template<typename U> class AllocatorType = std::allocator,
     template<typename T, typename SFINAE = void> class JSONSerializer =
     adl_serializer,
-    class BinaryType = std::vector<std::uint8_t>>
+    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+    class CustomBaseClass = void>
     class basic_json;
 
     /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
@@ -3577,6 +3595,63 @@ struct actual_object_comparator
 template<typename BasicJsonType>
 using actual_object_comparator_t = typename actual_object_comparator<BasicJsonType>::type;
 
+/////////////////
+// char_traits //
+/////////////////
+
+// Primary template of char_traits calls std char_traits
+template<typename T>
+struct char_traits : std::char_traits<T>
+{};
+
+// Explicitly define char traits for unsigned char since it is not standard
+template<>
+struct char_traits<unsigned char> : std::char_traits<char>
+{
+    using char_type = unsigned char;
+    using int_type = uint64_t;
+
+    // Redefine to_int_type function
+    static int_type to_int_type(char_type c) noexcept
+    {
+        return static_cast<int_type>(c);
+    }
+
+    static char_type to_char_type(int_type i) noexcept
+    {
+        return static_cast<char_type>(i);
+    }
+
+    static constexpr int_type eof() noexcept
+    {
+        return static_cast<int_type>(EOF);
+    }
+};
+
+// Explicitly define char traits for signed char since it is not standard
+template<>
+struct char_traits<signed char> : std::char_traits<char>
+{
+    using char_type = signed char;
+    using int_type = uint64_t;
+
+    // Redefine to_int_type function
+    static int_type to_int_type(char_type c) noexcept
+    {
+        return static_cast<int_type>(c);
+    }
+
+    static char_type to_char_type(int_type i) noexcept
+    {
+        return static_cast<char_type>(i);
+    }
+
+    static constexpr int_type eof() noexcept
+    {
+        return static_cast<int_type>(EOF);
+    }
+};
+
 ///////////////////
 // is_ functions //
 ///////////////////
@@ -3613,7 +3688,6 @@ template <typename... Ts>
 struct is_default_constructible<const std::tuple<Ts...>>
             : conjunction<is_default_constructible<Ts>...> {};
 
-
 template <typename T, typename... Args>
 struct is_constructible : std::is_constructible<T, Args...> {};
 
@@ -3628,7 +3702,6 @@ struct is_constructible<std::tuple<Ts...>> : is_default_constructible<std::tuple
 
 template <typename... Ts>
 struct is_constructible<const std::tuple<Ts...>> : is_default_constructible<const std::tuple<Ts...>> {};
-
 
 template<typename T, typename = void>
 struct is_iterator_traits : std::false_type {};
@@ -4039,7 +4112,6 @@ struct value_in_range_of_impl2<OfType, T, false, true>
     }
 };
 
-
 template<typename OfType, typename T>
 struct value_in_range_of_impl2<OfType, T, true, true>
 {
@@ -4138,10 +4210,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/string_concat.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -4165,28 +4237,28 @@ inline std::size_t concat_length()
 }
 
 template<typename... Args>
-inline std::size_t concat_length(const char* cstr, Args&& ... rest);
+inline std::size_t concat_length(const char* cstr, const Args& ... rest);
 
 template<typename StringType, typename... Args>
-inline std::size_t concat_length(const StringType& str, Args&& ... rest);
+inline std::size_t concat_length(const StringType& str, const Args& ... rest);
 
 template<typename... Args>
-inline std::size_t concat_length(const char /*c*/, Args&& ... rest)
+inline std::size_t concat_length(const char /*c*/, const Args& ... rest)
 {
-    return 1 + concat_length(std::forward<Args>(rest)...);
+    return 1 + concat_length(rest...);
 }
 
 template<typename... Args>
-inline std::size_t concat_length(const char* cstr, Args&& ... rest)
+inline std::size_t concat_length(const char* cstr, const Args& ... rest)
 {
     // cppcheck-suppress ignoredReturnValue
-    return ::strlen(cstr) + concat_length(std::forward<Args>(rest)...);
+    return ::strlen(cstr) + concat_length(rest...);
 }
 
 template<typename StringType, typename... Args>
-inline std::size_t concat_length(const StringType& str, Args&& ... rest)
+inline std::size_t concat_length(const StringType& str, const Args& ... rest)
 {
-    return str.size() + concat_length(std::forward<Args>(rest)...);
+    return str.size() + concat_length(rest...);
 }
 
 template<typename OutStringType>
@@ -4277,14 +4349,13 @@ template<typename OutStringType = std::string, typename... Args>
 inline OutStringType concat(Args && ... args)
 {
     OutStringType str;
-    str.reserve(concat_length(std::forward<Args>(args)...));
+    str.reserve(concat_length(args...));
     concat_into(str, std::forward<Args>(args)...);
     return str;
 }
 
 }  // namespace detail
 NLOHMANN_JSON_NAMESPACE_END
-
 
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
@@ -4334,9 +4405,9 @@ class exception : public std::exception
             {
                 case value_t::array:
                 {
-                    for (std::size_t i = 0; i < current->m_parent->m_value.array->size(); ++i)
+                    for (std::size_t i = 0; i < current->m_parent->m_data.m_value.array->size(); ++i)
                     {
-                        if (&current->m_parent->m_value.array->operator[](i) == current)
+                        if (&current->m_parent->m_data.m_value.array->operator[](i) == current)
                         {
                             tokens.emplace_back(std::to_string(i));
                             break;
@@ -4347,7 +4418,7 @@ class exception : public std::exception
 
                 case value_t::object:
                 {
-                    for (const auto& element : *current->m_parent->m_value.object)
+                    for (const auto& element : *current->m_parent->m_data.m_value.object)
                     {
                         if (&element.second == current)
                         {
@@ -4410,17 +4481,17 @@ class parse_error : public exception
     template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
     static parse_error create(int id_, const position_t& pos, const std::string& what_arg, BasicJsonContext context)
     {
-        std::string w = concat(exception::name("parse_error", id_), "parse error",
-                               position_string(pos), ": ", exception::diagnostics(context), what_arg);
+        const std::string w = concat(exception::name("parse_error", id_), "parse error",
+                                     position_string(pos), ": ", exception::diagnostics(context), what_arg);
         return {id_, pos.chars_read_total, w.c_str()};
     }
 
     template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
     static parse_error create(int id_, std::size_t byte_, const std::string& what_arg, BasicJsonContext context)
     {
-        std::string w = concat(exception::name("parse_error", id_), "parse error",
-                               (byte_ != 0 ? (concat(" at byte ", std::to_string(byte_))) : ""),
-                               ": ", exception::diagnostics(context), what_arg);
+        const std::string w = concat(exception::name("parse_error", id_), "parse error",
+                                     (byte_ != 0 ? (concat(" at byte ", std::to_string(byte_))) : ""),
+                                     ": ", exception::diagnostics(context), what_arg);
         return {id_, byte_, w.c_str()};
     }
 
@@ -4454,7 +4525,7 @@ class invalid_iterator : public exception
     template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
     static invalid_iterator create(int id_, const std::string& what_arg, BasicJsonContext context)
     {
-        std::string w = concat(exception::name("invalid_iterator", id_), exception::diagnostics(context), what_arg);
+        const std::string w = concat(exception::name("invalid_iterator", id_), exception::diagnostics(context), what_arg);
         return {id_, w.c_str()};
     }
 
@@ -4472,7 +4543,7 @@ class type_error : public exception
     template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
     static type_error create(int id_, const std::string& what_arg, BasicJsonContext context)
     {
-        std::string w = concat(exception::name("type_error", id_), exception::diagnostics(context), what_arg);
+        const std::string w = concat(exception::name("type_error", id_), exception::diagnostics(context), what_arg);
         return {id_, w.c_str()};
     }
 
@@ -4489,7 +4560,7 @@ class out_of_range : public exception
     template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
     static out_of_range create(int id_, const std::string& what_arg, BasicJsonContext context)
     {
-        std::string w = concat(exception::name("out_of_range", id_), exception::diagnostics(context), what_arg);
+        const std::string w = concat(exception::name("out_of_range", id_), exception::diagnostics(context), what_arg);
         return {id_, w.c_str()};
     }
 
@@ -4506,7 +4577,7 @@ class other_error : public exception
     template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
     static other_error create(int id_, const std::string& what_arg, BasicJsonContext context)
     {
-        std::string w = concat(exception::name("other_error", id_), exception::diagnostics(context), what_arg);
+        const std::string w = concat(exception::name("other_error", id_), exception::diagnostics(context), what_arg);
         return {id_, w.c_str()};
     }
 
@@ -4525,10 +4596,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/meta/identity_tag.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -4549,10 +4620,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/meta/std_fs.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -5055,10 +5126,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/conversions/to_json.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -5075,10 +5146,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/iterators/iteration_proxy.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -5147,10 +5218,10 @@ template<typename IteratorType> class iteration_proxy_value
     // older GCCs are a bit fussy and require explicit noexcept specifiers on defaulted functions
     iteration_proxy_value(iteration_proxy_value&&)
     noexcept(std::is_nothrow_move_constructible<IteratorType>::value
-             && std::is_nothrow_move_constructible<string_type>::value) = default;
+             && std::is_nothrow_move_constructible<string_type>::value) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor,cppcoreguidelines-noexcept-move-operations)
     iteration_proxy_value& operator=(iteration_proxy_value&&)
     noexcept(std::is_nothrow_move_assignable<IteratorType>::value
-             && std::is_nothrow_move_assignable<string_type>::value) = default;
+             && std::is_nothrow_move_assignable<string_type>::value) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor,cppcoreguidelines-noexcept-move-operations)
     ~iteration_proxy_value() = default;
 
     /// dereference operator (needed for range-based for)
@@ -5297,11 +5368,11 @@ namespace std
     #pragma clang diagnostic ignored "-Wmismatched-tags"
 #endif
 template<typename IteratorType>
-class tuple_size<::nlohmann::detail::iteration_proxy_value<IteratorType>>
+class tuple_size<::nlohmann::detail::iteration_proxy_value<IteratorType>> // NOLINT(cert-dcl58-cpp)
             : public std::integral_constant<std::size_t, 2> {};
 
 template<std::size_t N, typename IteratorType>
-class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >>
+class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >> // NOLINT(cert-dcl58-cpp)
 {
   public:
     using type = decltype(
@@ -5340,7 +5411,7 @@ namespace detail
 
 /*
  * Note all external_constructor<>::construct functions need to call
- * j.m_value.destroy(j.m_type) to avoid a memory leak in case j contains an
+ * j.m_data.m_value.destroy(j.m_data.m_type) to avoid a memory leak in case j contains an
  * allocated value (e.g., a string). See bug issue
  * https://github.com/nlohmann/json/issues/2865 for more information.
  */
@@ -5353,9 +5424,9 @@ struct external_constructor<value_t::boolean>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::boolean_t b) noexcept
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::boolean;
-        j.m_value = b;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::boolean;
+        j.m_data.m_value = b;
         j.assert_invariant();
     }
 };
@@ -5366,18 +5437,18 @@ struct external_constructor<value_t::string>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, const typename BasicJsonType::string_t& s)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::string;
-        j.m_value = s;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::string;
+        j.m_data.m_value = s;
         j.assert_invariant();
     }
 
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::string_t&& s)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::string;
-        j.m_value = std::move(s);
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::string;
+        j.m_data.m_value = std::move(s);
         j.assert_invariant();
     }
 
@@ -5386,9 +5457,9 @@ struct external_constructor<value_t::string>
                              int > = 0 >
     static void construct(BasicJsonType& j, const CompatibleStringType& str)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::string;
-        j.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::string;
+        j.m_data.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
         j.assert_invariant();
     }
 };
@@ -5399,18 +5470,18 @@ struct external_constructor<value_t::binary>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, const typename BasicJsonType::binary_t& b)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::binary;
-        j.m_value = typename BasicJsonType::binary_t(b);
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::binary;
+        j.m_data.m_value = typename BasicJsonType::binary_t(b);
         j.assert_invariant();
     }
 
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::binary_t&& b)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::binary;
-        j.m_value = typename BasicJsonType::binary_t(std::move(b));
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::binary;
+        j.m_data.m_value = typename BasicJsonType::binary_t(std::move(b));
         j.assert_invariant();
     }
 };
@@ -5421,9 +5492,9 @@ struct external_constructor<value_t::number_float>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::number_float_t val) noexcept
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::number_float;
-        j.m_value = val;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::number_float;
+        j.m_data.m_value = val;
         j.assert_invariant();
     }
 };
@@ -5434,9 +5505,9 @@ struct external_constructor<value_t::number_unsigned>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::number_unsigned_t val) noexcept
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::number_unsigned;
-        j.m_value = val;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::number_unsigned;
+        j.m_data.m_value = val;
         j.assert_invariant();
     }
 };
@@ -5447,9 +5518,9 @@ struct external_constructor<value_t::number_integer>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::number_integer_t val) noexcept
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::number_integer;
-        j.m_value = val;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::number_integer;
+        j.m_data.m_value = val;
         j.assert_invariant();
     }
 };
@@ -5460,9 +5531,9 @@ struct external_constructor<value_t::array>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, const typename BasicJsonType::array_t& arr)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::array;
-        j.m_value = arr;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = arr;
         j.set_parents();
         j.assert_invariant();
     }
@@ -5470,9 +5541,9 @@ struct external_constructor<value_t::array>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::array;
-        j.m_value = std::move(arr);
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = std::move(arr);
         j.set_parents();
         j.assert_invariant();
     }
@@ -5485,9 +5556,9 @@ struct external_constructor<value_t::array>
         using std::begin;
         using std::end;
 
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::array;
-        j.m_value.array = j.template create<typename BasicJsonType::array_t>(begin(arr), end(arr));
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value.array = j.template create<typename BasicJsonType::array_t>(begin(arr), end(arr));
         j.set_parents();
         j.assert_invariant();
     }
@@ -5495,14 +5566,14 @@ struct external_constructor<value_t::array>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, const std::vector<bool>& arr)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::array;
-        j.m_value = value_t::array;
-        j.m_value.array->reserve(arr.size());
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = value_t::array;
+        j.m_data.m_value.array->reserve(arr.size());
         for (const bool x : arr)
         {
-            j.m_value.array->push_back(x);
-            j.set_parent(j.m_value.array->back());
+            j.m_data.m_value.array->push_back(x);
+            j.set_parent(j.m_data.m_value.array->back());
         }
         j.assert_invariant();
     }
@@ -5511,13 +5582,13 @@ struct external_constructor<value_t::array>
              enable_if_t<std::is_convertible<T, BasicJsonType>::value, int> = 0>
     static void construct(BasicJsonType& j, const std::valarray<T>& arr)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::array;
-        j.m_value = value_t::array;
-        j.m_value.array->resize(arr.size());
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = value_t::array;
+        j.m_data.m_value.array->resize(arr.size());
         if (arr.size() > 0)
         {
-            std::copy(std::begin(arr), std::end(arr), j.m_value.array->begin());
+            std::copy(std::begin(arr), std::end(arr), j.m_data.m_value.array->begin());
         }
         j.set_parents();
         j.assert_invariant();
@@ -5530,9 +5601,9 @@ struct external_constructor<value_t::object>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, const typename BasicJsonType::object_t& obj)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::object;
-        j.m_value = obj;
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::object;
+        j.m_data.m_value = obj;
         j.set_parents();
         j.assert_invariant();
     }
@@ -5540,9 +5611,9 @@ struct external_constructor<value_t::object>
     template<typename BasicJsonType>
     static void construct(BasicJsonType& j, typename BasicJsonType::object_t&& obj)
     {
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::object;
-        j.m_value = std::move(obj);
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::object;
+        j.m_data.m_value = std::move(obj);
         j.set_parents();
         j.assert_invariant();
     }
@@ -5554,9 +5625,9 @@ struct external_constructor<value_t::object>
         using std::begin;
         using std::end;
 
-        j.m_value.destroy(j.m_type);
-        j.m_type = value_t::object;
-        j.m_value.object = j.template create<typename BasicJsonType::object_t>(begin(obj), end(obj));
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::object;
+        j.m_data.m_value.object = j.template create<typename BasicJsonType::object_t>(begin(obj), end(obj));
         j.set_parents();
         j.assert_invariant();
     }
@@ -5796,10 +5867,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/byte_container_with_subtype.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -5908,10 +5979,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/hash.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -6041,10 +6112,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/input/binary_reader.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -6067,10 +6138,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/input/input_adapters.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -6093,6 +6164,8 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/iterators/iterator_traits.hpp>
 
 // #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
 
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
@@ -6139,7 +6212,6 @@ class file_input_adapter
     /// the file pointer to read from
     std::FILE* m_file;
 };
-
 
 /*!
 Input adapter for a (caching) istream. Ignores a UFT Byte Order Mark at
@@ -6214,16 +6286,16 @@ class iterator_input_adapter
         : current(std::move(first)), end(std::move(last))
     {}
 
-    typename std::char_traits<char_type>::int_type get_character()
+    typename char_traits<char_type>::int_type get_character()
     {
         if (JSON_HEDLEY_LIKELY(current != end))
         {
-            auto result = std::char_traits<char_type>::to_int_type(*current);
+            auto result = char_traits<char_type>::to_int_type(*current);
             std::advance(current, 1);
             return result;
         }
 
-        return std::char_traits<char_type>::eof();
+        return char_traits<char_type>::eof();
     }
 
   private:
@@ -6238,7 +6310,6 @@ class iterator_input_adapter
         return current == end;
     }
 };
-
 
 template<typename BaseInputAdapter, size_t T>
 struct wide_string_input_helper;
@@ -6363,7 +6434,7 @@ struct wide_string_input_helper<BaseInputAdapter, 2>
     }
 };
 
-// Wraps another input apdater to convert wide character types into individual bytes.
+// Wraps another input adapter to convert wide character types into individual bytes.
 template<typename BaseInputAdapter, typename WideCharType>
 class wide_string_input_adapter
 {
@@ -6407,7 +6478,6 @@ class wide_string_input_adapter
     /// number of valid bytes in the utf8_codes array
     std::size_t utf8_bytes_filled = 0;
 };
-
 
 template<typename IteratorType, typename Enable = void>
 struct iterator_input_adapter_factory
@@ -6565,10 +6635,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/input/json_sax.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -6710,7 +6780,6 @@ struct json_sax
     virtual ~json_sax() = default;
 };
 
-
 namespace detail
 {
 /*!
@@ -6812,7 +6881,7 @@ class json_sax_dom_parser
         JSON_ASSERT(ref_stack.back()->is_object());
 
         // add null at given key and store the reference for later
-        object_element = &(ref_stack.back()->m_value.object->operator[](val));
+        object_element = &(ref_stack.back()->m_data.m_value.object->operator[](val));
         return true;
     }
 
@@ -6887,8 +6956,8 @@ class json_sax_dom_parser
 
         if (ref_stack.back()->is_array())
         {
-            ref_stack.back()->m_value.array->emplace_back(std::forward<Value>(v));
-            return &(ref_stack.back()->m_value.array->back());
+            ref_stack.back()->m_data.m_value.array->emplace_back(std::forward<Value>(v));
+            return &(ref_stack.back()->m_data.m_value.array->back());
         }
 
         JSON_ASSERT(ref_stack.back()->is_object());
@@ -7007,7 +7076,7 @@ class json_sax_dom_callback_parser
         // add discarded value at given key and store the reference for later
         if (keep && ref_stack.back())
         {
-            object_element = &(ref_stack.back()->m_value.object->operator[](val) = discarded);
+            object_element = &(ref_stack.back()->m_data.m_value.object->operator[](val) = discarded);
         }
 
         return true;
@@ -7092,7 +7161,7 @@ class json_sax_dom_callback_parser
         // remove discarded value
         if (!keep && !ref_stack.empty() && ref_stack.back()->is_array())
         {
-            ref_stack.back()->m_value.array->pop_back();
+            ref_stack.back()->m_data.m_value.array->pop_back();
         }
 
         return true;
@@ -7159,7 +7228,7 @@ class json_sax_dom_callback_parser
         if (ref_stack.empty())
         {
             root = std::move(value);
-            return {true, &root};
+            return {true, & root};
         }
 
         // skip this value if we already decided to skip the parent
@@ -7175,8 +7244,8 @@ class json_sax_dom_callback_parser
         // array
         if (ref_stack.back()->is_array())
         {
-            ref_stack.back()->m_value.array->emplace_back(std::move(value));
-            return {true, &(ref_stack.back()->m_value.array->back())};
+            ref_stack.back()->m_data.m_value.array->emplace_back(std::move(value));
+            return {true, & (ref_stack.back()->m_data.m_value.array->back())};
         }
 
         // object
@@ -7298,10 +7367,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/input/lexer.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -7321,6 +7390,8 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/input/position_t.hpp>
 
 // #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
 
 
 NLOHMANN_JSON_NAMESPACE_BEGIN
@@ -7416,7 +7487,7 @@ class lexer : public lexer_base<BasicJsonType>
     using number_float_t = typename BasicJsonType::number_float_t;
     using string_t = typename BasicJsonType::string_t;
     using char_type = typename InputAdapterType::char_type;
-    using char_int_type = typename std::char_traits<char_type>::int_type;
+    using char_int_type = typename char_traits<char_type>::int_type;
 
   public:
     using token_type = typename lexer_base<BasicJsonType>::token_type;
@@ -7523,7 +7594,7 @@ class lexer : public lexer_base<BasicJsonType>
         for (auto range = ranges.begin(); range != ranges.end(); ++range)
         {
             get();
-            if (JSON_HEDLEY_LIKELY(*range <= current && current <= *(++range)))
+            if (JSON_HEDLEY_LIKELY(*range <= current && current <= *(++range))) // NOLINT(bugprone-inc-dec-in-conditions)
             {
                 add(current);
             }
@@ -7566,7 +7637,7 @@ class lexer : public lexer_base<BasicJsonType>
             switch (get())
             {
                 // end of file while parsing string
-                case std::char_traits<char_type>::eof():
+                case char_traits<char_type>::eof():
                 {
                     error_message = "invalid string: missing closing quote";
                     return token_type::parse_error;
@@ -8155,7 +8226,7 @@ class lexer : public lexer_base<BasicJsonType>
                     {
                         case '\n':
                         case '\r':
-                        case std::char_traits<char_type>::eof():
+                        case char_traits<char_type>::eof():
                         case '\0':
                             return true;
 
@@ -8172,7 +8243,7 @@ class lexer : public lexer_base<BasicJsonType>
                 {
                     switch (get())
                     {
-                        case std::char_traits<char_type>::eof():
+                        case char_traits<char_type>::eof():
                         case '\0':
                         {
                             error_message = "invalid comment; missing closing '*/'";
@@ -8601,10 +8672,10 @@ scan_number_done:
     token_type scan_literal(const char_type* literal_text, const std::size_t length,
                             token_type return_type)
     {
-        JSON_ASSERT(std::char_traits<char_type>::to_char_type(current) == literal_text[0]);
+        JSON_ASSERT(char_traits<char_type>::to_char_type(current) == literal_text[0]);
         for (std::size_t i = 1; i < length; ++i)
         {
-            if (JSON_HEDLEY_UNLIKELY(std::char_traits<char_type>::to_char_type(get()) != literal_text[i]))
+            if (JSON_HEDLEY_UNLIKELY(char_traits<char_type>::to_char_type(get()) != literal_text[i]))
             {
                 error_message = "invalid literal";
                 return token_type::parse_error;
@@ -8622,7 +8693,7 @@ scan_number_done:
     {
         token_buffer.clear();
         token_string.clear();
-        token_string.push_back(std::char_traits<char_type>::to_char_type(current));
+        token_string.push_back(char_traits<char_type>::to_char_type(current));
     }
 
     /*
@@ -8630,7 +8701,7 @@ scan_number_done:
 
     This function provides the interface to the used input adapter. It does
     not throw in case the input reached EOF, but returns a
-    `std::char_traits<char>::eof()` in that case.  Stores the scanned characters
+    `char_traits<char>::eof()` in that case.  Stores the scanned characters
     for use in error messages.
 
     @return character read from the input
@@ -8650,9 +8721,9 @@ scan_number_done:
             current = ia.get_character();
         }
 
-        if (JSON_HEDLEY_LIKELY(current != std::char_traits<char_type>::eof()))
+        if (JSON_HEDLEY_LIKELY(current != char_traits<char_type>::eof()))
         {
-            token_string.push_back(std::char_traits<char_type>::to_char_type(current));
+            token_string.push_back(char_traits<char_type>::to_char_type(current));
         }
 
         if (current == '\n')
@@ -8691,7 +8762,7 @@ scan_number_done:
             --position.chars_read_current_line;
         }
 
-        if (JSON_HEDLEY_LIKELY(current != std::char_traits<char_type>::eof()))
+        if (JSON_HEDLEY_LIKELY(current != char_traits<char_type>::eof()))
         {
             JSON_ASSERT(!token_string.empty());
             token_string.pop_back();
@@ -8885,7 +8956,7 @@ scan_number_done:
             // end of input (the null byte is needed when parsing from
             // string literals)
             case '\0':
-            case std::char_traits<char_type>::eof():
+            case char_traits<char_type>::eof():
                 return token_type::end_of_input;
 
             // error
@@ -8903,7 +8974,7 @@ scan_number_done:
     const bool ignore_comments = false;
 
     /// the current character
-    char_int_type current = std::char_traits<char_type>::eof();
+    char_int_type current = char_traits<char_type>::eof();
 
     /// whether the next get() call should just return current
     bool next_unget = false;
@@ -8937,10 +9008,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/meta/is_sax.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -9129,7 +9200,6 @@ static inline bool little_endianness(int num = 1) noexcept
     return *reinterpret_cast<char*>(&num) == 1;
 }
 
-
 ///////////////////
 // binary reader //
 ///////////////////
@@ -9147,7 +9217,7 @@ class binary_reader
     using binary_t = typename BasicJsonType::binary_t;
     using json_sax_t = SAX;
     using char_type = typename InputAdapterType::char_type;
-    using char_int_type = typename std::char_traits<char_type>::int_type;
+    using char_int_type = typename char_traits<char_type>::int_type;
 
   public:
     /*!
@@ -9220,7 +9290,7 @@ class binary_reader
                 get();
             }
 
-            if (JSON_HEDLEY_UNLIKELY(current != std::char_traits<char_type>::eof()))
+            if (JSON_HEDLEY_UNLIKELY(current != char_traits<char_type>::eof()))
             {
                 return sax->parse_error(chars_read, get_token_string(), parse_error::create(110, chars_read,
                                         exception_message(input_format, concat("expected end of input; last byte: 0x", get_token_string()), "value"), nullptr));
@@ -9303,7 +9373,7 @@ class binary_reader
                                     exception_message(input_format_t::bson, concat("string length must be at least 1, is ", std::to_string(len)), "string"), nullptr));
         }
 
-        return get_string(input_format_t::bson, len - static_cast<NumberType>(1), result) && get() != std::char_traits<char_type>::eof();
+        return get_string(input_format_t::bson, len - static_cast<NumberType>(1), result) && get() != char_traits<char_type>::eof();
     }
 
     /*!
@@ -9404,7 +9474,7 @@ class binary_reader
             {
                 std::array<char, 3> cr{{}};
                 static_cast<void>((std::snprintf)(cr.data(), cr.size(), "%.2hhX", static_cast<unsigned char>(element_type))); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-                std::string cr_str{cr.data()};
+                const std::string cr_str{cr.data()};
                 return sax->parse_error(element_type_parse_position, cr_str,
                                         parse_error::create(114, element_type_parse_position, concat("Unsupported BSON record type 0x", cr_str), nullptr));
             }
@@ -9497,7 +9567,7 @@ class binary_reader
         switch (get_char ? get() : current)
         {
             // EOF
-            case std::char_traits<char_type>::eof():
+            case char_traits<char_type>::eof():
                 return unexpect_eof(input_format_t::cbor, "value");
 
             // Integer 0x00..0x17 (0..23)
@@ -10272,7 +10342,7 @@ class binary_reader
         switch (get())
         {
             // EOF
-            case std::char_traits<char_type>::eof():
+            case char_traits<char_type>::eof():
                 return unexpect_eof(input_format_t::msgpack, "value");
 
             // positive fixint
@@ -11227,7 +11297,7 @@ class binary_reader
                 }
                 if (is_ndarray) // ndarray dimensional vector can only contain integers, and can not embed another array
                 {
-                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimentional vector is not allowed", "size"), nullptr));
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimensional vector is not allowed", "size"), nullptr));
                 }
                 std::vector<size_t> dim;
                 if (JSON_HEDLEY_UNLIKELY(!get_ubjson_ndarray_size(dim)))
@@ -11339,7 +11409,7 @@ class binary_reader
                                         exception_message(input_format, concat("expected '#' after type information; last byte: 0x", last_token), "size"), nullptr));
             }
 
-            bool is_error = get_ubjson_size_value(result.first, is_ndarray);
+            const bool is_error = get_ubjson_size_value(result.first, is_ndarray);
             if (input_format == input_format_t::bjdata && is_ndarray)
             {
                 if (inside_ndarray)
@@ -11354,7 +11424,7 @@ class binary_reader
 
         if (current == '#')
         {
-            bool is_error = get_ubjson_size_value(result.first, is_ndarray);
+            const bool is_error = get_ubjson_size_value(result.first, is_ndarray);
             if (input_format == input_format_t::bjdata && is_ndarray)
             {
                 return sax->parse_error(chars_read, get_token_string(), parse_error::create(112, chars_read,
@@ -11374,7 +11444,7 @@ class binary_reader
     {
         switch (prefix)
         {
-            case std::char_traits<char_type>::eof():  // EOF
+            case char_traits<char_type>::eof():  // EOF
                 return unexpect_eof(input_format, "value");
 
             case 'T':  // true
@@ -11819,7 +11889,7 @@ class binary_reader
 
     This function provides the interface to the used input adapter. It does
     not throw in case the input reached EOF, but returns a -'ve valued
-    `std::char_traits<char_type>::eof()` in that case.
+    `char_traits<char_type>::eof()` in that case.
 
     @return character read from the input
     */
@@ -11961,7 +12031,7 @@ class binary_reader
     JSON_HEDLEY_NON_NULL(3)
     bool unexpect_eof(const input_format_t format, const char* context) const
     {
-        if (JSON_HEDLEY_UNLIKELY(current == std::char_traits<char_type>::eof()))
+        if (JSON_HEDLEY_UNLIKELY(current == char_traits<char_type>::eof()))
         {
             return sax->parse_error(chars_read, "<end of file>",
                                     parse_error::create(110, chars_read, exception_message(format, "unexpected end of input", context), nullptr));
@@ -12028,7 +12098,7 @@ class binary_reader
     InputAdapterType ia;
 
     /// the current character
-    char_int_type current = std::char_traits<char_type>::eof();
+    char_int_type current = char_traits<char_type>::eof();
 
     /// the number of characters read
     std::size_t chars_read = 0;
@@ -12090,10 +12160,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/input/parser.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -12439,13 +12509,25 @@ class parser
                                                 m_lexer.get_token_string(),
                                                 parse_error::create(101, m_lexer.get_position(), exception_message(token_type::uninitialized, "value"), nullptr));
                     }
+                    case token_type::end_of_input:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(m_lexer.get_position().chars_read_total == 1))
+                        {
+                            return sax->parse_error(m_lexer.get_position(),
+                                                    m_lexer.get_token_string(),
+                                                    parse_error::create(101, m_lexer.get_position(),
+                                                            "attempting to parse an empty input; check that your input string or stream contains the expected JSON", nullptr));
+                        }
 
+                        return sax->parse_error(m_lexer.get_position(),
+                                                m_lexer.get_token_string(),
+                                                parse_error::create(101, m_lexer.get_position(), exception_message(token_type::literal_or_value, "value"), nullptr));
+                    }
                     case token_type::uninitialized:
                     case token_type::end_array:
                     case token_type::end_object:
                     case token_type::name_separator:
                     case token_type::value_separator:
-                    case token_type::end_of_input:
                     case token_type::literal_or_value:
                     default: // the last token was unexpected
                     {
@@ -12607,10 +12689,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/iterators/internal_iterator.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -12620,10 +12702,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/iterators/primitive_iterator.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -12779,10 +12861,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/iterators/iter_impl.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -12887,7 +12969,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
             {
@@ -12984,17 +13066,17 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
             {
-                m_it.object_iterator = m_object->m_value.object->begin();
+                m_it.object_iterator = m_object->m_data.m_value.object->begin();
                 break;
             }
 
             case value_t::array:
             {
-                m_it.array_iterator = m_object->m_value.array->begin();
+                m_it.array_iterator = m_object->m_data.m_value.array->begin();
                 break;
             }
 
@@ -13028,17 +13110,17 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
             {
-                m_it.object_iterator = m_object->m_value.object->end();
+                m_it.object_iterator = m_object->m_data.m_value.object->end();
                 break;
             }
 
             case value_t::array:
             {
-                m_it.array_iterator = m_object->m_value.array->end();
+                m_it.array_iterator = m_object->m_data.m_value.array->end();
                 break;
             }
 
@@ -13067,17 +13149,17 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
             {
-                JSON_ASSERT(m_it.object_iterator != m_object->m_value.object->end());
+                JSON_ASSERT(m_it.object_iterator != m_object->m_data.m_value.object->end());
                 return m_it.object_iterator->second;
             }
 
             case value_t::array:
             {
-                JSON_ASSERT(m_it.array_iterator != m_object->m_value.array->end());
+                JSON_ASSERT(m_it.array_iterator != m_object->m_data.m_value.array->end());
                 return *m_it.array_iterator;
             }
 
@@ -13111,17 +13193,17 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
             {
-                JSON_ASSERT(m_it.object_iterator != m_object->m_value.object->end());
+                JSON_ASSERT(m_it.object_iterator != m_object->m_data.m_value.object->end());
                 return &(m_it.object_iterator->second);
             }
 
             case value_t::array:
             {
-                JSON_ASSERT(m_it.array_iterator != m_object->m_value.array->end());
+                JSON_ASSERT(m_it.array_iterator != m_object->m_data.m_value.array->end());
                 return &*m_it.array_iterator;
             }
 
@@ -13164,7 +13246,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
             {
@@ -13215,7 +13297,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
             {
@@ -13262,7 +13344,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
 
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
                 return (m_it.object_iterator == other.m_it.object_iterator);
@@ -13307,7 +13389,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
 
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
                 JSON_THROW(invalid_iterator::create(213, "cannot compare order of object iterators", m_object));
@@ -13363,7 +13445,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
                 JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators", m_object));
@@ -13442,7 +13524,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
                 JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators", m_object));
@@ -13471,7 +13553,7 @@ class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-speci
     {
         JSON_ASSERT(m_object != nullptr);
 
-        switch (m_object->m_type)
+        switch (m_object->m_data.m_type)
         {
             case value_t::object:
                 JSON_THROW(invalid_iterator::create(208, "cannot use operator[] for object iterators", m_object));
@@ -13541,10 +13623,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/iterators/json_reverse_iterator.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -13673,13 +13755,55 @@ NLOHMANN_JSON_NAMESPACE_END
 
 // #include <nlohmann/detail/iterators/primitive_iterator.hpp>
 
+// #include <nlohmann/detail/json_custom_base_class.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <type_traits> // conditional, is_same
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/*!
+@brief Default base class of the @ref basic_json class.
+
+So that the correct implementations of the copy / move ctors / assign operators
+of @ref basic_json do not require complex case distinctions
+(no base class / custom base class used as customization point),
+@ref basic_json always has a base class.
+By default, this class is used because it is empty and thus has no effect
+on the behavior of @ref basic_json.
+*/
+struct json_default_base {};
+
+template<class T>
+using json_base_class = typename std::conditional <
+                        std::is_same<T, void>::value,
+                        json_default_base,
+                        T
+                        >::type;
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
 // #include <nlohmann/detail/json_pointer.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -13911,7 +14035,7 @@ class json_pointer
         const char* p = s.c_str();
         char* p_end = nullptr;
         errno = 0; // strtoull doesn't reset errno
-        unsigned long long res = std::strtoull(p, &p_end, 10); // NOLINT(runtime/int)
+        const unsigned long long res = std::strtoull(p, &p_end, 10); // NOLINT(runtime/int)
         if (p == p_end // invalid input or empty string
                 || errno == ERANGE // out of range
                 || JSON_HEDLEY_UNLIKELY(static_cast<std::size_t>(p_end - p) != s.size())) // incomplete read
@@ -14067,7 +14191,7 @@ class json_pointer
                     if (reference_token == "-")
                     {
                         // explicitly treat "-" as index beyond the end
-                        ptr = &ptr->operator[](ptr->m_value.array->size());
+                        ptr = &ptr->operator[](ptr->m_data.m_value.array->size());
                     }
                     else
                     {
@@ -14119,7 +14243,7 @@ class json_pointer
                     {
                         // "-" always fails the range check
                         JSON_THROW(detail::out_of_range::create(402, detail::concat(
-                                "array index '-' (", std::to_string(ptr->m_value.array->size()),
+                                "array index '-' (", std::to_string(ptr->m_data.m_value.array->size()),
                                 ") is out of range"), ptr));
                     }
 
@@ -14176,7 +14300,7 @@ class json_pointer
                     if (JSON_HEDLEY_UNLIKELY(reference_token == "-"))
                     {
                         // "-" cannot be used for const access
-                        JSON_THROW(detail::out_of_range::create(402, detail::concat("array index '-' (", std::to_string(ptr->m_value.array->size()), ") is out of range"), ptr));
+                        JSON_THROW(detail::out_of_range::create(402, detail::concat("array index '-' (", std::to_string(ptr->m_data.m_value.array->size()), ") is out of range"), ptr));
                     }
 
                     // use unchecked array access
@@ -14226,7 +14350,7 @@ class json_pointer
                     {
                         // "-" always fails the range check
                         JSON_THROW(detail::out_of_range::create(402, detail::concat(
-                                "array index '-' (", std::to_string(ptr->m_value.array->size()),
+                                "array index '-' (", std::to_string(ptr->m_data.m_value.array->size()),
                                 ") is out of range"), ptr));
                     }
 
@@ -14421,7 +14545,7 @@ class json_pointer
         {
             case detail::value_t::array:
             {
-                if (value.m_value.array->empty())
+                if (value.m_data.m_value.array->empty())
                 {
                     // flatten empty array as null
                     result[reference_string] = nullptr;
@@ -14429,10 +14553,10 @@ class json_pointer
                 else
                 {
                     // iterate array and use index as reference string
-                    for (std::size_t i = 0; i < value.m_value.array->size(); ++i)
+                    for (std::size_t i = 0; i < value.m_data.m_value.array->size(); ++i)
                     {
                         flatten(detail::concat(reference_string, '/', std::to_string(i)),
-                                value.m_value.array->operator[](i), result);
+                                value.m_data.m_value.array->operator[](i), result);
                     }
                 }
                 break;
@@ -14440,7 +14564,7 @@ class json_pointer
 
             case detail::value_t::object:
             {
-                if (value.m_value.object->empty())
+                if (value.m_data.m_value.object->empty())
                 {
                     // flatten empty object as null
                     result[reference_string] = nullptr;
@@ -14448,7 +14572,7 @@ class json_pointer
                 else
                 {
                     // iterate object and use keys as reference string
-                    for (const auto& element : *value.m_value.object)
+                    for (const auto& element : *value.m_data.m_value.object)
                     {
                         flatten(detail::concat(reference_string, '/', detail::escape(element.first)), element.second, result);
                     }
@@ -14495,7 +14619,7 @@ class json_pointer
         BasicJsonType result;
 
         // iterate the JSON object values
-        for (const auto& element : *value.m_value.object)
+        for (const auto& element : *value.m_data.m_value.object)
         {
             if (JSON_HEDLEY_UNLIKELY(!element.second.is_primitive()))
             {
@@ -14671,10 +14795,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/json_ref.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -14763,10 +14887,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/output/binary_writer.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -14789,10 +14913,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/output/output_adapters.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -14978,7 +15102,7 @@ class binary_writer
         {
             case value_t::object:
             {
-                write_bson_object(*j.m_value.object);
+                write_bson_object(*j.m_data.m_value.object);
                 break;
             }
 
@@ -15013,7 +15137,7 @@ class binary_writer
 
             case value_t::boolean:
             {
-                oa->write_character(j.m_value.boolean
+                oa->write_character(j.m_data.m_value.boolean
                                     ? to_char_type(0xF5)
                                     : to_char_type(0xF4));
                 break;
@@ -15021,42 +15145,42 @@ class binary_writer
 
             case value_t::number_integer:
             {
-                if (j.m_value.number_integer >= 0)
+                if (j.m_data.m_value.number_integer >= 0)
                 {
                     // CBOR does not differentiate between positive signed
                     // integers and unsigned integers. Therefore, we used the
                     // code from the value_t::number_unsigned case here.
-                    if (j.m_value.number_integer <= 0x17)
+                    if (j.m_data.m_value.number_integer <= 0x17)
                     {
-                        write_number(static_cast<std::uint8_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_integer <= (std::numeric_limits<std::uint8_t>::max)())
+                    else if (j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint8_t>::max)())
                     {
                         oa->write_character(to_char_type(0x18));
-                        write_number(static_cast<std::uint8_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_integer <= (std::numeric_limits<std::uint16_t>::max)())
+                    else if (j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint16_t>::max)())
                     {
                         oa->write_character(to_char_type(0x19));
-                        write_number(static_cast<std::uint16_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_integer <= (std::numeric_limits<std::uint32_t>::max)())
+                    else if (j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint32_t>::max)())
                     {
                         oa->write_character(to_char_type(0x1A));
-                        write_number(static_cast<std::uint32_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_integer));
                     }
                     else
                     {
                         oa->write_character(to_char_type(0x1B));
-                        write_number(static_cast<std::uint64_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_integer));
                     }
                 }
                 else
                 {
                     // The conversions below encode the sign in the first
                     // byte, and the value is converted to a positive number.
-                    const auto positive_number = -1 - j.m_value.number_integer;
-                    if (j.m_value.number_integer >= -24)
+                    const auto positive_number = -1 - j.m_data.m_value.number_integer;
+                    if (j.m_data.m_value.number_integer >= -24)
                     {
                         write_number(static_cast<std::uint8_t>(0x20 + positive_number));
                     }
@@ -15086,52 +15210,52 @@ class binary_writer
 
             case value_t::number_unsigned:
             {
-                if (j.m_value.number_unsigned <= 0x17)
+                if (j.m_data.m_value.number_unsigned <= 0x17)
                 {
-                    write_number(static_cast<std::uint8_t>(j.m_value.number_unsigned));
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_unsigned));
                 }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
                 {
                     oa->write_character(to_char_type(0x18));
-                    write_number(static_cast<std::uint8_t>(j.m_value.number_unsigned));
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_unsigned));
                 }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
                 {
                     oa->write_character(to_char_type(0x19));
-                    write_number(static_cast<std::uint16_t>(j.m_value.number_unsigned));
+                    write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_unsigned));
                 }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
                 {
                     oa->write_character(to_char_type(0x1A));
-                    write_number(static_cast<std::uint32_t>(j.m_value.number_unsigned));
+                    write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_unsigned));
                 }
                 else
                 {
                     oa->write_character(to_char_type(0x1B));
-                    write_number(static_cast<std::uint64_t>(j.m_value.number_unsigned));
+                    write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_unsigned));
                 }
                 break;
             }
 
             case value_t::number_float:
             {
-                if (std::isnan(j.m_value.number_float))
+                if (std::isnan(j.m_data.m_value.number_float))
                 {
                     // NaN is 0xf97e00 in CBOR
                     oa->write_character(to_char_type(0xF9));
                     oa->write_character(to_char_type(0x7E));
                     oa->write_character(to_char_type(0x00));
                 }
-                else if (std::isinf(j.m_value.number_float))
+                else if (std::isinf(j.m_data.m_value.number_float))
                 {
                     // Infinity is 0xf97c00, -Infinity is 0xf9fc00
                     oa->write_character(to_char_type(0xf9));
-                    oa->write_character(j.m_value.number_float > 0 ? to_char_type(0x7C) : to_char_type(0xFC));
+                    oa->write_character(j.m_data.m_value.number_float > 0 ? to_char_type(0x7C) : to_char_type(0xFC));
                     oa->write_character(to_char_type(0x00));
                 }
                 else
                 {
-                    write_compact_float(j.m_value.number_float, detail::input_format_t::cbor);
+                    write_compact_float(j.m_data.m_value.number_float, detail::input_format_t::cbor);
                 }
                 break;
             }
@@ -15139,7 +15263,7 @@ class binary_writer
             case value_t::string:
             {
                 // step 1: write control byte and the string length
-                const auto N = j.m_value.string->size();
+                const auto N = j.m_data.m_value.string->size();
                 if (N <= 0x17)
                 {
                     write_number(static_cast<std::uint8_t>(0x60 + N));
@@ -15169,15 +15293,15 @@ class binary_writer
 
                 // step 2: write the string
                 oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.string->c_str()),
-                    j.m_value.string->size());
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.string->c_str()),
+                    j.m_data.m_value.string->size());
                 break;
             }
 
             case value_t::array:
             {
                 // step 1: write control byte and the array size
-                const auto N = j.m_value.array->size();
+                const auto N = j.m_data.m_value.array->size();
                 if (N <= 0x17)
                 {
                     write_number(static_cast<std::uint8_t>(0x80 + N));
@@ -15206,7 +15330,7 @@ class binary_writer
                 // LCOV_EXCL_STOP
 
                 // step 2: write each element
-                for (const auto& el : *j.m_value.array)
+                for (const auto& el : *j.m_data.m_value.array)
                 {
                     write_cbor(el);
                 }
@@ -15215,32 +15339,32 @@ class binary_writer
 
             case value_t::binary:
             {
-                if (j.m_value.binary->has_subtype())
+                if (j.m_data.m_value.binary->has_subtype())
                 {
-                    if (j.m_value.binary->subtype() <= (std::numeric_limits<std::uint8_t>::max)())
+                    if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint8_t>::max)())
                     {
                         write_number(static_cast<std::uint8_t>(0xd8));
-                        write_number(static_cast<std::uint8_t>(j.m_value.binary->subtype()));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.binary->subtype()));
                     }
-                    else if (j.m_value.binary->subtype() <= (std::numeric_limits<std::uint16_t>::max)())
+                    else if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint16_t>::max)())
                     {
                         write_number(static_cast<std::uint8_t>(0xd9));
-                        write_number(static_cast<std::uint16_t>(j.m_value.binary->subtype()));
+                        write_number(static_cast<std::uint16_t>(j.m_data.m_value.binary->subtype()));
                     }
-                    else if (j.m_value.binary->subtype() <= (std::numeric_limits<std::uint32_t>::max)())
+                    else if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint32_t>::max)())
                     {
                         write_number(static_cast<std::uint8_t>(0xda));
-                        write_number(static_cast<std::uint32_t>(j.m_value.binary->subtype()));
+                        write_number(static_cast<std::uint32_t>(j.m_data.m_value.binary->subtype()));
                     }
-                    else if (j.m_value.binary->subtype() <= (std::numeric_limits<std::uint64_t>::max)())
+                    else if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint64_t>::max)())
                     {
                         write_number(static_cast<std::uint8_t>(0xdb));
-                        write_number(static_cast<std::uint64_t>(j.m_value.binary->subtype()));
+                        write_number(static_cast<std::uint64_t>(j.m_data.m_value.binary->subtype()));
                     }
                 }
 
                 // step 1: write control byte and the binary array size
-                const auto N = j.m_value.binary->size();
+                const auto N = j.m_data.m_value.binary->size();
                 if (N <= 0x17)
                 {
                     write_number(static_cast<std::uint8_t>(0x40 + N));
@@ -15270,7 +15394,7 @@ class binary_writer
 
                 // step 2: write each element
                 oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.binary->data()),
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.binary->data()),
                     N);
 
                 break;
@@ -15279,7 +15403,7 @@ class binary_writer
             case value_t::object:
             {
                 // step 1: write control byte and the object size
-                const auto N = j.m_value.object->size();
+                const auto N = j.m_data.m_value.object->size();
                 if (N <= 0x17)
                 {
                     write_number(static_cast<std::uint8_t>(0xA0 + N));
@@ -15308,7 +15432,7 @@ class binary_writer
                 // LCOV_EXCL_STOP
 
                 // step 2: write each element
-                for (const auto& el : *j.m_value.object)
+                for (const auto& el : *j.m_data.m_value.object)
                 {
                     write_cbor(el.first);
                     write_cbor(el.second);
@@ -15337,7 +15461,7 @@ class binary_writer
 
             case value_t::boolean: // true and false
             {
-                oa->write_character(j.m_value.boolean
+                oa->write_character(j.m_data.m_value.boolean
                                     ? to_char_type(0xC3)
                                     : to_char_type(0xC2));
                 break;
@@ -15345,75 +15469,75 @@ class binary_writer
 
             case value_t::number_integer:
             {
-                if (j.m_value.number_integer >= 0)
+                if (j.m_data.m_value.number_integer >= 0)
                 {
                     // MessagePack does not differentiate between positive
                     // signed integers and unsigned integers. Therefore, we used
                     // the code from the value_t::number_unsigned case here.
-                    if (j.m_value.number_unsigned < 128)
+                    if (j.m_data.m_value.number_unsigned < 128)
                     {
                         // positive fixnum
-                        write_number(static_cast<std::uint8_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
                     {
                         // uint 8
                         oa->write_character(to_char_type(0xCC));
-                        write_number(static_cast<std::uint8_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
                     {
                         // uint 16
                         oa->write_character(to_char_type(0xCD));
-                        write_number(static_cast<std::uint16_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
                     {
                         // uint 32
                         oa->write_character(to_char_type(0xCE));
-                        write_number(static_cast<std::uint32_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
                     {
                         // uint 64
                         oa->write_character(to_char_type(0xCF));
-                        write_number(static_cast<std::uint64_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_integer));
                     }
                 }
                 else
                 {
-                    if (j.m_value.number_integer >= -32)
+                    if (j.m_data.m_value.number_integer >= -32)
                     {
                         // negative fixnum
-                        write_number(static_cast<std::int8_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::int8_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<std::int8_t>::min)() &&
-                             j.m_value.number_integer <= (std::numeric_limits<std::int8_t>::max)())
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int8_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int8_t>::max)())
                     {
                         // int 8
                         oa->write_character(to_char_type(0xD0));
-                        write_number(static_cast<std::int8_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::int8_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<std::int16_t>::min)() &&
-                             j.m_value.number_integer <= (std::numeric_limits<std::int16_t>::max)())
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int16_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int16_t>::max)())
                     {
                         // int 16
                         oa->write_character(to_char_type(0xD1));
-                        write_number(static_cast<std::int16_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::int16_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<std::int32_t>::min)() &&
-                             j.m_value.number_integer <= (std::numeric_limits<std::int32_t>::max)())
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int32_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int32_t>::max)())
                     {
                         // int 32
                         oa->write_character(to_char_type(0xD2));
-                        write_number(static_cast<std::int32_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::int32_t>(j.m_data.m_value.number_integer));
                     }
-                    else if (j.m_value.number_integer >= (std::numeric_limits<std::int64_t>::min)() &&
-                             j.m_value.number_integer <= (std::numeric_limits<std::int64_t>::max)())
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int64_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int64_t>::max)())
                     {
                         // int 64
                         oa->write_character(to_char_type(0xD3));
-                        write_number(static_cast<std::int64_t>(j.m_value.number_integer));
+                        write_number(static_cast<std::int64_t>(j.m_data.m_value.number_integer));
                     }
                 }
                 break;
@@ -15421,48 +15545,48 @@ class binary_writer
 
             case value_t::number_unsigned:
             {
-                if (j.m_value.number_unsigned < 128)
+                if (j.m_data.m_value.number_unsigned < 128)
                 {
                     // positive fixnum
-                    write_number(static_cast<std::uint8_t>(j.m_value.number_integer));
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
                 }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
                 {
                     // uint 8
                     oa->write_character(to_char_type(0xCC));
-                    write_number(static_cast<std::uint8_t>(j.m_value.number_integer));
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
                 }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
                 {
                     // uint 16
                     oa->write_character(to_char_type(0xCD));
-                    write_number(static_cast<std::uint16_t>(j.m_value.number_integer));
+                    write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_integer));
                 }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
                 {
                     // uint 32
                     oa->write_character(to_char_type(0xCE));
-                    write_number(static_cast<std::uint32_t>(j.m_value.number_integer));
+                    write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_integer));
                 }
-                else if (j.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
                 {
                     // uint 64
                     oa->write_character(to_char_type(0xCF));
-                    write_number(static_cast<std::uint64_t>(j.m_value.number_integer));
+                    write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_integer));
                 }
                 break;
             }
 
             case value_t::number_float:
             {
-                write_compact_float(j.m_value.number_float, detail::input_format_t::msgpack);
+                write_compact_float(j.m_data.m_value.number_float, detail::input_format_t::msgpack);
                 break;
             }
 
             case value_t::string:
             {
                 // step 1: write control byte and the string length
-                const auto N = j.m_value.string->size();
+                const auto N = j.m_data.m_value.string->size();
                 if (N <= 31)
                 {
                     // fixstr
@@ -15489,15 +15613,15 @@ class binary_writer
 
                 // step 2: write the string
                 oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.string->c_str()),
-                    j.m_value.string->size());
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.string->c_str()),
+                    j.m_data.m_value.string->size());
                 break;
             }
 
             case value_t::array:
             {
                 // step 1: write control byte and the array size
-                const auto N = j.m_value.array->size();
+                const auto N = j.m_data.m_value.array->size();
                 if (N <= 15)
                 {
                     // fixarray
@@ -15517,7 +15641,7 @@ class binary_writer
                 }
 
                 // step 2: write each element
-                for (const auto& el : *j.m_value.array)
+                for (const auto& el : *j.m_data.m_value.array)
                 {
                     write_msgpack(el);
                 }
@@ -15528,10 +15652,10 @@ class binary_writer
             {
                 // step 0: determine if the binary type has a set subtype to
                 // determine whether or not to use the ext or fixext types
-                const bool use_ext = j.m_value.binary->has_subtype();
+                const bool use_ext = j.m_data.m_value.binary->has_subtype();
 
                 // step 1: write control byte and the byte string length
-                const auto N = j.m_value.binary->size();
+                const auto N = j.m_data.m_value.binary->size();
                 if (N <= (std::numeric_limits<std::uint8_t>::max)())
                 {
                     std::uint8_t output_type{};
@@ -15576,18 +15700,18 @@ class binary_writer
                 }
                 else if (N <= (std::numeric_limits<std::uint16_t>::max)())
                 {
-                    std::uint8_t output_type = use_ext
-                                               ? 0xC8 // ext 16
-                                               : 0xC5; // bin 16
+                    const std::uint8_t output_type = use_ext
+                                                     ? 0xC8 // ext 16
+                                                     : 0xC5; // bin 16
 
                     oa->write_character(to_char_type(output_type));
                     write_number(static_cast<std::uint16_t>(N));
                 }
                 else if (N <= (std::numeric_limits<std::uint32_t>::max)())
                 {
-                    std::uint8_t output_type = use_ext
-                                               ? 0xC9 // ext 32
-                                               : 0xC6; // bin 32
+                    const std::uint8_t output_type = use_ext
+                                                     ? 0xC9 // ext 32
+                                                     : 0xC6; // bin 32
 
                     oa->write_character(to_char_type(output_type));
                     write_number(static_cast<std::uint32_t>(N));
@@ -15596,12 +15720,12 @@ class binary_writer
                 // step 1.5: if this is an ext type, write the subtype
                 if (use_ext)
                 {
-                    write_number(static_cast<std::int8_t>(j.m_value.binary->subtype()));
+                    write_number(static_cast<std::int8_t>(j.m_data.m_value.binary->subtype()));
                 }
 
                 // step 2: write the byte string
                 oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.binary->data()),
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.binary->data()),
                     N);
 
                 break;
@@ -15610,7 +15734,7 @@ class binary_writer
             case value_t::object:
             {
                 // step 1: write control byte and the object size
-                const auto N = j.m_value.object->size();
+                const auto N = j.m_data.m_value.object->size();
                 if (N <= 15)
                 {
                     // fixmap
@@ -15630,7 +15754,7 @@ class binary_writer
                 }
 
                 // step 2: write each element
-                for (const auto& el : *j.m_value.object)
+                for (const auto& el : *j.m_data.m_value.object)
                 {
                     write_msgpack(el.first);
                     write_msgpack(el.second);
@@ -15670,7 +15794,7 @@ class binary_writer
             {
                 if (add_prefix)
                 {
-                    oa->write_character(j.m_value.boolean
+                    oa->write_character(j.m_data.m_value.boolean
                                         ? to_char_type('T')
                                         : to_char_type('F'));
                 }
@@ -15679,19 +15803,19 @@ class binary_writer
 
             case value_t::number_integer:
             {
-                write_number_with_ubjson_prefix(j.m_value.number_integer, add_prefix, use_bjdata);
+                write_number_with_ubjson_prefix(j.m_data.m_value.number_integer, add_prefix, use_bjdata);
                 break;
             }
 
             case value_t::number_unsigned:
             {
-                write_number_with_ubjson_prefix(j.m_value.number_unsigned, add_prefix, use_bjdata);
+                write_number_with_ubjson_prefix(j.m_data.m_value.number_unsigned, add_prefix, use_bjdata);
                 break;
             }
 
             case value_t::number_float:
             {
-                write_number_with_ubjson_prefix(j.m_value.number_float, add_prefix, use_bjdata);
+                write_number_with_ubjson_prefix(j.m_data.m_value.number_float, add_prefix, use_bjdata);
                 break;
             }
 
@@ -15701,10 +15825,10 @@ class binary_writer
                 {
                     oa->write_character(to_char_type('S'));
                 }
-                write_number_with_ubjson_prefix(j.m_value.string->size(), true, use_bjdata);
+                write_number_with_ubjson_prefix(j.m_data.m_value.string->size(), true, use_bjdata);
                 oa->write_characters(
-                    reinterpret_cast<const CharType*>(j.m_value.string->c_str()),
-                    j.m_value.string->size());
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.string->c_str()),
+                    j.m_data.m_value.string->size());
                 break;
             }
 
@@ -15716,7 +15840,7 @@ class binary_writer
                 }
 
                 bool prefix_required = true;
-                if (use_type && !j.m_value.array->empty())
+                if (use_type && !j.m_data.m_value.array->empty())
                 {
                     JSON_ASSERT(use_count);
                     const CharType first_prefix = ubjson_prefix(j.front(), use_bjdata);
@@ -15739,10 +15863,10 @@ class binary_writer
                 if (use_count)
                 {
                     oa->write_character(to_char_type('#'));
-                    write_number_with_ubjson_prefix(j.m_value.array->size(), true, use_bjdata);
+                    write_number_with_ubjson_prefix(j.m_data.m_value.array->size(), true, use_bjdata);
                 }
 
-                for (const auto& el : *j.m_value.array)
+                for (const auto& el : *j.m_data.m_value.array)
                 {
                     write_ubjson(el, use_count, use_type, prefix_required, use_bjdata);
                 }
@@ -15762,7 +15886,7 @@ class binary_writer
                     oa->write_character(to_char_type('['));
                 }
 
-                if (use_type && !j.m_value.binary->empty())
+                if (use_type && !j.m_data.m_value.binary->empty())
                 {
                     JSON_ASSERT(use_count);
                     oa->write_character(to_char_type('$'));
@@ -15772,21 +15896,21 @@ class binary_writer
                 if (use_count)
                 {
                     oa->write_character(to_char_type('#'));
-                    write_number_with_ubjson_prefix(j.m_value.binary->size(), true, use_bjdata);
+                    write_number_with_ubjson_prefix(j.m_data.m_value.binary->size(), true, use_bjdata);
                 }
 
                 if (use_type)
                 {
                     oa->write_characters(
-                        reinterpret_cast<const CharType*>(j.m_value.binary->data()),
-                        j.m_value.binary->size());
+                        reinterpret_cast<const CharType*>(j.m_data.m_value.binary->data()),
+                        j.m_data.m_value.binary->size());
                 }
                 else
                 {
-                    for (size_t i = 0; i < j.m_value.binary->size(); ++i)
+                    for (size_t i = 0; i < j.m_data.m_value.binary->size(); ++i)
                     {
                         oa->write_character(to_char_type('U'));
-                        oa->write_character(j.m_value.binary->data()[i]);
+                        oa->write_character(j.m_data.m_value.binary->data()[i]);
                     }
                 }
 
@@ -15800,9 +15924,9 @@ class binary_writer
 
             case value_t::object:
             {
-                if (use_bjdata && j.m_value.object->size() == 3 && j.m_value.object->find("_ArrayType_") != j.m_value.object->end() && j.m_value.object->find("_ArraySize_") != j.m_value.object->end() && j.m_value.object->find("_ArrayData_") != j.m_value.object->end())
+                if (use_bjdata && j.m_data.m_value.object->size() == 3 && j.m_data.m_value.object->find("_ArrayType_") != j.m_data.m_value.object->end() && j.m_data.m_value.object->find("_ArraySize_") != j.m_data.m_value.object->end() && j.m_data.m_value.object->find("_ArrayData_") != j.m_data.m_value.object->end())
                 {
-                    if (!write_bjdata_ndarray(*j.m_value.object, use_count, use_type))  // decode bjdata ndarray in the JData format (https://github.com/NeuroJSON/jdata)
+                    if (!write_bjdata_ndarray(*j.m_data.m_value.object, use_count, use_type))  // decode bjdata ndarray in the JData format (https://github.com/NeuroJSON/jdata)
                     {
                         break;
                     }
@@ -15814,7 +15938,7 @@ class binary_writer
                 }
 
                 bool prefix_required = true;
-                if (use_type && !j.m_value.object->empty())
+                if (use_type && !j.m_data.m_value.object->empty())
                 {
                     JSON_ASSERT(use_count);
                     const CharType first_prefix = ubjson_prefix(j.front(), use_bjdata);
@@ -15837,10 +15961,10 @@ class binary_writer
                 if (use_count)
                 {
                     oa->write_character(to_char_type('#'));
-                    write_number_with_ubjson_prefix(j.m_value.object->size(), true, use_bjdata);
+                    write_number_with_ubjson_prefix(j.m_data.m_value.object->size(), true, use_bjdata);
                 }
 
-                for (const auto& el : *j.m_value.object)
+                for (const auto& el : *j.m_data.m_value.object)
                 {
                     write_number_with_ubjson_prefix(el.first.size(), true, use_bjdata);
                     oa->write_characters(
@@ -15990,19 +16114,19 @@ class binary_writer
     void write_bson_unsigned(const string_t& name,
                              const BasicJsonType& j)
     {
-        if (j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
+        if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
         {
             write_bson_entry_header(name, 0x10 /* int32 */);
-            write_number<std::int32_t>(static_cast<std::int32_t>(j.m_value.number_unsigned), true);
+            write_number<std::int32_t>(static_cast<std::int32_t>(j.m_data.m_value.number_unsigned), true);
         }
-        else if (j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
+        else if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
         {
             write_bson_entry_header(name, 0x12 /* int64 */);
-            write_number<std::int64_t>(static_cast<std::int64_t>(j.m_value.number_unsigned), true);
+            write_number<std::int64_t>(static_cast<std::int64_t>(j.m_data.m_value.number_unsigned), true);
         }
         else
         {
-            JSON_THROW(out_of_range::create(407, concat("integer number ", std::to_string(j.m_value.number_unsigned), " cannot be represented by BSON as it does not fit int64"), &j));
+            JSON_THROW(out_of_range::create(407, concat("integer number ", std::to_string(j.m_data.m_value.number_unsigned), " cannot be represented by BSON as it does not fit int64"), &j));
         }
     }
 
@@ -16083,13 +16207,13 @@ class binary_writer
         switch (j.type())
         {
             case value_t::object:
-                return header_size + calc_bson_object_size(*j.m_value.object);
+                return header_size + calc_bson_object_size(*j.m_data.m_value.object);
 
             case value_t::array:
-                return header_size + calc_bson_array_size(*j.m_value.array);
+                return header_size + calc_bson_array_size(*j.m_data.m_value.array);
 
             case value_t::binary:
-                return header_size + calc_bson_binary_size(*j.m_value.binary);
+                return header_size + calc_bson_binary_size(*j.m_data.m_value.binary);
 
             case value_t::boolean:
                 return header_size + 1ul;
@@ -16098,13 +16222,13 @@ class binary_writer
                 return header_size + 8ul;
 
             case value_t::number_integer:
-                return header_size + calc_bson_integer_size(j.m_value.number_integer);
+                return header_size + calc_bson_integer_size(j.m_data.m_value.number_integer);
 
             case value_t::number_unsigned:
-                return header_size + calc_bson_unsigned_size(j.m_value.number_unsigned);
+                return header_size + calc_bson_unsigned_size(j.m_data.m_value.number_unsigned);
 
             case value_t::string:
-                return header_size + calc_bson_string_size(*j.m_value.string);
+                return header_size + calc_bson_string_size(*j.m_data.m_value.string);
 
             case value_t::null:
                 return header_size + 0ul;
@@ -16130,28 +16254,28 @@ class binary_writer
         switch (j.type())
         {
             case value_t::object:
-                return write_bson_object_entry(name, *j.m_value.object);
+                return write_bson_object_entry(name, *j.m_data.m_value.object);
 
             case value_t::array:
-                return write_bson_array(name, *j.m_value.array);
+                return write_bson_array(name, *j.m_data.m_value.array);
 
             case value_t::binary:
-                return write_bson_binary(name, *j.m_value.binary);
+                return write_bson_binary(name, *j.m_data.m_value.binary);
 
             case value_t::boolean:
-                return write_bson_boolean(name, j.m_value.boolean);
+                return write_bson_boolean(name, j.m_data.m_value.boolean);
 
             case value_t::number_float:
-                return write_bson_double(name, j.m_value.number_float);
+                return write_bson_double(name, j.m_data.m_value.number_float);
 
             case value_t::number_integer:
-                return write_bson_integer(name, j.m_value.number_integer);
+                return write_bson_integer(name, j.m_data.m_value.number_integer);
 
             case value_t::number_unsigned:
                 return write_bson_unsigned(name, j);
 
             case value_t::string:
-                return write_bson_string(name, *j.m_value.string);
+                return write_bson_string(name, *j.m_data.m_value.string);
 
             case value_t::null:
                 return write_bson_null(name);
@@ -16173,8 +16297,8 @@ class binary_writer
     */
     static std::size_t calc_bson_object_size(const typename BasicJsonType::object_t& value)
     {
-        std::size_t document_size = std::accumulate(value.begin(), value.end(), static_cast<std::size_t>(0),
-                                    [](size_t result, const typename BasicJsonType::object_t::value_type & el)
+        const std::size_t document_size = std::accumulate(value.begin(), value.end(), static_cast<std::size_t>(0),
+                                          [](size_t result, const typename BasicJsonType::object_t::value_type & el)
         {
             return result += calc_bson_element_size(el.first, el.second);
         });
@@ -16424,35 +16548,35 @@ class binary_writer
                 return 'Z';
 
             case value_t::boolean:
-                return j.m_value.boolean ? 'T' : 'F';
+                return j.m_data.m_value.boolean ? 'T' : 'F';
 
             case value_t::number_integer:
             {
-                if ((std::numeric_limits<std::int8_t>::min)() <= j.m_value.number_integer && j.m_value.number_integer <= (std::numeric_limits<std::int8_t>::max)())
+                if ((std::numeric_limits<std::int8_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int8_t>::max)())
                 {
                     return 'i';
                 }
-                if ((std::numeric_limits<std::uint8_t>::min)() <= j.m_value.number_integer && j.m_value.number_integer <= (std::numeric_limits<std::uint8_t>::max)())
+                if ((std::numeric_limits<std::uint8_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint8_t>::max)())
                 {
                     return 'U';
                 }
-                if ((std::numeric_limits<std::int16_t>::min)() <= j.m_value.number_integer && j.m_value.number_integer <= (std::numeric_limits<std::int16_t>::max)())
+                if ((std::numeric_limits<std::int16_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int16_t>::max)())
                 {
                     return 'I';
                 }
-                if (use_bjdata && ((std::numeric_limits<std::uint16_t>::min)() <= j.m_value.number_integer && j.m_value.number_integer <= (std::numeric_limits<std::uint16_t>::max)()))
+                if (use_bjdata && ((std::numeric_limits<std::uint16_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint16_t>::max)()))
                 {
                     return 'u';
                 }
-                if ((std::numeric_limits<std::int32_t>::min)() <= j.m_value.number_integer && j.m_value.number_integer <= (std::numeric_limits<std::int32_t>::max)())
+                if ((std::numeric_limits<std::int32_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int32_t>::max)())
                 {
                     return 'l';
                 }
-                if (use_bjdata && ((std::numeric_limits<std::uint32_t>::min)() <= j.m_value.number_integer && j.m_value.number_integer <= (std::numeric_limits<std::uint32_t>::max)()))
+                if (use_bjdata && ((std::numeric_limits<std::uint32_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint32_t>::max)()))
                 {
                     return 'm';
                 }
-                if ((std::numeric_limits<std::int64_t>::min)() <= j.m_value.number_integer && j.m_value.number_integer <= (std::numeric_limits<std::int64_t>::max)())
+                if ((std::numeric_limits<std::int64_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int64_t>::max)())
                 {
                     return 'L';
                 }
@@ -16462,35 +16586,35 @@ class binary_writer
 
             case value_t::number_unsigned:
             {
-                if (j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int8_t>::max)()))
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int8_t>::max)()))
                 {
                     return 'i';
                 }
-                if (j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint8_t>::max)()))
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint8_t>::max)()))
                 {
                     return 'U';
                 }
-                if (j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int16_t>::max)()))
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int16_t>::max)()))
                 {
                     return 'I';
                 }
-                if (use_bjdata && j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint16_t>::max)()))
+                if (use_bjdata && j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint16_t>::max)()))
                 {
                     return 'u';
                 }
-                if (j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
                 {
                     return 'l';
                 }
-                if (use_bjdata && j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint32_t>::max)()))
+                if (use_bjdata && j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint32_t>::max)()))
                 {
                     return 'm';
                 }
-                if (j.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
                 {
                     return 'L';
                 }
-                if (use_bjdata && j.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
+                if (use_bjdata && j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
                 {
                     return 'M';
                 }
@@ -16499,7 +16623,7 @@ class binary_writer
             }
 
             case value_t::number_float:
-                return get_ubjson_float_prefix(j.m_value.number_float);
+                return get_ubjson_float_prefix(j.m_data.m_value.number_float);
 
             case value_t::string:
                 return 'S';
@@ -16548,7 +16672,7 @@ class binary_writer
         std::size_t len = (value.at(key).empty() ? 0 : 1);
         for (const auto& el : value.at(key))
         {
-            len *= static_cast<std::size_t>(el.m_value.number_unsigned);
+            len *= static_cast<std::size_t>(el.m_data.m_value.number_unsigned);
         }
 
         key = "_ArrayData_";
@@ -16570,70 +16694,70 @@ class binary_writer
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::uint8_t>(el.m_value.number_unsigned), true);
+                write_number(static_cast<std::uint8_t>(el.m_data.m_value.number_unsigned), true);
             }
         }
         else if (dtype == 'i')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::int8_t>(el.m_value.number_integer), true);
+                write_number(static_cast<std::int8_t>(el.m_data.m_value.number_integer), true);
             }
         }
         else if (dtype == 'u')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::uint16_t>(el.m_value.number_unsigned), true);
+                write_number(static_cast<std::uint16_t>(el.m_data.m_value.number_unsigned), true);
             }
         }
         else if (dtype == 'I')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::int16_t>(el.m_value.number_integer), true);
+                write_number(static_cast<std::int16_t>(el.m_data.m_value.number_integer), true);
             }
         }
         else if (dtype == 'm')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::uint32_t>(el.m_value.number_unsigned), true);
+                write_number(static_cast<std::uint32_t>(el.m_data.m_value.number_unsigned), true);
             }
         }
         else if (dtype == 'l')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::int32_t>(el.m_value.number_integer), true);
+                write_number(static_cast<std::int32_t>(el.m_data.m_value.number_integer), true);
             }
         }
         else if (dtype == 'M')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::uint64_t>(el.m_value.number_unsigned), true);
+                write_number(static_cast<std::uint64_t>(el.m_data.m_value.number_unsigned), true);
             }
         }
         else if (dtype == 'L')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<std::int64_t>(el.m_value.number_integer), true);
+                write_number(static_cast<std::int64_t>(el.m_data.m_value.number_integer), true);
             }
         }
         else if (dtype == 'd')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<float>(el.m_value.number_float), true);
+                write_number(static_cast<float>(el.m_data.m_value.number_float), true);
             }
         }
         else if (dtype == 'D')
         {
             for (const auto& el : value.at(key))
             {
-                write_number(static_cast<double>(el.m_value.number_float), true);
+                write_number(static_cast<double>(el.m_data.m_value.number_float), true);
             }
         }
         return false;
@@ -16757,11 +16881,11 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/output/serializer.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
 // SPDX-FileCopyrightText: 2008-2009 Björn Hoehrmann <bjoern@hoehrmann.de>
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -16782,11 +16906,11 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/detail/conversions/to_chars.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
 // SPDX-FileCopyrightText: 2009 Florian Loitsch <https://florian.loitsch.com/>
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -17692,7 +17816,7 @@ void grisu2(char* buf, int& len, int& decimal_exponent, FloatType value)
     // NB: If the neighbors are computed for single-precision numbers, there is a single float
     //     (7.0385307e-26f) which can't be recovered using strtod. The resulting double precision
     //     value is off by 1 ulp.
-#if 0
+#if 0 // NOLINT(readability-avoid-unconditional-preprocessor-if)
     const boundaries w = compute_boundaries(static_cast<double>(value));
 #else
     const boundaries w = compute_boundaries(value);
@@ -17994,11 +18118,11 @@ class serializer
               const unsigned int indent_step,
               const unsigned int current_indent = 0)
     {
-        switch (val.m_type)
+        switch (val.m_data.m_type)
         {
             case value_t::object:
             {
-                if (val.m_value.object->empty())
+                if (val.m_data.m_value.object->empty())
                 {
                     o->write_characters("{}", 2);
                     return;
@@ -18016,8 +18140,8 @@ class serializer
                     }
 
                     // first n-1 elements
-                    auto i = val.m_value.object->cbegin();
-                    for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i)
+                    auto i = val.m_data.m_value.object->cbegin();
+                    for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         o->write_characters(indent_string.c_str(), new_indent);
                         o->write_character('\"');
@@ -18028,8 +18152,8 @@ class serializer
                     }
 
                     // last element
-                    JSON_ASSERT(i != val.m_value.object->cend());
-                    JSON_ASSERT(std::next(i) == val.m_value.object->cend());
+                    JSON_ASSERT(i != val.m_data.m_value.object->cend());
+                    JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     o->write_characters(indent_string.c_str(), new_indent);
                     o->write_character('\"');
                     dump_escaped(i->first, ensure_ascii);
@@ -18045,8 +18169,8 @@ class serializer
                     o->write_character('{');
 
                     // first n-1 elements
-                    auto i = val.m_value.object->cbegin();
-                    for (std::size_t cnt = 0; cnt < val.m_value.object->size() - 1; ++cnt, ++i)
+                    auto i = val.m_data.m_value.object->cbegin();
+                    for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
                     {
                         o->write_character('\"');
                         dump_escaped(i->first, ensure_ascii);
@@ -18056,8 +18180,8 @@ class serializer
                     }
 
                     // last element
-                    JSON_ASSERT(i != val.m_value.object->cend());
-                    JSON_ASSERT(std::next(i) == val.m_value.object->cend());
+                    JSON_ASSERT(i != val.m_data.m_value.object->cend());
+                    JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
                     o->write_character('\"');
                     dump_escaped(i->first, ensure_ascii);
                     o->write_characters("\":", 2);
@@ -18071,7 +18195,7 @@ class serializer
 
             case value_t::array:
             {
-                if (val.m_value.array->empty())
+                if (val.m_data.m_value.array->empty())
                 {
                     o->write_characters("[]", 2);
                     return;
@@ -18089,8 +18213,8 @@ class serializer
                     }
 
                     // first n-1 elements
-                    for (auto i = val.m_value.array->cbegin();
-                            i != val.m_value.array->cend() - 1; ++i)
+                    for (auto i = val.m_data.m_value.array->cbegin();
+                            i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
                         o->write_characters(indent_string.c_str(), new_indent);
                         dump(*i, true, ensure_ascii, indent_step, new_indent);
@@ -18098,9 +18222,9 @@ class serializer
                     }
 
                     // last element
-                    JSON_ASSERT(!val.m_value.array->empty());
+                    JSON_ASSERT(!val.m_data.m_value.array->empty());
                     o->write_characters(indent_string.c_str(), new_indent);
-                    dump(val.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+                    dump(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
 
                     o->write_character('\n');
                     o->write_characters(indent_string.c_str(), current_indent);
@@ -18111,16 +18235,16 @@ class serializer
                     o->write_character('[');
 
                     // first n-1 elements
-                    for (auto i = val.m_value.array->cbegin();
-                            i != val.m_value.array->cend() - 1; ++i)
+                    for (auto i = val.m_data.m_value.array->cbegin();
+                            i != val.m_data.m_value.array->cend() - 1; ++i)
                     {
                         dump(*i, false, ensure_ascii, indent_step, current_indent);
                         o->write_character(',');
                     }
 
                     // last element
-                    JSON_ASSERT(!val.m_value.array->empty());
-                    dump(val.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+                    JSON_ASSERT(!val.m_data.m_value.array->empty());
+                    dump(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
 
                     o->write_character(']');
                 }
@@ -18131,7 +18255,7 @@ class serializer
             case value_t::string:
             {
                 o->write_character('\"');
-                dump_escaped(*val.m_value.string, ensure_ascii);
+                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
                 o->write_character('\"');
                 return;
             }
@@ -18153,24 +18277,24 @@ class serializer
 
                     o->write_characters("\"bytes\": [", 10);
 
-                    if (!val.m_value.binary->empty())
+                    if (!val.m_data.m_value.binary->empty())
                     {
-                        for (auto i = val.m_value.binary->cbegin();
-                                i != val.m_value.binary->cend() - 1; ++i)
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
                             o->write_characters(", ", 2);
                         }
-                        dump_integer(val.m_value.binary->back());
+                        dump_integer(val.m_data.m_value.binary->back());
                     }
 
                     o->write_characters("],\n", 3);
                     o->write_characters(indent_string.c_str(), new_indent);
 
                     o->write_characters("\"subtype\": ", 11);
-                    if (val.m_value.binary->has_subtype())
+                    if (val.m_data.m_value.binary->has_subtype())
                     {
-                        dump_integer(val.m_value.binary->subtype());
+                        dump_integer(val.m_data.m_value.binary->subtype());
                     }
                     else
                     {
@@ -18184,21 +18308,21 @@ class serializer
                 {
                     o->write_characters("{\"bytes\":[", 10);
 
-                    if (!val.m_value.binary->empty())
+                    if (!val.m_data.m_value.binary->empty())
                     {
-                        for (auto i = val.m_value.binary->cbegin();
-                                i != val.m_value.binary->cend() - 1; ++i)
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
                         {
                             dump_integer(*i);
                             o->write_character(',');
                         }
-                        dump_integer(val.m_value.binary->back());
+                        dump_integer(val.m_data.m_value.binary->back());
                     }
 
                     o->write_characters("],\"subtype\":", 12);
-                    if (val.m_value.binary->has_subtype())
+                    if (val.m_data.m_value.binary->has_subtype())
                     {
-                        dump_integer(val.m_value.binary->subtype());
+                        dump_integer(val.m_data.m_value.binary->subtype());
                         o->write_character('}');
                     }
                     else
@@ -18211,7 +18335,7 @@ class serializer
 
             case value_t::boolean:
             {
-                if (val.m_value.boolean)
+                if (val.m_data.m_value.boolean)
                 {
                     o->write_characters("true", 4);
                 }
@@ -18224,19 +18348,19 @@ class serializer
 
             case value_t::number_integer:
             {
-                dump_integer(val.m_value.number_integer);
+                dump_integer(val.m_data.m_value.number_integer);
                 return;
             }
 
             case value_t::number_unsigned:
             {
-                dump_integer(val.m_value.number_unsigned);
+                dump_integer(val.m_data.m_value.number_unsigned);
                 return;
             }
 
             case value_t::number_float:
             {
-                dump_float(val.m_value.number_float);
+                dump_float(val.m_data.m_value.number_float);
                 return;
             }
 
@@ -18810,8 +18934,8 @@ class serializer
                 ? (byte & 0x3fu) | (codep << 6u)
                 : (0xFFu >> type) & (byte);
 
-        std::size_t index = 256u + static_cast<size_t>(state) * 16u + static_cast<size_t>(type);
-        JSON_ASSERT(index < 400);
+        const std::size_t index = 256u + static_cast<size_t>(state) * 16u + static_cast<size_t>(type);
+        JSON_ASSERT(index < utf8d.size());
         state = utf8d[index];
         return state;
     }
@@ -18878,10 +19002,10 @@ NLOHMANN_JSON_NAMESPACE_END
 // #include <nlohmann/ordered_map.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -18998,7 +19122,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    T & at(KeyType && key)
+    T & at(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -19026,7 +19150,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    const T & at(KeyType && key) const
+    const T & at(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -19060,7 +19184,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    size_type erase(KeyType && key)
+    size_type erase(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -19151,7 +19275,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    size_type count(KeyType && key) const
+    size_type count(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -19177,7 +19301,7 @@ template <class Key, class T, class IgnoredLess = std::less<Key>,
 
     template<class KeyType, detail::enable_if_t<
                  detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
-    iterator find(KeyType && key)
+    iterator find(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
     {
         for (auto it = this->begin(); it != this->end(); ++it)
         {
@@ -19240,7 +19364,9 @@ NLOHMANN_JSON_NAMESPACE_END
 
 
 #if defined(JSON_HAS_CPP_17)
-    #include <any>
+    #if JSON_HAS_STATIC_RTTI
+        #include <any>
+    #endif
     #include <string_view>
 #endif
 
@@ -19271,6 +19397,7 @@ The invariants are checked by member function assert_invariant().
 */
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
 class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
+    : public ::nlohmann::detail::json_base_class<CustomBaseClass>
 {
   private:
     template<detail::value_t> friend struct detail::external_constructor;
@@ -19297,6 +19424,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// workaround type for MSVC
     using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
+    using json_base_class_t = ::nlohmann::detail::json_base_class<CustomBaseClass>;
 
   JSON_PRIVATE_UNLESS_TESTED:
     // convenience aliases for types residing in namespace detail;
@@ -19368,7 +19496,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @}
 
-
     /////////////////////
     // container types //
     /////////////////////
@@ -19410,7 +19537,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @}
 
-
     /// @brief returns the allocator associated with the container
     /// @sa https://json.nlohmann.me/api/basic_json/get_allocator/
     static allocator_type get_allocator()
@@ -19425,7 +19551,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     {
         basic_json result;
 
-        result["copyright"] = "(C) 2013-2022 Niels Lohmann";
+        result["copyright"] = "(C) 2013-2023 Niels Lohmann";
         result["name"] = "JSON for Modern C++";
         result["url"] = "https://github.com/nlohmann/json";
         result["version"]["string"] =
@@ -19473,7 +19599,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         result["compiler"] = {{"family", "unknown"}, {"version", "unknown"}};
 #endif
 
-
 #if defined(_MSVC_LANG)
         result["compiler"]["c++"] = std::to_string(_MSVC_LANG);
 #elif defined(__cplusplus)
@@ -19483,7 +19608,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 #endif
         return result;
     }
-
 
     ///////////////////////////
     // JSON value data types //
@@ -19692,7 +19816,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                     object = nullptr;  // silence warning, see #821
                     if (JSON_HEDLEY_UNLIKELY(t == value_t::null))
                     {
-                        JSON_THROW(other_error::create(500, "961c151d2e87f2686a955a9be24d316f1362bf21 3.11.2", nullptr)); // LCOV_EXCL_LINE
+                        JSON_THROW(other_error::create(500, "961c151d2e87f2686a955a9be24d316f1362bf21 3.11.3", nullptr)); // LCOV_EXCL_LINE
                     }
                     break;
                 }
@@ -19731,6 +19855,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         void destroy(value_t t)
         {
+            if (
+                (t == value_t::object && object == nullptr) ||
+                (t == value_t::array && array == nullptr) ||
+                (t == value_t::string && string == nullptr) ||
+                (t == value_t::binary && binary == nullptr)
+            )
+            {
+                //not initialized (e.g. due to exception in the ctor)
+                return;
+            }
             if (t == value_t::array || t == value_t::object)
             {
                 // flatten the current json_value to a heap-allocated stack
@@ -19761,18 +19895,18 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                     // its children to the stack to be processed later
                     if (current_item.is_array())
                     {
-                        std::move(current_item.m_value.array->begin(), current_item.m_value.array->end(), std::back_inserter(stack));
+                        std::move(current_item.m_data.m_value.array->begin(), current_item.m_data.m_value.array->end(), std::back_inserter(stack));
 
-                        current_item.m_value.array->clear();
+                        current_item.m_data.m_value.array->clear();
                     }
                     else if (current_item.is_object())
                     {
-                        for (auto&& it : *current_item.m_value.object)
+                        for (auto&& it : *current_item.m_data.m_value.object)
                         {
                             stack.push_back(std::move(it.second));
                         }
 
-                        current_item.m_value.object->clear();
+                        current_item.m_data.m_value.object->clear();
                     }
 
                     // it's now safe that current_item get destructed
@@ -19849,10 +19983,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     */
     void assert_invariant(bool check_parents = true) const noexcept
     {
-        JSON_ASSERT(m_type != value_t::object || m_value.object != nullptr);
-        JSON_ASSERT(m_type != value_t::array || m_value.array != nullptr);
-        JSON_ASSERT(m_type != value_t::string || m_value.string != nullptr);
-        JSON_ASSERT(m_type != value_t::binary || m_value.binary != nullptr);
+        JSON_ASSERT(m_data.m_type != value_t::object || m_data.m_value.object != nullptr);
+        JSON_ASSERT(m_data.m_type != value_t::array || m_data.m_value.array != nullptr);
+        JSON_ASSERT(m_data.m_type != value_t::string || m_data.m_value.string != nullptr);
+        JSON_ASSERT(m_data.m_type != value_t::binary || m_data.m_value.binary != nullptr);
 
 #if JSON_DIAGNOSTICS
         JSON_TRY
@@ -19871,11 +20005,11 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     void set_parents()
     {
 #if JSON_DIAGNOSTICS
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::array:
             {
-                for (auto& element : *m_value.array)
+                for (auto& element : *m_data.m_value.array)
                 {
                     element.m_parent = this;
                 }
@@ -19884,7 +20018,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
             case value_t::object:
             {
-                for (auto& element : *m_value.object)
+                for (auto& element : *m_data.m_value.object)
                 {
                     element.second.m_parent = this;
                 }
@@ -19925,7 +20059,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         {
             // see https://github.com/nlohmann/json/issues/2838
             JSON_ASSERT(type() == value_t::array);
-            if (JSON_HEDLEY_UNLIKELY(m_value.array->capacity() != old_capacity))
+            if (JSON_HEDLEY_UNLIKELY(m_data.m_value.array->capacity() != old_capacity))
             {
                 // capacity has changed: update all parents
                 set_parents();
@@ -19981,7 +20115,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief create an empty value with a given type
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(const value_t v)
-        : m_type(v), m_value(v)
+        : m_data(v)
     {
         assert_invariant();
     }
@@ -20055,12 +20189,12 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 *this = nullptr;
                 break;
             case value_t::discarded:
-                m_type = value_t::discarded;
+                m_data.m_type = value_t::discarded;
                 break;
             default:            // LCOV_EXCL_LINE
                 JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
         }
-        JSON_ASSERT(m_type == val.type());
+        JSON_ASSERT(m_data.m_type == val.type());
         set_parents();
         assert_invariant();
     }
@@ -20076,7 +20210,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         bool is_an_object = std::all_of(init.begin(), init.end(),
                                         [](const detail::json_ref<basic_json>& element_ref)
         {
-            return element_ref->is_array() && element_ref->size() == 2 && (*element_ref)[0].is_string();
+            // The cast is to ensure op[size_type] is called, bearing in mind size_type may not be int;
+            // (many string types can be constructed from 0 via its null-pointer guise, so we get a
+            // broken call to op[key_type], the wrong semantics and a 4804 warning on Windows)
+            return element_ref->is_array() && element_ref->size() == 2 && (*element_ref)[static_cast<size_type>(0)].is_string();
         });
 
         // adjust type if type deduction is not wanted
@@ -20098,22 +20235,22 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         if (is_an_object)
         {
             // the initializer list is a list of pairs -> create object
-            m_type = value_t::object;
-            m_value = value_t::object;
+            m_data.m_type = value_t::object;
+            m_data.m_value = value_t::object;
 
             for (auto& element_ref : init)
             {
                 auto element = element_ref.moved_or_copied();
-                m_value.object->emplace(
-                    std::move(*((*element.m_value.array)[0].m_value.string)),
-                    std::move((*element.m_value.array)[1]));
+                m_data.m_value.object->emplace(
+                    std::move(*((*element.m_data.m_value.array)[0].m_data.m_value.string)),
+                    std::move((*element.m_data.m_value.array)[1]));
             }
         }
         else
         {
             // the initializer list describes an array -> create array
-            m_type = value_t::array;
-            m_value.array = create<array_t>(init.begin(), init.end());
+            m_data.m_type = value_t::array;
+            m_data.m_value.array = create<array_t>(init.begin(), init.end());
         }
 
         set_parents();
@@ -20126,8 +20263,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     static basic_json binary(const typename binary_t::container_type& init)
     {
         auto res = basic_json();
-        res.m_type = value_t::binary;
-        res.m_value = init;
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = init;
         return res;
     }
 
@@ -20137,8 +20274,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     static basic_json binary(const typename binary_t::container_type& init, typename binary_t::subtype_type subtype)
     {
         auto res = basic_json();
-        res.m_type = value_t::binary;
-        res.m_value = binary_t(init, subtype);
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = binary_t(init, subtype);
         return res;
     }
 
@@ -20148,8 +20285,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     static basic_json binary(typename binary_t::container_type&& init)
     {
         auto res = basic_json();
-        res.m_type = value_t::binary;
-        res.m_value = std::move(init);
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = std::move(init);
         return res;
     }
 
@@ -20159,8 +20296,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     static basic_json binary(typename binary_t::container_type&& init, typename binary_t::subtype_type subtype)
     {
         auto res = basic_json();
-        res.m_type = value_t::binary;
-        res.m_value = binary_t(std::move(init), subtype);
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = binary_t(std::move(init), subtype);
         return res;
     }
 
@@ -20182,10 +20319,9 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @brief construct an array with count copies of given value
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
-    basic_json(size_type cnt, const basic_json& val)
-        : m_type(value_t::array)
+    basic_json(size_type cnt, const basic_json& val):
+        m_data{cnt, val}
     {
-        m_value.array = create<array_t>(cnt, val);
         set_parents();
         assert_invariant();
     }
@@ -20207,10 +20343,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         }
 
         // copy type from first iterator
-        m_type = first.m_object->m_type;
+        m_data.m_type = first.m_object->m_data.m_type;
 
         // check if iterator range is complete for primitive values
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::boolean:
             case value_t::number_float:
@@ -20235,55 +20371,55 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 break;
         }
 
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::number_integer:
             {
-                m_value.number_integer = first.m_object->m_value.number_integer;
+                m_data.m_value.number_integer = first.m_object->m_data.m_value.number_integer;
                 break;
             }
 
             case value_t::number_unsigned:
             {
-                m_value.number_unsigned = first.m_object->m_value.number_unsigned;
+                m_data.m_value.number_unsigned = first.m_object->m_data.m_value.number_unsigned;
                 break;
             }
 
             case value_t::number_float:
             {
-                m_value.number_float = first.m_object->m_value.number_float;
+                m_data.m_value.number_float = first.m_object->m_data.m_value.number_float;
                 break;
             }
 
             case value_t::boolean:
             {
-                m_value.boolean = first.m_object->m_value.boolean;
+                m_data.m_value.boolean = first.m_object->m_data.m_value.boolean;
                 break;
             }
 
             case value_t::string:
             {
-                m_value = *first.m_object->m_value.string;
+                m_data.m_value = *first.m_object->m_data.m_value.string;
                 break;
             }
 
             case value_t::object:
             {
-                m_value.object = create<object_t>(first.m_it.object_iterator,
-                                                  last.m_it.object_iterator);
+                m_data.m_value.object = create<object_t>(first.m_it.object_iterator,
+                                        last.m_it.object_iterator);
                 break;
             }
 
             case value_t::array:
             {
-                m_value.array = create<array_t>(first.m_it.array_iterator,
-                                                last.m_it.array_iterator);
+                m_data.m_value.array = create<array_t>(first.m_it.array_iterator,
+                                                       last.m_it.array_iterator);
                 break;
             }
 
             case value_t::binary:
             {
-                m_value = *first.m_object->m_value.binary;
+                m_data.m_value = *first.m_object->m_data.m_value.binary;
                 break;
             }
 
@@ -20297,7 +20433,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         assert_invariant();
     }
 
-
     ///////////////////////////////////////
     // other constructors and destructor //
     ///////////////////////////////////////
@@ -20310,58 +20445,59 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief copy constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(const basic_json& other)
-        : m_type(other.m_type)
+        : json_base_class_t(other)
     {
+        m_data.m_type = other.m_data.m_type;
         // check of passed value is valid
         other.assert_invariant();
 
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::object:
             {
-                m_value = *other.m_value.object;
+                m_data.m_value = *other.m_data.m_value.object;
                 break;
             }
 
             case value_t::array:
             {
-                m_value = *other.m_value.array;
+                m_data.m_value = *other.m_data.m_value.array;
                 break;
             }
 
             case value_t::string:
             {
-                m_value = *other.m_value.string;
+                m_data.m_value = *other.m_data.m_value.string;
                 break;
             }
 
             case value_t::boolean:
             {
-                m_value = other.m_value.boolean;
+                m_data.m_value = other.m_data.m_value.boolean;
                 break;
             }
 
             case value_t::number_integer:
             {
-                m_value = other.m_value.number_integer;
+                m_data.m_value = other.m_data.m_value.number_integer;
                 break;
             }
 
             case value_t::number_unsigned:
             {
-                m_value = other.m_value.number_unsigned;
+                m_data.m_value = other.m_data.m_value.number_unsigned;
                 break;
             }
 
             case value_t::number_float:
             {
-                m_value = other.m_value.number_float;
+                m_data.m_value = other.m_data.m_value.number_float;
                 break;
             }
 
             case value_t::binary:
             {
-                m_value = *other.m_value.binary;
+                m_data.m_value = *other.m_data.m_value.binary;
                 break;
             }
 
@@ -20378,15 +20514,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @brief move constructor
     /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
     basic_json(basic_json&& other) noexcept
-        : m_type(std::move(other.m_type)),
-          m_value(std::move(other.m_value))
+        : json_base_class_t(std::forward<json_base_class_t>(other)),
+          m_data(std::move(other.m_data))
     {
         // check that passed value is valid
         other.assert_invariant(false);
 
         // invalidate payload
-        other.m_type = value_t::null;
-        other.m_value = {};
+        other.m_data.m_type = value_t::null;
+        other.m_data.m_value = {};
 
         set_parents();
         assert_invariant();
@@ -20398,15 +20534,17 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         std::is_nothrow_move_constructible<value_t>::value&&
         std::is_nothrow_move_assignable<value_t>::value&&
         std::is_nothrow_move_constructible<json_value>::value&&
-        std::is_nothrow_move_assignable<json_value>::value
+        std::is_nothrow_move_assignable<json_value>::value&&
+        std::is_nothrow_move_assignable<json_base_class_t>::value
     )
     {
         // check that passed value is valid
         other.assert_invariant();
 
         using std::swap;
-        swap(m_type, other.m_type);
-        swap(m_value, other.m_value);
+        swap(m_data.m_type, other.m_data.m_type);
+        swap(m_data.m_value, other.m_data.m_value);
+        json_base_class_t::operator=(std::move(other));
 
         set_parents();
         assert_invariant();
@@ -20418,7 +20556,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     ~basic_json() noexcept
     {
         assert_invariant(false);
-        m_value.destroy(m_type);
     }
 
     /// @}
@@ -20458,7 +20595,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/type/
     constexpr value_t type() const noexcept
     {
-        return m_type;
+        return m_data.m_type;
     }
 
     /// @brief return whether type is primitive
@@ -20479,14 +20616,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/is_null/
     constexpr bool is_null() const noexcept
     {
-        return m_type == value_t::null;
+        return m_data.m_type == value_t::null;
     }
 
     /// @brief return whether value is a boolean
     /// @sa https://json.nlohmann.me/api/basic_json/is_boolean/
     constexpr bool is_boolean() const noexcept
     {
-        return m_type == value_t::boolean;
+        return m_data.m_type == value_t::boolean;
     }
 
     /// @brief return whether value is a number
@@ -20500,63 +20637,63 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/is_number_integer/
     constexpr bool is_number_integer() const noexcept
     {
-        return m_type == value_t::number_integer || m_type == value_t::number_unsigned;
+        return m_data.m_type == value_t::number_integer || m_data.m_type == value_t::number_unsigned;
     }
 
     /// @brief return whether value is an unsigned integer number
     /// @sa https://json.nlohmann.me/api/basic_json/is_number_unsigned/
     constexpr bool is_number_unsigned() const noexcept
     {
-        return m_type == value_t::number_unsigned;
+        return m_data.m_type == value_t::number_unsigned;
     }
 
     /// @brief return whether value is a floating-point number
     /// @sa https://json.nlohmann.me/api/basic_json/is_number_float/
     constexpr bool is_number_float() const noexcept
     {
-        return m_type == value_t::number_float;
+        return m_data.m_type == value_t::number_float;
     }
 
     /// @brief return whether value is an object
     /// @sa https://json.nlohmann.me/api/basic_json/is_object/
     constexpr bool is_object() const noexcept
     {
-        return m_type == value_t::object;
+        return m_data.m_type == value_t::object;
     }
 
     /// @brief return whether value is an array
     /// @sa https://json.nlohmann.me/api/basic_json/is_array/
     constexpr bool is_array() const noexcept
     {
-        return m_type == value_t::array;
+        return m_data.m_type == value_t::array;
     }
 
     /// @brief return whether value is a string
     /// @sa https://json.nlohmann.me/api/basic_json/is_string/
     constexpr bool is_string() const noexcept
     {
-        return m_type == value_t::string;
+        return m_data.m_type == value_t::string;
     }
 
     /// @brief return whether value is a binary array
     /// @sa https://json.nlohmann.me/api/basic_json/is_binary/
     constexpr bool is_binary() const noexcept
     {
-        return m_type == value_t::binary;
+        return m_data.m_type == value_t::binary;
     }
 
     /// @brief return whether value is discarded
     /// @sa https://json.nlohmann.me/api/basic_json/is_discarded/
     constexpr bool is_discarded() const noexcept
     {
-        return m_type == value_t::discarded;
+        return m_data.m_type == value_t::discarded;
     }
 
     /// @brief return the type of the JSON value (implicit)
     /// @sa https://json.nlohmann.me/api/basic_json/operator_value_t/
     constexpr operator value_t() const noexcept
     {
-        return m_type;
+        return m_data.m_type;
     }
 
     /// @}
@@ -20571,7 +20708,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     {
         if (JSON_HEDLEY_LIKELY(is_boolean()))
         {
-            return m_value.boolean;
+            return m_data.m_value.boolean;
         }
 
         JSON_THROW(type_error::create(302, detail::concat("type must be boolean, but is ", type_name()), this));
@@ -20580,97 +20717,97 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// get a pointer to the value (object)
     object_t* get_impl_ptr(object_t* /*unused*/) noexcept
     {
-        return is_object() ? m_value.object : nullptr;
+        return is_object() ? m_data.m_value.object : nullptr;
     }
 
     /// get a pointer to the value (object)
     constexpr const object_t* get_impl_ptr(const object_t* /*unused*/) const noexcept
     {
-        return is_object() ? m_value.object : nullptr;
+        return is_object() ? m_data.m_value.object : nullptr;
     }
 
     /// get a pointer to the value (array)
     array_t* get_impl_ptr(array_t* /*unused*/) noexcept
     {
-        return is_array() ? m_value.array : nullptr;
+        return is_array() ? m_data.m_value.array : nullptr;
     }
 
     /// get a pointer to the value (array)
     constexpr const array_t* get_impl_ptr(const array_t* /*unused*/) const noexcept
     {
-        return is_array() ? m_value.array : nullptr;
+        return is_array() ? m_data.m_value.array : nullptr;
     }
 
     /// get a pointer to the value (string)
     string_t* get_impl_ptr(string_t* /*unused*/) noexcept
     {
-        return is_string() ? m_value.string : nullptr;
+        return is_string() ? m_data.m_value.string : nullptr;
     }
 
     /// get a pointer to the value (string)
     constexpr const string_t* get_impl_ptr(const string_t* /*unused*/) const noexcept
     {
-        return is_string() ? m_value.string : nullptr;
+        return is_string() ? m_data.m_value.string : nullptr;
     }
 
     /// get a pointer to the value (boolean)
     boolean_t* get_impl_ptr(boolean_t* /*unused*/) noexcept
     {
-        return is_boolean() ? &m_value.boolean : nullptr;
+        return is_boolean() ? &m_data.m_value.boolean : nullptr;
     }
 
     /// get a pointer to the value (boolean)
     constexpr const boolean_t* get_impl_ptr(const boolean_t* /*unused*/) const noexcept
     {
-        return is_boolean() ? &m_value.boolean : nullptr;
+        return is_boolean() ? &m_data.m_value.boolean : nullptr;
     }
 
     /// get a pointer to the value (integer number)
     number_integer_t* get_impl_ptr(number_integer_t* /*unused*/) noexcept
     {
-        return is_number_integer() ? &m_value.number_integer : nullptr;
+        return is_number_integer() ? &m_data.m_value.number_integer : nullptr;
     }
 
     /// get a pointer to the value (integer number)
     constexpr const number_integer_t* get_impl_ptr(const number_integer_t* /*unused*/) const noexcept
     {
-        return is_number_integer() ? &m_value.number_integer : nullptr;
+        return is_number_integer() ? &m_data.m_value.number_integer : nullptr;
     }
 
     /// get a pointer to the value (unsigned number)
     number_unsigned_t* get_impl_ptr(number_unsigned_t* /*unused*/) noexcept
     {
-        return is_number_unsigned() ? &m_value.number_unsigned : nullptr;
+        return is_number_unsigned() ? &m_data.m_value.number_unsigned : nullptr;
     }
 
     /// get a pointer to the value (unsigned number)
     constexpr const number_unsigned_t* get_impl_ptr(const number_unsigned_t* /*unused*/) const noexcept
     {
-        return is_number_unsigned() ? &m_value.number_unsigned : nullptr;
+        return is_number_unsigned() ? &m_data.m_value.number_unsigned : nullptr;
     }
 
     /// get a pointer to the value (floating-point number)
     number_float_t* get_impl_ptr(number_float_t* /*unused*/) noexcept
     {
-        return is_number_float() ? &m_value.number_float : nullptr;
+        return is_number_float() ? &m_data.m_value.number_float : nullptr;
     }
 
     /// get a pointer to the value (floating-point number)
     constexpr const number_float_t* get_impl_ptr(const number_float_t* /*unused*/) const noexcept
     {
-        return is_number_float() ? &m_value.number_float : nullptr;
+        return is_number_float() ? &m_data.m_value.number_float : nullptr;
     }
 
     /// get a pointer to the value (binary)
     binary_t* get_impl_ptr(binary_t* /*unused*/) noexcept
     {
-        return is_binary() ? m_value.binary : nullptr;
+        return is_binary() ? m_data.m_value.binary : nullptr;
     }
 
     /// get a pointer to the value (binary)
     constexpr const binary_t* get_impl_ptr(const binary_t* /*unused*/) const noexcept
     {
-        return is_binary() ? m_value.binary : nullptr;
+        return is_binary() ? m_data.m_value.binary : nullptr;
     }
 
     /*!
@@ -21053,7 +21190,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 #if defined(JSON_HAS_CPP_17) && (defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER <= 1914))
                                                 detail::negation<std::is_same<ValueType, std::string_view>>,
 #endif
-#if defined(JSON_HAS_CPP_17)
+#if defined(JSON_HAS_CPP_17) && JSON_HAS_STATIC_RTTI
                                                 detail::negation<std::is_same<ValueType, std::any>>,
 #endif
                                                 detail::is_detected_lazy<detail::get_template_function, const basic_json_t&, ValueType>
@@ -21090,7 +21227,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @}
 
-
     ////////////////////
     // element access //
     ////////////////////
@@ -21108,7 +21244,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         {
             JSON_TRY
             {
-                return set_parent(m_value.array->at(idx));
+                return set_parent(m_data.m_value.array->at(idx));
             }
             JSON_CATCH (std::out_of_range&)
             {
@@ -21131,7 +21267,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         {
             JSON_TRY
             {
-                return m_value.array->at(idx);
+                return m_data.m_value.array->at(idx);
             }
             JSON_CATCH (std::out_of_range&)
             {
@@ -21155,8 +21291,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
         }
 
-        auto it = m_value.object->find(key);
-        if (it == m_value.object->end())
+        auto it = m_data.m_value.object->find(key);
+        if (it == m_data.m_value.object->end())
         {
             JSON_THROW(out_of_range::create(403, detail::concat("key '", key, "' not found"), this));
         }
@@ -21175,8 +21311,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
         }
 
-        auto it = m_value.object->find(std::forward<KeyType>(key));
-        if (it == m_value.object->end())
+        auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+        if (it == m_data.m_value.object->end())
         {
             JSON_THROW(out_of_range::create(403, detail::concat("key '", string_t(std::forward<KeyType>(key)), "' not found"), this));
         }
@@ -21193,8 +21329,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
         }
 
-        auto it = m_value.object->find(key);
-        if (it == m_value.object->end())
+        auto it = m_data.m_value.object->find(key);
+        if (it == m_data.m_value.object->end())
         {
             JSON_THROW(out_of_range::create(403, detail::concat("key '", key, "' not found"), this));
         }
@@ -21213,8 +21349,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
         }
 
-        auto it = m_value.object->find(std::forward<KeyType>(key));
-        if (it == m_value.object->end())
+        auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+        if (it == m_data.m_value.object->end())
         {
             JSON_THROW(out_of_range::create(403, detail::concat("key '", string_t(std::forward<KeyType>(key)), "' not found"), this));
         }
@@ -21228,8 +21364,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // implicitly convert null value to an empty array
         if (is_null())
         {
-            m_type = value_t::array;
-            m_value.array = create<array_t>();
+            m_data.m_type = value_t::array;
+            m_data.m_value.array = create<array_t>();
             assert_invariant();
         }
 
@@ -21237,17 +21373,17 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         if (JSON_HEDLEY_LIKELY(is_array()))
         {
             // fill up array with null values if given idx is outside range
-            if (idx >= m_value.array->size())
+            if (idx >= m_data.m_value.array->size())
             {
 #if JSON_DIAGNOSTICS
                 // remember array size & capacity before resizing
-                const auto old_size = m_value.array->size();
-                const auto old_capacity = m_value.array->capacity();
+                const auto old_size = m_data.m_value.array->size();
+                const auto old_capacity = m_data.m_value.array->capacity();
 #endif
-                m_value.array->resize(idx + 1);
+                m_data.m_value.array->resize(idx + 1);
 
 #if JSON_DIAGNOSTICS
-                if (JSON_HEDLEY_UNLIKELY(m_value.array->capacity() != old_capacity))
+                if (JSON_HEDLEY_UNLIKELY(m_data.m_value.array->capacity() != old_capacity))
                 {
                     // capacity has changed: update all parents
                     set_parents();
@@ -21261,7 +21397,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 assert_invariant();
             }
 
-            return m_value.array->operator[](idx);
+            return m_data.m_value.array->operator[](idx);
         }
 
         JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a numeric argument with ", type_name()), this));
@@ -21274,7 +21410,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // const operator[] only works for arrays
         if (JSON_HEDLEY_LIKELY(is_array()))
         {
-            return m_value.array->operator[](idx);
+            return m_data.m_value.array->operator[](idx);
         }
 
         JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a numeric argument with ", type_name()), this));
@@ -21287,15 +21423,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // implicitly convert null value to an empty object
         if (is_null())
         {
-            m_type = value_t::object;
-            m_value.object = create<object_t>();
+            m_data.m_type = value_t::object;
+            m_data.m_value.object = create<object_t>();
             assert_invariant();
         }
 
         // operator[] only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            auto result = m_value.object->emplace(std::move(key), nullptr);
+            auto result = m_data.m_value.object->emplace(std::move(key), nullptr);
             return set_parent(result.first->second);
         }
 
@@ -21309,8 +21445,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // const operator[] only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            auto it = m_value.object->find(key);
-            JSON_ASSERT(it != m_value.object->end());
+            auto it = m_data.m_value.object->find(key);
+            JSON_ASSERT(it != m_data.m_value.object->end());
             return it->second;
         }
 
@@ -21340,15 +21476,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // implicitly convert null value to an empty object
         if (is_null())
         {
-            m_type = value_t::object;
-            m_value.object = create<object_t>();
+            m_data.m_type = value_t::object;
+            m_data.m_value.object = create<object_t>();
             assert_invariant();
         }
 
         // operator[] only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            auto result = m_value.object->emplace(std::forward<KeyType>(key), nullptr);
+            auto result = m_data.m_value.object->emplace(std::forward<KeyType>(key), nullptr);
             return set_parent(result.first->second);
         }
 
@@ -21364,8 +21500,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // const operator[] only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
-            auto it = m_value.object->find(std::forward<KeyType>(key));
-            JSON_ASSERT(it != m_value.object->end());
+            auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+            JSON_ASSERT(it != m_data.m_value.object->end());
             return it->second;
         }
 
@@ -21602,7 +21738,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         IteratorType result = end();
 
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::boolean:
             case value_t::number_float:
@@ -21619,32 +21755,32 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 if (is_string())
                 {
                     AllocatorType<string_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.string);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.string, 1);
-                    m_value.string = nullptr;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.string);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.string, 1);
+                    m_data.m_value.string = nullptr;
                 }
                 else if (is_binary())
                 {
                     AllocatorType<binary_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.binary);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.binary, 1);
-                    m_value.binary = nullptr;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.binary);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.binary, 1);
+                    m_data.m_value.binary = nullptr;
                 }
 
-                m_type = value_t::null;
+                m_data.m_type = value_t::null;
                 assert_invariant();
                 break;
             }
 
             case value_t::object:
             {
-                result.m_it.object_iterator = m_value.object->erase(pos.m_it.object_iterator);
+                result.m_it.object_iterator = m_data.m_value.object->erase(pos.m_it.object_iterator);
                 break;
             }
 
             case value_t::array:
             {
-                result.m_it.array_iterator = m_value.array->erase(pos.m_it.array_iterator);
+                result.m_it.array_iterator = m_data.m_value.array->erase(pos.m_it.array_iterator);
                 break;
             }
 
@@ -21672,7 +21808,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         IteratorType result = end();
 
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::boolean:
             case value_t::number_float:
@@ -21690,33 +21826,33 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 if (is_string())
                 {
                     AllocatorType<string_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.string);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.string, 1);
-                    m_value.string = nullptr;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.string);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.string, 1);
+                    m_data.m_value.string = nullptr;
                 }
                 else if (is_binary())
                 {
                     AllocatorType<binary_t> alloc;
-                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_value.binary);
-                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_value.binary, 1);
-                    m_value.binary = nullptr;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.binary);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.binary, 1);
+                    m_data.m_value.binary = nullptr;
                 }
 
-                m_type = value_t::null;
+                m_data.m_type = value_t::null;
                 assert_invariant();
                 break;
             }
 
             case value_t::object:
             {
-                result.m_it.object_iterator = m_value.object->erase(first.m_it.object_iterator,
+                result.m_it.object_iterator = m_data.m_value.object->erase(first.m_it.object_iterator,
                                               last.m_it.object_iterator);
                 break;
             }
 
             case value_t::array:
             {
-                result.m_it.array_iterator = m_value.array->erase(first.m_it.array_iterator,
+                result.m_it.array_iterator = m_data.m_value.array->erase(first.m_it.array_iterator,
                                              last.m_it.array_iterator);
                 break;
             }
@@ -21741,7 +21877,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             JSON_THROW(type_error::create(307, detail::concat("cannot use erase() with ", type_name()), this));
         }
 
-        return m_value.object->erase(std::forward<KeyType>(key));
+        return m_data.m_value.object->erase(std::forward<KeyType>(key));
     }
 
     template < typename KeyType, detail::enable_if_t <
@@ -21754,10 +21890,10 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             JSON_THROW(type_error::create(307, detail::concat("cannot use erase() with ", type_name()), this));
         }
 
-        const auto it = m_value.object->find(std::forward<KeyType>(key));
-        if (it != m_value.object->end())
+        const auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+        if (it != m_data.m_value.object->end())
         {
-            m_value.object->erase(it);
+            m_data.m_value.object->erase(it);
             return 1;
         }
         return 0;
@@ -21795,7 +21931,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                 JSON_THROW(out_of_range::create(401, detail::concat("array index ", std::to_string(idx), " is out of range"), this));
             }
 
-            m_value.array->erase(m_value.array->begin() + static_cast<difference_type>(idx));
+            m_data.m_value.array->erase(m_data.m_value.array->begin() + static_cast<difference_type>(idx));
         }
         else
         {
@@ -21804,7 +21940,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     }
 
     /// @}
-
 
     ////////////
     // lookup //
@@ -21821,7 +21956,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (is_object())
         {
-            result.m_it.object_iterator = m_value.object->find(key);
+            result.m_it.object_iterator = m_data.m_value.object->find(key);
         }
 
         return result;
@@ -21835,7 +21970,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (is_object())
         {
-            result.m_it.object_iterator = m_value.object->find(key);
+            result.m_it.object_iterator = m_data.m_value.object->find(key);
         }
 
         return result;
@@ -21851,7 +21986,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (is_object())
         {
-            result.m_it.object_iterator = m_value.object->find(std::forward<KeyType>(key));
+            result.m_it.object_iterator = m_data.m_value.object->find(std::forward<KeyType>(key));
         }
 
         return result;
@@ -21867,7 +22002,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
         if (is_object())
         {
-            result.m_it.object_iterator = m_value.object->find(std::forward<KeyType>(key));
+            result.m_it.object_iterator = m_data.m_value.object->find(std::forward<KeyType>(key));
         }
 
         return result;
@@ -21878,7 +22013,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     size_type count(const typename object_t::key_type& key) const
     {
         // return 0 for all nonobject types
-        return is_object() ? m_value.object->count(key) : 0;
+        return is_object() ? m_data.m_value.object->count(key) : 0;
     }
 
     /// @brief returns the number of occurrences of a key in a JSON object
@@ -21888,14 +22023,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     size_type count(KeyType && key) const
     {
         // return 0 for all nonobject types
-        return is_object() ? m_value.object->count(std::forward<KeyType>(key)) : 0;
+        return is_object() ? m_data.m_value.object->count(std::forward<KeyType>(key)) : 0;
     }
 
     /// @brief check the existence of an element in a JSON object
     /// @sa https://json.nlohmann.me/api/basic_json/contains/
     bool contains(const typename object_t::key_type& key) const
     {
-        return is_object() && m_value.object->find(key) != m_value.object->end();
+        return is_object() && m_data.m_value.object->find(key) != m_data.m_value.object->end();
     }
 
     /// @brief check the existence of an element in a JSON object
@@ -21904,7 +22039,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                  detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
     bool contains(KeyType && key) const
     {
-        return is_object() && m_value.object->find(std::forward<KeyType>(key)) != m_value.object->end();
+        return is_object() && m_data.m_value.object->find(std::forward<KeyType>(key)) != m_data.m_value.object->end();
     }
 
     /// @brief check the existence of an element in a JSON object given a JSON pointer
@@ -21922,7 +22057,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     }
 
     /// @}
-
 
     ///////////////
     // iterators //
@@ -22062,7 +22196,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @}
 
-
     //////////////
     // capacity //
     //////////////
@@ -22074,7 +22207,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/empty/
     bool empty() const noexcept
     {
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::null:
             {
@@ -22085,13 +22218,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             case value_t::array:
             {
                 // delegate call to array_t::empty()
-                return m_value.array->empty();
+                return m_data.m_value.array->empty();
             }
 
             case value_t::object:
             {
                 // delegate call to object_t::empty()
-                return m_value.object->empty();
+                return m_data.m_value.object->empty();
             }
 
             case value_t::string:
@@ -22113,7 +22246,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/size/
     size_type size() const noexcept
     {
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::null:
             {
@@ -22124,13 +22257,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             case value_t::array:
             {
                 // delegate call to array_t::size()
-                return m_value.array->size();
+                return m_data.m_value.array->size();
             }
 
             case value_t::object:
             {
                 // delegate call to object_t::size()
-                return m_value.object->size();
+                return m_data.m_value.object->size();
             }
 
             case value_t::string:
@@ -22152,18 +22285,18 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/max_size/
     size_type max_size() const noexcept
     {
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::array:
             {
                 // delegate call to array_t::max_size()
-                return m_value.array->max_size();
+                return m_data.m_value.array->max_size();
             }
 
             case value_t::object:
             {
                 // delegate call to object_t::max_size()
-                return m_value.object->max_size();
+                return m_data.m_value.object->max_size();
             }
 
             case value_t::null:
@@ -22184,7 +22317,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @}
 
-
     ///////////////
     // modifiers //
     ///////////////
@@ -22196,53 +22328,53 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     /// @sa https://json.nlohmann.me/api/basic_json/clear/
     void clear() noexcept
     {
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::number_integer:
             {
-                m_value.number_integer = 0;
+                m_data.m_value.number_integer = 0;
                 break;
             }
 
             case value_t::number_unsigned:
             {
-                m_value.number_unsigned = 0;
+                m_data.m_value.number_unsigned = 0;
                 break;
             }
 
             case value_t::number_float:
             {
-                m_value.number_float = 0.0;
+                m_data.m_value.number_float = 0.0;
                 break;
             }
 
             case value_t::boolean:
             {
-                m_value.boolean = false;
+                m_data.m_value.boolean = false;
                 break;
             }
 
             case value_t::string:
             {
-                m_value.string->clear();
+                m_data.m_value.string->clear();
                 break;
             }
 
             case value_t::binary:
             {
-                m_value.binary->clear();
+                m_data.m_value.binary->clear();
                 break;
             }
 
             case value_t::array:
             {
-                m_value.array->clear();
+                m_data.m_value.array->clear();
                 break;
             }
 
             case value_t::object:
             {
-                m_value.object->clear();
+                m_data.m_value.object->clear();
                 break;
             }
 
@@ -22266,15 +22398,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // transform null object into an array
         if (is_null())
         {
-            m_type = value_t::array;
-            m_value = value_t::array;
+            m_data.m_type = value_t::array;
+            m_data.m_value = value_t::array;
             assert_invariant();
         }
 
         // add element to array (move semantics)
-        const auto old_capacity = m_value.array->capacity();
-        m_value.array->push_back(std::move(val));
-        set_parent(m_value.array->back(), old_capacity);
+        const auto old_capacity = m_data.m_value.array->capacity();
+        m_data.m_value.array->push_back(std::move(val));
+        set_parent(m_data.m_value.array->back(), old_capacity);
         // if val is moved from, basic_json move constructor marks it null, so we do not call the destructor
     }
 
@@ -22299,15 +22431,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // transform null object into an array
         if (is_null())
         {
-            m_type = value_t::array;
-            m_value = value_t::array;
+            m_data.m_type = value_t::array;
+            m_data.m_value = value_t::array;
             assert_invariant();
         }
 
         // add element to array
-        const auto old_capacity = m_value.array->capacity();
-        m_value.array->push_back(val);
-        set_parent(m_value.array->back(), old_capacity);
+        const auto old_capacity = m_data.m_value.array->capacity();
+        m_data.m_value.array->push_back(val);
+        set_parent(m_data.m_value.array->back(), old_capacity);
     }
 
     /// @brief add an object to an array
@@ -22331,13 +22463,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // transform null object into an object
         if (is_null())
         {
-            m_type = value_t::object;
-            m_value = value_t::object;
+            m_data.m_type = value_t::object;
+            m_data.m_value = value_t::object;
             assert_invariant();
         }
 
         // add element to object
-        auto res = m_value.object->insert(val);
+        auto res = m_data.m_value.object->insert(val);
         set_parent(res.first->second);
     }
 
@@ -22387,15 +22519,15 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // transform null object into an array
         if (is_null())
         {
-            m_type = value_t::array;
-            m_value = value_t::array;
+            m_data.m_type = value_t::array;
+            m_data.m_value = value_t::array;
             assert_invariant();
         }
 
         // add element to array (perfect forwarding)
-        const auto old_capacity = m_value.array->capacity();
-        m_value.array->emplace_back(std::forward<Args>(args)...);
-        return set_parent(m_value.array->back(), old_capacity);
+        const auto old_capacity = m_data.m_value.array->capacity();
+        m_data.m_value.array->emplace_back(std::forward<Args>(args)...);
+        return set_parent(m_data.m_value.array->back(), old_capacity);
     }
 
     /// @brief add an object to an object if key does not exist
@@ -22412,13 +22544,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // transform null object into an object
         if (is_null())
         {
-            m_type = value_t::object;
-            m_value = value_t::object;
+            m_data.m_type = value_t::object;
+            m_data.m_value = value_t::object;
             assert_invariant();
         }
 
         // add element to array (perfect forwarding)
-        auto res = m_value.object->emplace(std::forward<Args>(args)...);
+        auto res = m_data.m_value.object->emplace(std::forward<Args>(args)...);
         set_parent(res.first->second);
 
         // create result iterator and set iterator to the result of emplace
@@ -22436,14 +22568,14 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     iterator insert_iterator(const_iterator pos, Args&& ... args)
     {
         iterator result(this);
-        JSON_ASSERT(m_value.array != nullptr);
+        JSON_ASSERT(m_data.m_value.array != nullptr);
 
-        auto insert_pos = std::distance(m_value.array->begin(), pos.m_it.array_iterator);
-        m_value.array->insert(pos.m_it.array_iterator, std::forward<Args>(args)...);
-        result.m_it.array_iterator = m_value.array->begin() + insert_pos;
+        auto insert_pos = std::distance(m_data.m_value.array->begin(), pos.m_it.array_iterator);
+        m_data.m_value.array->insert(pos.m_it.array_iterator, std::forward<Args>(args)...);
+        result.m_it.array_iterator = m_data.m_value.array->begin() + insert_pos;
 
         // This could have been written as:
-        // result.m_it.array_iterator = m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+        // result.m_it.array_iterator = m_data.m_value.array->insert(pos.m_it.array_iterator, cnt, val);
         // but the return value of insert is missing in GCC 4.8, so it is written this way instead.
 
         set_parents();
@@ -22570,7 +22702,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             JSON_THROW(invalid_iterator::create(202, "iterators first and last must point to objects", this));
         }
 
-        m_value.object->insert(first.m_it.object_iterator, last.m_it.object_iterator);
+        m_data.m_value.object->insert(first.m_it.object_iterator, last.m_it.object_iterator);
     }
 
     /// @brief updates a JSON object from another object, overwriting existing keys
@@ -22587,8 +22719,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         // implicitly convert null value to an empty object
         if (is_null())
         {
-            m_type = value_t::object;
-            m_value.object = create<object_t>();
+            m_data.m_type = value_t::object;
+            m_data.m_value.object = create<object_t>();
             assert_invariant();
         }
 
@@ -22613,16 +22745,16 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         {
             if (merge_objects && it.value().is_object())
             {
-                auto it2 = m_value.object->find(it.key());
-                if (it2 != m_value.object->end())
+                auto it2 = m_data.m_value.object->find(it.key());
+                if (it2 != m_data.m_value.object->end())
                 {
                     it2->second.update(it.value(), true);
                     continue;
                 }
             }
-            m_value.object->operator[](it.key()) = it.value();
+            m_data.m_value.object->operator[](it.key()) = it.value();
 #if JSON_DIAGNOSTICS
-            m_value.object->operator[](it.key()).m_parent = this;
+            m_data.m_value.object->operator[](it.key()).m_parent = this;
 #endif
         }
     }
@@ -22632,12 +22764,12 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     void swap(reference other) noexcept (
         std::is_nothrow_move_constructible<value_t>::value&&
         std::is_nothrow_move_assignable<value_t>::value&&
-        std::is_nothrow_move_constructible<json_value>::value&&
+        std::is_nothrow_move_constructible<json_value>::value&& // NOLINT(cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
         std::is_nothrow_move_assignable<json_value>::value
     )
     {
-        std::swap(m_type, other.m_type);
-        std::swap(m_value, other.m_value);
+        std::swap(m_data.m_type, other.m_data.m_type);
+        std::swap(m_data.m_value, other.m_data.m_value);
 
         set_parents();
         other.set_parents();
@@ -22649,7 +22781,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     friend void swap(reference left, reference right) noexcept (
         std::is_nothrow_move_constructible<value_t>::value&&
         std::is_nothrow_move_assignable<value_t>::value&&
-        std::is_nothrow_move_constructible<json_value>::value&&
+        std::is_nothrow_move_constructible<json_value>::value&& // NOLINT(cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
         std::is_nothrow_move_assignable<json_value>::value
     )
     {
@@ -22658,13 +22790,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @brief exchanges the values
     /// @sa https://json.nlohmann.me/api/basic_json/swap/
-    void swap(array_t& other) // NOLINT(bugprone-exception-escape)
+    void swap(array_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
     {
         // swap only works for arrays
         if (JSON_HEDLEY_LIKELY(is_array()))
         {
             using std::swap;
-            swap(*(m_value.array), other);
+            swap(*(m_data.m_value.array), other);
         }
         else
         {
@@ -22674,13 +22806,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @brief exchanges the values
     /// @sa https://json.nlohmann.me/api/basic_json/swap/
-    void swap(object_t& other) // NOLINT(bugprone-exception-escape)
+    void swap(object_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
     {
         // swap only works for objects
         if (JSON_HEDLEY_LIKELY(is_object()))
         {
             using std::swap;
-            swap(*(m_value.object), other);
+            swap(*(m_data.m_value.object), other);
         }
         else
         {
@@ -22690,13 +22822,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @brief exchanges the values
     /// @sa https://json.nlohmann.me/api/basic_json/swap/
-    void swap(string_t& other) // NOLINT(bugprone-exception-escape)
+    void swap(string_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
     {
         // swap only works for strings
         if (JSON_HEDLEY_LIKELY(is_string()))
         {
             using std::swap;
-            swap(*(m_value.string), other);
+            swap(*(m_data.m_value.string), other);
         }
         else
         {
@@ -22706,13 +22838,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 
     /// @brief exchanges the values
     /// @sa https://json.nlohmann.me/api/basic_json/swap/
-    void swap(binary_t& other) // NOLINT(bugprone-exception-escape)
+    void swap(binary_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
     {
         // swap only works for strings
         if (JSON_HEDLEY_LIKELY(is_binary()))
         {
             using std::swap;
-            swap(*(m_value.binary), other);
+            swap(*(m_data.m_value.binary), other);
         }
         else
         {
@@ -22728,7 +22860,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         if (JSON_HEDLEY_LIKELY(is_binary()))
         {
             using std::swap;
-            swap(*(m_value.binary), other);
+            swap(*(m_data.m_value.binary), other);
         }
         else
         {
@@ -22756,31 +22888,31 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         switch (lhs_type)                                                                                \
         {                                                                                                \
             case value_t::array:                                                                         \
-                return (*lhs.m_value.array) op (*rhs.m_value.array);                                     \
+                return (*lhs.m_data.m_value.array) op (*rhs.m_data.m_value.array);                                     \
                 \
             case value_t::object:                                                                        \
-                return (*lhs.m_value.object) op (*rhs.m_value.object);                                   \
+                return (*lhs.m_data.m_value.object) op (*rhs.m_data.m_value.object);                                   \
                 \
             case value_t::null:                                                                          \
                 return (null_result);                                                                    \
                 \
             case value_t::string:                                                                        \
-                return (*lhs.m_value.string) op (*rhs.m_value.string);                                   \
+                return (*lhs.m_data.m_value.string) op (*rhs.m_data.m_value.string);                                   \
                 \
             case value_t::boolean:                                                                       \
-                return (lhs.m_value.boolean) op (rhs.m_value.boolean);                                   \
+                return (lhs.m_data.m_value.boolean) op (rhs.m_data.m_value.boolean);                                   \
                 \
             case value_t::number_integer:                                                                \
-                return (lhs.m_value.number_integer) op (rhs.m_value.number_integer);                     \
+                return (lhs.m_data.m_value.number_integer) op (rhs.m_data.m_value.number_integer);                     \
                 \
             case value_t::number_unsigned:                                                               \
-                return (lhs.m_value.number_unsigned) op (rhs.m_value.number_unsigned);                   \
+                return (lhs.m_data.m_value.number_unsigned) op (rhs.m_data.m_value.number_unsigned);                   \
                 \
             case value_t::number_float:                                                                  \
-                return (lhs.m_value.number_float) op (rhs.m_value.number_float);                         \
+                return (lhs.m_data.m_value.number_float) op (rhs.m_data.m_value.number_float);                         \
                 \
             case value_t::binary:                                                                        \
-                return (*lhs.m_value.binary) op (*rhs.m_value.binary);                                   \
+                return (*lhs.m_data.m_value.binary) op (*rhs.m_data.m_value.binary);                                   \
                 \
             case value_t::discarded:                                                                     \
             default:                                                                                     \
@@ -22789,27 +22921,27 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     }                                                                                                    \
     else if (lhs_type == value_t::number_integer && rhs_type == value_t::number_float)                   \
     {                                                                                                    \
-        return static_cast<number_float_t>(lhs.m_value.number_integer) op rhs.m_value.number_float;      \
+        return static_cast<number_float_t>(lhs.m_data.m_value.number_integer) op rhs.m_data.m_value.number_float;      \
     }                                                                                                    \
     else if (lhs_type == value_t::number_float && rhs_type == value_t::number_integer)                   \
     {                                                                                                    \
-        return lhs.m_value.number_float op static_cast<number_float_t>(rhs.m_value.number_integer);      \
+        return lhs.m_data.m_value.number_float op static_cast<number_float_t>(rhs.m_data.m_value.number_integer);      \
     }                                                                                                    \
     else if (lhs_type == value_t::number_unsigned && rhs_type == value_t::number_float)                  \
     {                                                                                                    \
-        return static_cast<number_float_t>(lhs.m_value.number_unsigned) op rhs.m_value.number_float;     \
+        return static_cast<number_float_t>(lhs.m_data.m_value.number_unsigned) op rhs.m_data.m_value.number_float;     \
     }                                                                                                    \
     else if (lhs_type == value_t::number_float && rhs_type == value_t::number_unsigned)                  \
     {                                                                                                    \
-        return lhs.m_value.number_float op static_cast<number_float_t>(rhs.m_value.number_unsigned);     \
+        return lhs.m_data.m_value.number_float op static_cast<number_float_t>(rhs.m_data.m_value.number_unsigned);     \
     }                                                                                                    \
     else if (lhs_type == value_t::number_unsigned && rhs_type == value_t::number_integer)                \
     {                                                                                                    \
-        return static_cast<number_integer_t>(lhs.m_value.number_unsigned) op rhs.m_value.number_integer; \
+        return static_cast<number_integer_t>(lhs.m_data.m_value.number_unsigned) op rhs.m_data.m_value.number_integer; \
     }                                                                                                    \
     else if (lhs_type == value_t::number_integer && rhs_type == value_t::number_unsigned)                \
     {                                                                                                    \
-        return lhs.m_value.number_integer op static_cast<number_integer_t>(rhs.m_value.number_unsigned); \
+        return lhs.m_data.m_value.number_integer op static_cast<number_integer_t>(rhs.m_data.m_value.number_unsigned); \
     }                                                                                                    \
     else if(compares_unordered(lhs, rhs))\
     {\
@@ -22826,8 +22958,8 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     // an operation is computed as an odd number of inverses of others
     static bool compares_unordered(const_reference lhs, const_reference rhs, bool inverse = false) noexcept
     {
-        if ((lhs.is_number_float() && std::isnan(lhs.m_value.number_float) && rhs.is_number())
-                || (rhs.is_number_float() && std::isnan(rhs.m_value.number_float) && lhs.is_number()))
+        if ((lhs.is_number_float() && std::isnan(lhs.m_data.m_value.number_float) && rhs.is_number())
+                || (rhs.is_number_float() && std::isnan(rhs.m_data.m_value.number_float) && lhs.is_number()))
         {
             return true;
         }
@@ -23171,7 +23303,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
 #endif  // JSON_NO_IO
     /// @}
 
-
     /////////////////////
     // deserialization //
     /////////////////////
@@ -23328,7 +23459,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     JSON_HEDLEY_RETURNS_NON_NULL
     const char* type_name() const noexcept
     {
-        switch (m_type)
+        switch (m_data.m_type)
         {
             case value_t::null:
                 return "null";
@@ -23352,17 +23483,43 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         }
     }
 
-
   JSON_PRIVATE_UNLESS_TESTED:
     //////////////////////
     // member variables //
     //////////////////////
 
-    /// the type of the current element
-    value_t m_type = value_t::null;
+    struct data
+    {
+        /// the type of the current element
+        value_t m_type = value_t::null;
 
-    /// the value of the current element
-    json_value m_value = {};
+        /// the value of the current element
+        json_value m_value = {};
+
+        data(const value_t v)
+            : m_type(v), m_value(v)
+        {
+        }
+
+        data(size_type cnt, const basic_json& val)
+            : m_type(value_t::array)
+        {
+            m_value.array = create<array_t>(cnt, val);
+        }
+
+        data() noexcept = default;
+        data(data&&) noexcept = default;
+        data(const data&) noexcept = delete;
+        data& operator=(data&&) noexcept = delete;
+        data& operator=(const data&) noexcept = delete;
+
+        ~data() noexcept
+        {
+            m_value.destroy(m_type);
+        }
+    };
+
+    data m_data = {};
 
 #if JSON_DIAGNOSTICS
     /// a pointer to a parent value (for debugging purposes)
@@ -23543,7 +23700,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         return from_cbor(ptr, ptr + len, strict, allow_exceptions, tag_handler);
     }
 
-
     JSON_HEDLEY_WARN_UNUSED_RESULT
     JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_cbor(ptr, ptr + len))
     static basic_json from_cbor(detail::span_input_adapter&& i,
@@ -23666,7 +23822,6 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::ubjson).sax_parse(input_format_t::ubjson, &sdp, strict);
         return res ? result : basic_json(value_t::discarded);
     }
-
 
     /// @brief create a JSON value from an input in BJData format
     /// @sa https://json.nlohmann.me/api/basic_json/from_bjdata/
@@ -23890,7 +24045,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             }
 
             // make sure the top element of the pointer exists
-            json_pointer top_pointer = ptr.top();
+            json_pointer const top_pointer = ptr.top();
             if (top_pointer != ptr)
             {
                 result.at(top_pointer);
@@ -23902,7 +24057,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
             // parent must exist when performing patch add per RFC6902 specs
             basic_json& parent = result.at(ptr);
 
-            switch (parent.m_type)
+            switch (parent.m_data.m_type)
             {
                 case value_t::null:
                 case value_t::object:
@@ -23948,7 +24103,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
         };
 
         // wrapper for "remove" operation; remove value at ptr
-        const auto operation_remove = [this, &result](json_pointer & ptr)
+        const auto operation_remove = [this, & result](json_pointer & ptr)
         {
             // get reference to parent of JSON pointer ptr
             const auto last_path = ptr.back();
@@ -23991,13 +24146,13 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                                           bool string_type) -> basic_json &
             {
                 // find value
-                auto it = val.m_value.object->find(member);
+                auto it = val.m_data.m_value.object->find(member);
 
                 // context-sensitive error message
                 const auto error_msg = (op == "op") ? "operation" : detail::concat("operation '", op, '\'');
 
                 // check if desired value is present
-                if (JSON_HEDLEY_UNLIKELY(it == val.m_value.object->end()))
+                if (JSON_HEDLEY_UNLIKELY(it == val.m_data.m_value.object->end()))
                 {
                     // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
                     JSON_THROW(parse_error::create(105, 0, detail::concat(error_msg, " must have member '", member, "'"), &val));
@@ -24052,7 +24207,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                     json_pointer from_ptr(from_path);
 
                     // the "from" location must exist - use at()
-                    basic_json v = result.at(from_ptr);
+                    basic_json const v = result.at(from_ptr);
 
                     // The move operation is functionally identical to a
                     // "remove" operation on the "from" location, followed
@@ -24069,7 +24224,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
                     const json_pointer from_ptr(from_path);
 
                     // the "from" location must exist - use at()
-                    basic_json v = result.at(from_ptr);
+                    basic_json const v = result.at(from_ptr);
 
                     // The copy is functionally identical to an "add"
                     // operation at the target location using the value
@@ -24311,7 +24466,11 @@ inline namespace json_literals
 /// @brief user-defined string literal for JSON values
 /// @sa https://json.nlohmann.me/api/basic_json/operator_literal_json/
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+#if !defined(JSON_HEDLEY_GCC_VERSION) || JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0)
+    inline nlohmann::json operator ""_json(const char* s, std::size_t n)
+#else
+    inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+#endif
 {
     return nlohmann::json::parse(s, s + n);
 }
@@ -24319,7 +24478,11 @@ inline nlohmann::json operator "" _json(const char* s, std::size_t n)
 /// @brief user-defined string literal for JSON pointer
 /// @sa https://json.nlohmann.me/api/basic_json/operator_literal_json_pointer/
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+#if !defined(JSON_HEDLEY_GCC_VERSION) || JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0)
+    inline nlohmann::json::json_pointer operator ""_json_pointer(const char* s, std::size_t n)
+#else
+    inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+#endif
 {
     return nlohmann::json::json_pointer(std::string(s, n));
 }
@@ -24338,7 +24501,7 @@ namespace std // NOLINT(cert-dcl58-cpp)
 /// @brief hash value for JSON objects
 /// @sa https://json.nlohmann.me/api/basic_json/std_hash/
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
-struct hash<nlohmann::NLOHMANN_BASIC_JSON_TPL>
+struct hash<nlohmann::NLOHMANN_BASIC_JSON_TPL> // NOLINT(cert-dcl58-cpp)
 {
     std::size_t operator()(const nlohmann::NLOHMANN_BASIC_JSON_TPL& j) const
     {
@@ -24371,8 +24534,8 @@ struct less< ::nlohmann::detail::value_t> // do not remove the space after '<', 
 /// @brief exchanges the values of two JSON objects
 /// @sa https://json.nlohmann.me/api/basic_json/std_swap/
 NLOHMANN_BASIC_JSON_TPL_DECLARATION
-inline void swap(nlohmann::NLOHMANN_BASIC_JSON_TPL& j1, nlohmann::NLOHMANN_BASIC_JSON_TPL& j2) noexcept(  // NOLINT(readability-inconsistent-declaration-parameter-name)
-    is_nothrow_move_constructible<nlohmann::NLOHMANN_BASIC_JSON_TPL>::value&&                          // NOLINT(misc-redundant-expression)
+inline void swap(nlohmann::NLOHMANN_BASIC_JSON_TPL& j1, nlohmann::NLOHMANN_BASIC_JSON_TPL& j2) noexcept(  // NOLINT(readability-inconsistent-declaration-parameter-name, cert-dcl58-cpp)
+    is_nothrow_move_constructible<nlohmann::NLOHMANN_BASIC_JSON_TPL>::value&&                          // NOLINT(misc-redundant-expression,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
     is_nothrow_move_assignable<nlohmann::NLOHMANN_BASIC_JSON_TPL>::value)
 {
     j1.swap(j2);
@@ -24383,17 +24546,22 @@ inline void swap(nlohmann::NLOHMANN_BASIC_JSON_TPL& j1, nlohmann::NLOHMANN_BASIC
 }  // namespace std
 
 #if JSON_USE_GLOBAL_UDLS
-    using nlohmann::literals::json_literals::operator "" _json; // NOLINT(misc-unused-using-decls,google-global-names-in-headers)
-    using nlohmann::literals::json_literals::operator "" _json_pointer; //NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+    #if !defined(JSON_HEDLEY_GCC_VERSION) || JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0)
+        using nlohmann::literals::json_literals::operator ""_json; // NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+        using nlohmann::literals::json_literals::operator ""_json_pointer; //NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+    #else
+        using nlohmann::literals::json_literals::operator "" _json; // NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+        using nlohmann::literals::json_literals::operator "" _json_pointer; //NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+    #endif
 #endif
 
 // #include <nlohmann/detail/macro_unscope.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 
@@ -24428,16 +24596,17 @@ inline void swap(nlohmann::NLOHMANN_BASIC_JSON_TPL& j1, nlohmann::NLOHMANN_BASIC
     #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
     #undef JSON_HAS_THREE_WAY_COMPARISON
     #undef JSON_HAS_RANGES
+    #undef JSON_HAS_STATIC_RTTI
     #undef JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
 #endif
 
 // #include <nlohmann/thirdparty/hedley/hedley_undef.hpp>
 //     __ _____ _____ _____
 //  __|  |   __|     |   | |  JSON for Modern C++
-// |  |  |__   |  |  | | | |  version 3.11.2
+// |  |  |__   |  |  | | | |  version 3.11.3
 // |_____|_____|_____|_|___|  https://github.com/nlohmann/json
 //
-// SPDX-FileCopyrightText: 2013-2022 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
 // SPDX-License-Identifier: MIT
 
 

--- a/game.cpp
+++ b/game.cpp
@@ -1031,7 +1031,7 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 					} else {
 						delete pTemp;
 						AString saveorder = *pLine;
-						int getatsign = pLine->getat();
+						bool repeating = pLine->getat();
 						pTemp = pLine->gettoken();
 						if (!pTemp) {
 							Awrite(AString("Order: must provide unit order ")+
@@ -1044,10 +1044,10 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 								Awrite(AString("Order: invalid order given ")+
 										"for faction "+pFac->num);
 							} else {
-								if (getatsign) {
+								if (repeating) {
 									u->oldorders.push_back(string(saveorder.const_str()));
 								}
-								ProcessOrder(o, u, pLine, NULL);
+								ProcessOrder(o, u, pLine, NULL, repeating);
 							}
 						}
 					}

--- a/game.h
+++ b/game.h
@@ -343,12 +343,10 @@ private:
 	int ParseDir(AString *token);
 
 	void ParseOrders(int faction, std::istream& ordersFile, OrdersCheck *pCheck);
-	void ProcessOrder(int orderNum, Unit *unit, AString *order,
-					  OrdersCheck *pCheck);
+	void ProcessOrder(int orderNum, Unit *unit, AString *order, OrdersCheck *pCheck, bool repeating);
 	void ProcessMoveOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessAdvanceOrder(Unit *, AString *, OrdersCheck *pCheck);
-	Unit *ProcessFormOrder(Unit *former, AString *order,
-						   OrdersCheck *pCheck, int atsign);
+	Unit *ProcessFormOrder(Unit *former, AString *order, OrdersCheck *pCheck, bool repeating);
 	void ProcessAddressOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessAvoidOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessGuardOrder(Unit *, AString *, OrdersCheck *pCheck);
@@ -362,8 +360,8 @@ private:
 	void ProcessTeachOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessWorkOrder(Unit *, int quiet, OrdersCheck *pCheck);
 	void ProcessProduceOrder(Unit *, AString *, OrdersCheck *pCheck);
-	void ProcessBuyOrder(Unit *, AString *, OrdersCheck *pCheck);
-	void ProcessSellOrder(Unit *, AString *, OrdersCheck *pCheck);
+	void ProcessBuyOrder(Unit *, AString *, OrdersCheck *pCheck, bool repeating);
+	void ProcessSellOrder(Unit *, AString *, OrdersCheck *pCheck, bool repeating);
 	void ProcessAttackOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessBuildOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessSailOrder(Unit *, AString *, OrdersCheck *pCheck);
@@ -403,7 +401,7 @@ private:
 	void ProcessIdleOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessTransportOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessShareOrder(Unit *, AString *, OrdersCheck *pCheck);
-	AString *ProcessTurnOrder(Unit *, std::istream& f, OrdersCheck *pCheck, int);
+	AString *ProcessTurnOrder(Unit *, std::istream& f, OrdersCheck *pCheck, bool repeating);
 	void ProcessJoinOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessAnnihilateOrder(Unit *, AString *, OrdersCheck *pCheck);
 	void ProcessSacrificeOrder(Unit *, AString *, OrdersCheck *pCheck);

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -3842,6 +3842,9 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("h4", true) << "BUILD\n" << enclose("h4", false);
 	f << enclose("h4", true) << "BUILD [object type]\n" << enclose("h4", false);
 	f << enclose("h4", true) << "BUILD HELP [unit]\n" << enclose("h4", false);
+	f << enclose("h4", true) << "BUILD COMPLETE\n" << enclose("h4", false);
+	f << enclose("h4", true) << "BUILD [object type] COMPLETE\n" << enclose("h4", false);
+	f << enclose("h4", true) << "BUILD HELP [unit] COMPLETE\n" << enclose("h4", false);
 	f << enclose("p", true) << "BUILD given with no parameters causes the unit to perform work on "
 	  << (may_sail ? "an unfinished ship it possesses, or on ": "") << "the object that it is currently inside.  "
 	  << "BUILD given with an [object type] (such as \"Tower\" or \"Galleon\") instructs the unit to begin work "
@@ -3849,12 +3852,20 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	  << "current building task, even if that task was begun this same turn. This help will be rejected if the "
 	  << "unit you are trying to help does not consider you to be friendly.\n"
 	  << enclose("p", false);
+	f << enclose("p", true) << "The variants with COMPLETE instruct the unit to continue with the same build order "
+	  << "and repeat it the next month if the built object is not yet complete.  In the case of BUILD [object "
+	  << "type] COMPLETE, the unit will remain in the current building if it is not complete, and it is the same "
+	  << "type as the one specified, otherwise it will start a new object of the type specified."
+	  << enclose("p", false);
 	f << enclose("p", true) << "Examples:\n" << enclose("p", false);
 	f << example_start("To build a new tower.")
 	  << "BUILD Tower\n"
 	  << example_end();
 	f << example_start("To help unit 5789 build a structure.")
 	  << "BUILD HELP 5789\n"
+	  << example_end();
+	f << example_start("To start a new castle and continue building until it is complete.")
+	  << "BUILD Castle COMPLETE\n"
 	  << example_end();
 
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);

--- a/map_viewer/package.json
+++ b/map_viewer/package.json
@@ -1,22 +1,21 @@
 {
   "name": "map",
-  "packageManager": "yarn@4.3.1",
+  "packageManager": "yarn@4.8.1",
   "version": "1.0.0",
-  "main": "index.js",
   "license": "MIT",
   "scripts": {
     "start": "parcel index.html"
   },
   "dependencies": {
-    "@parcel/core": "^2.2.0",
-    "@types/color": "^3.0.2",
-    "alpinejs": "^3.14.1",
-    "color": "^4.2.0",
-    "parcel": "^2.2.0",
-    "rainbowvis.js": "^1.0.1"
+    "@parcel/core": "^2.14.4",
+    "@types/color": "^4.2.0",
+    "alpinejs": "^3.14.9",
+    "color": "^5.0.0",
+    "parcel": "^2.14.4",
+    "rainbowvis.js": "^1.1.1"
   },
   "devDependencies": {
-    "@types/alpinejs": "^3.13.10",
-    "typescript": "^5.5.3"
+    "@types/alpinejs": "^3.13.11",
+    "typescript": "^5.8.3"
   }
 }

--- a/map_viewer/yarn.lock
+++ b/map_viewer/yarn.lock
@@ -181,487 +181,512 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/bundler-default@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/bundler-default@npm:2.12.0"
+"@parcel/bundler-default@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/bundler-default@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/graph": "npm:3.2.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/graph": "npm:3.4.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/797e7494c82f2669a8d8d409b2efa2c956d2ac4edd5cd1b85560bbd7696483edb8ec220f66cdd88f7a3e47cfb346f33b21818c96f5a2bac098d5eef5085475d8
+  checksum: 10c0/894e9c9a88d81562959b5212da8d761c553d316685c5eed3ef8d20ac1abfff769b8981ecee92794e06c8addaa16c23f0e6d5053f9e10c5e3d568c153c7881975
   languageName: node
   linkType: hard
 
-"@parcel/cache@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/cache@npm:2.12.0"
+"@parcel/cache@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/cache@npm:2.14.4"
   dependencies:
-    "@parcel/fs": "npm:2.12.0"
-    "@parcel/logger": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/fs": "npm:2.14.4"
+    "@parcel/logger": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     lmdb: "npm:2.8.5"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/ef80c88a754d2e1c9161eb8e518f4a4b03c186001384100d037e333a1c00b4a701b0f6c1743a1663c6bb7e20d09c8582584f44ebea0fc6d81c81b4a81a1d0b6b
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/ef671d610e882c1c0a5ef939936e6e5316b53111258a9a513161d3b25e2b3713460521c5f948a0f6f9331ad22b6c9a1acdea4b7b9f3c13c4b853c2f1fd3750c3
   languageName: node
   linkType: hard
 
-"@parcel/codeframe@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/codeframe@npm:2.12.0"
+"@parcel/codeframe@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/codeframe@npm:2.14.4"
   dependencies:
-    chalk: "npm:^4.1.0"
-  checksum: 10c0/23a73d8a5b6a7612ab6a5918ad52631f58d3529758730517a0ce151f0c533e5b4b1788278dd521d4863dd0e0b972afb590af69cb8523b14e809279825da549a1
+    chalk: "npm:^4.1.2"
+  checksum: 10c0/62847e1b53438f13a5bb98b37a44d6600269bb28ca6dbb0c7180e531caef4c9968272625eda7c4286db52af81769dbc7b19e42f9cb1c2051f1469d2174540983
   languageName: node
   linkType: hard
 
-"@parcel/compressor-raw@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/compressor-raw@npm:2.12.0"
+"@parcel/compressor-raw@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/compressor-raw@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-  checksum: 10c0/e057b38d3cae862048f3777ea97544e60465e8efc16ecab0b8602d9c2787c80a09ac3bb338f773af5c17a6b4356caf103986951b47022fdf02b21c5e0b600033
+    "@parcel/plugin": "npm:2.14.4"
+  checksum: 10c0/eb2a21d1fc1fbad3e26eb231469dcc5af6e3027ba3d813ba0cf0f41d5d25230743705cc53e9da36fa6b656284752b37995631419aefff0bcec5a257c2213f1aa
   languageName: node
   linkType: hard
 
-"@parcel/config-default@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/config-default@npm:2.12.0"
+"@parcel/config-default@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/config-default@npm:2.14.4"
   dependencies:
-    "@parcel/bundler-default": "npm:2.12.0"
-    "@parcel/compressor-raw": "npm:2.12.0"
-    "@parcel/namer-default": "npm:2.12.0"
-    "@parcel/optimizer-css": "npm:2.12.0"
-    "@parcel/optimizer-htmlnano": "npm:2.12.0"
-    "@parcel/optimizer-image": "npm:2.12.0"
-    "@parcel/optimizer-svgo": "npm:2.12.0"
-    "@parcel/optimizer-swc": "npm:2.12.0"
-    "@parcel/packager-css": "npm:2.12.0"
-    "@parcel/packager-html": "npm:2.12.0"
-    "@parcel/packager-js": "npm:2.12.0"
-    "@parcel/packager-raw": "npm:2.12.0"
-    "@parcel/packager-svg": "npm:2.12.0"
-    "@parcel/packager-wasm": "npm:2.12.0"
-    "@parcel/reporter-dev-server": "npm:2.12.0"
-    "@parcel/resolver-default": "npm:2.12.0"
-    "@parcel/runtime-browser-hmr": "npm:2.12.0"
-    "@parcel/runtime-js": "npm:2.12.0"
-    "@parcel/runtime-react-refresh": "npm:2.12.0"
-    "@parcel/runtime-service-worker": "npm:2.12.0"
-    "@parcel/transformer-babel": "npm:2.12.0"
-    "@parcel/transformer-css": "npm:2.12.0"
-    "@parcel/transformer-html": "npm:2.12.0"
-    "@parcel/transformer-image": "npm:2.12.0"
-    "@parcel/transformer-js": "npm:2.12.0"
-    "@parcel/transformer-json": "npm:2.12.0"
-    "@parcel/transformer-postcss": "npm:2.12.0"
-    "@parcel/transformer-posthtml": "npm:2.12.0"
-    "@parcel/transformer-raw": "npm:2.12.0"
-    "@parcel/transformer-react-refresh-wrap": "npm:2.12.0"
-    "@parcel/transformer-svg": "npm:2.12.0"
+    "@parcel/bundler-default": "npm:2.14.4"
+    "@parcel/compressor-raw": "npm:2.14.4"
+    "@parcel/namer-default": "npm:2.14.4"
+    "@parcel/optimizer-css": "npm:2.14.4"
+    "@parcel/optimizer-htmlnano": "npm:2.14.4"
+    "@parcel/optimizer-image": "npm:2.14.4"
+    "@parcel/optimizer-svgo": "npm:2.14.4"
+    "@parcel/optimizer-swc": "npm:2.14.4"
+    "@parcel/packager-css": "npm:2.14.4"
+    "@parcel/packager-html": "npm:2.14.4"
+    "@parcel/packager-js": "npm:2.14.4"
+    "@parcel/packager-raw": "npm:2.14.4"
+    "@parcel/packager-svg": "npm:2.14.4"
+    "@parcel/packager-wasm": "npm:2.14.4"
+    "@parcel/reporter-dev-server": "npm:2.14.4"
+    "@parcel/resolver-default": "npm:2.14.4"
+    "@parcel/runtime-browser-hmr": "npm:2.14.4"
+    "@parcel/runtime-js": "npm:2.14.4"
+    "@parcel/runtime-rsc": "npm:2.14.4"
+    "@parcel/runtime-service-worker": "npm:2.14.4"
+    "@parcel/transformer-babel": "npm:2.14.4"
+    "@parcel/transformer-css": "npm:2.14.4"
+    "@parcel/transformer-html": "npm:2.14.4"
+    "@parcel/transformer-image": "npm:2.14.4"
+    "@parcel/transformer-js": "npm:2.14.4"
+    "@parcel/transformer-json": "npm:2.14.4"
+    "@parcel/transformer-node": "npm:2.14.4"
+    "@parcel/transformer-postcss": "npm:2.14.4"
+    "@parcel/transformer-posthtml": "npm:2.14.4"
+    "@parcel/transformer-raw": "npm:2.14.4"
+    "@parcel/transformer-react-refresh-wrap": "npm:2.14.4"
+    "@parcel/transformer-svg": "npm:2.14.4"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/c3fec515c14479f1a0041db79a70198f04bea94a03a7f331257f057de178d4e0061b68853c2e83d45f891d09fadb8b4361f38421832b6e116edd46f8e0ee51a9
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/196e4034c12b9e6166caa6fe32e1a89246be8912377e060295ec67cbf89737bd2bb20f658a0e9d423b4cb6c9d7b35a737aa4b0a02a3746a00d5107eded47279e
   languageName: node
   linkType: hard
 
-"@parcel/core@npm:2.12.0, @parcel/core@npm:^2.2.0":
-  version: 2.12.0
-  resolution: "@parcel/core@npm:2.12.0"
+"@parcel/core@npm:2.14.4, @parcel/core@npm:^2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/core@npm:2.14.4"
   dependencies:
     "@mischnic/json-sourcemap": "npm:^0.1.0"
-    "@parcel/cache": "npm:2.12.0"
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/events": "npm:2.12.0"
-    "@parcel/fs": "npm:2.12.0"
-    "@parcel/graph": "npm:3.2.0"
-    "@parcel/logger": "npm:2.12.0"
-    "@parcel/package-manager": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/profiler": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
+    "@parcel/cache": "npm:2.14.4"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/events": "npm:2.14.4"
+    "@parcel/feature-flags": "npm:2.14.4"
+    "@parcel/fs": "npm:2.14.4"
+    "@parcel/graph": "npm:3.4.4"
+    "@parcel/logger": "npm:2.14.4"
+    "@parcel/package-manager": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/profiler": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    "@parcel/workers": "npm:2.12.0"
-    abortcontroller-polyfill: "npm:^1.1.9"
+    "@parcel/types": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    "@parcel/workers": "npm:2.14.4"
     base-x: "npm:^3.0.8"
     browserslist: "npm:^4.6.6"
     clone: "npm:^2.1.1"
-    dotenv: "npm:^7.0.0"
-    dotenv-expand: "npm:^5.1.0"
+    dotenv: "npm:^16.4.5"
+    dotenv-expand: "npm:^11.0.6"
     json5: "npm:^2.2.0"
     msgpackr: "npm:^1.9.9"
     nullthrows: "npm:^1.1.1"
     semver: "npm:^7.5.2"
-  checksum: 10c0/ab6b4bc1e95b0aaee23c5aec8479cf6681cf84a0c422e1001a3a0f3957aa28756851eb201a89d8b55ce84912c8987a76597f77193ade771f034c1c33a07ece44
+  checksum: 10c0/346f802be0f43ef91fc420807f3fece1028210a5bccf5df890f26a5a31699120f4d46ec65bfd2415a0abb4d3b1e5f7c552f2ee144c6d618e26ca127b3a9c74ce
   languageName: node
   linkType: hard
 
-"@parcel/diagnostic@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/diagnostic@npm:2.12.0"
+"@parcel/diagnostic@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/diagnostic@npm:2.14.4"
   dependencies:
     "@mischnic/json-sourcemap": "npm:^0.1.0"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/61c2fce32a1abdf343a4d2e3a109779dc2a9c255059e4dd70ad9b4b3bd5b11b676d0c42bc77e4b32e886ef471be018b25b952baa9da137c066410642d2d0507f
+  checksum: 10c0/ff426677e423248326db97b1d1ac933d192b3f00bfb83f365c5ac97dc455b713d6f374fbe0f35987882e065bba96c8d29f5cd21f94a437002a0d031a019a0b2f
   languageName: node
   linkType: hard
 
-"@parcel/events@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/events@npm:2.12.0"
-  checksum: 10c0/0f0a0b02086b81d68cf8f239414e9e09b5a6eca6dddfd22d2e922979b2d85b03e6f68bcafa2c6434c46867c908e25f2002f47f0ed5551f2674a75f4d6c5731ff
+"@parcel/error-overlay@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/error-overlay@npm:2.14.4"
+  checksum: 10c0/57acf3af76ffd9d4a68a68670c697caea6f9d1ab058ae7d6779f3d2c48026c3a686c13af62a35e7abb977792621dbf39e6a600e78b9f99ccc35ec4388fcc9cc1
   languageName: node
   linkType: hard
 
-"@parcel/fs@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/fs@npm:2.12.0"
+"@parcel/events@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/events@npm:2.14.4"
+  checksum: 10c0/49cd8680e4b5205a9290295cd2385018bd32757c7928b2be4455d561d34947d9c6efb50b85624f2d8637d002d191a7844d8b346e6bd415c993e39fd56d6c142e
+  languageName: node
+  linkType: hard
+
+"@parcel/feature-flags@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/feature-flags@npm:2.14.4"
+  checksum: 10c0/215738bdd93a135bffeb684ff6ab548637a93171c1d7913ac65c3b2e0609629ebd9369a36baedb1fb27bf9b15a39c04ccb74d57ea64cfc529211274540ae469c
+  languageName: node
+  linkType: hard
+
+"@parcel/fs@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/fs@npm:2.14.4"
   dependencies:
-    "@parcel/rust": "npm:2.12.0"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/feature-flags": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
+    "@parcel/types-internal": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     "@parcel/watcher": "npm:^2.0.7"
-    "@parcel/workers": "npm:2.12.0"
+    "@parcel/workers": "npm:2.14.4"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/5d9ebf62e80dc3781fcd1eb763da46188115e254d285690383539a085aeaf9d864a54655046223ea42815b9b308ecba80d9af53cff6390c6bbb37d2b29df8e35
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/6fc55ca6a9ecd0e01be4e0a87926eca13c0605b947955c580a264f72464bffac3bf4a2bb363460b68810f02f10d6e58aa2cceb9e6c0bf0edb11cdccbed9cfa0c
   languageName: node
   linkType: hard
 
-"@parcel/graph@npm:3.2.0":
-  version: 3.2.0
-  resolution: "@parcel/graph@npm:3.2.0"
+"@parcel/graph@npm:3.4.4":
+  version: 3.4.4
+  resolution: "@parcel/graph@npm:3.4.4"
   dependencies:
+    "@parcel/feature-flags": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/acb98a9c44dbabaa38e2a7b6b07aa489d75dc207ed6107ea43575d3c68ebf388a65a982d85677c7d00cd2d7bb6f8a6f75df9618a53389e9f640aa9346fb75c3b
+  checksum: 10c0/21c70d2de864a21f1c8a0c24533a9271bd7f3c447affbaccb20a1ee03558921e1cb5bb9d194a05d68b44a2ded1ac56919c805e37e35cdd2cc967650aaeb0a796
   languageName: node
   linkType: hard
 
-"@parcel/logger@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/logger@npm:2.12.0"
+"@parcel/logger@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/logger@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/events": "npm:2.12.0"
-  checksum: 10c0/b33782bbf0cfff30169a4ee8dd3a1d14c9b2c0d4781715e26b5dc6f2321ddff8ca84eca8de40bccb1a8c5d3ce847494408f5db63bbeddcdaaf9b82b1cc376a17
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/events": "npm:2.14.4"
+  checksum: 10c0/3efaa6f002cea2c0901c382836d87702074b1f84fde76788855f6948cfa5e68d2a0dea09295858a1a3c6b16025f17399aece86846ab7675d0aacebb2c13de776
   languageName: node
   linkType: hard
 
-"@parcel/markdown-ansi@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/markdown-ansi@npm:2.12.0"
+"@parcel/markdown-ansi@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/markdown-ansi@npm:2.14.4"
   dependencies:
-    chalk: "npm:^4.1.0"
-  checksum: 10c0/0c203c70ab1eb12f4976c32b086b2abf5dc841b42310610e70e1e713fe915acfd0942b56a78456811a9ee150226bb44052910a3f98ea56289aafa36b6ce89e27
+    chalk: "npm:^4.1.2"
+  checksum: 10c0/42eb84119d544b0ea9059c74d6a0c60f075ce1070a85397a9551e2b71de83ccdeafdef7b43ab3dc9199c9039be66a512fde6b4a8f5bb5f8cf83fdc677794d7aa
   languageName: node
   linkType: hard
 
-"@parcel/namer-default@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/namer-default@npm:2.12.0"
+"@parcel/namer-default@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/namer-default@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/5baffe07af2329315b9d2b897565b915038246afaa3269d81bcd5eb4bcc7a21771bf1171918d68a67c099584b006167beeefa4716fb4557aae4bc112ebaf4159
+  checksum: 10c0/487b31af0a0e06098607d5a76d9d229eff7251cdd5e0365adb78e2239ad661adc157aed0551f77e40fdbdf039b8a103f0dea7d2e91daedb2cf1107498bf94597
   languageName: node
   linkType: hard
 
-"@parcel/node-resolver-core@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@parcel/node-resolver-core@npm:3.3.0"
+"@parcel/node-resolver-core@npm:3.5.4":
+  version: 3.5.4
+  resolution: "@parcel/node-resolver-core@npm:3.5.4"
   dependencies:
     "@mischnic/json-sourcemap": "npm:^0.1.0"
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/fs": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/fs": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
     semver: "npm:^7.5.2"
-  checksum: 10c0/9a2731763514c0a54da9710e1131b5960b928900cbc33faf67d07a892cf9ed9f1b11ed2653e574e8363c4527d16e008365917b7b09eb3b9ee727fd244a5f51ee
+  checksum: 10c0/86615efe5215a6468bc584eed8fc5e5bd4c908a028e07f5c7f33b3269f1b82c3c7383953b3e4afce59bb8120fb39fa00e1d0bd28a59323fa54152f6f0e5045fa
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-css@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/optimizer-css@npm:2.12.0"
+"@parcel/optimizer-css@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/optimizer-css@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/utils": "npm:2.14.4"
     browserslist: "npm:^4.6.6"
     lightningcss: "npm:^1.22.1"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/537e84a85fda7a2f73acd2a55842ffe9846abb02d18a7518baf8ae140fc6140a26bb1988285dbccb49a883fdc8597eabbb6d4882500bf160b97d6d93e3664677
+  checksum: 10c0/62ea166d91b9b18f9396f85a0c7a4cb82e34d0b3d93e48ac30926d5ba4999ba9b068e8cfcbaac5620cdff20c372a6e79ede33a88849b688d1d615dd628343807
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-htmlnano@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/optimizer-htmlnano@npm:2.12.0"
+"@parcel/optimizer-htmlnano@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/optimizer-htmlnano@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     htmlnano: "npm:^2.0.0"
     nullthrows: "npm:^1.1.1"
     posthtml: "npm:^0.16.5"
-    svgo: "npm:^2.4.0"
-  checksum: 10c0/487e0fa99e975e6f9add2759e4ad412c0595d7b80d5dde9e186700fa54a9ecb9d1cb611fbd5a0d3392fda3a01050d95e3ded53ca8b50ede3203fe77af489cd0b
+  checksum: 10c0/bb538a76193956b95bd5baf3772e18dbf3cb8c9aec592b3c5fad0604c7f118b62d25789ee7f6cc884363100c74ab0cbad8dd2e2528f808fbac9d11f0de86fe5e
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-image@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/optimizer-image@npm:2.12.0"
+"@parcel/optimizer-image@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/optimizer-image@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    "@parcel/workers": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    "@parcel/workers": "npm:2.14.4"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/f050c569548ec8330c65d0e9b6f6b15d5761e14e704ef16b950db19ae0d6b5a30fd42a38bb04841561244e8ab8f7fb781d9e9f1418ae84858fe7ad325a4be494
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/27f10bdb6e4044e5a2906bf5746447531a2d5928ed40e50bf0d46dea27472de52ff801180d1e0993dc96ec5cd652d9ca96132e1339de873e9f9516448ee1f4b3
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-svgo@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/optimizer-svgo@npm:2.12.0"
+"@parcel/optimizer-svgo@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/optimizer-svgo@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    svgo: "npm:^2.4.0"
-  checksum: 10c0/dc49c565d8f15b4f78ee70910a9c527f25316f0440e9cba6c5b8af1562d34708e5276b35f1e1ea26e7911d6d5c60fa82be6627517fe818df6f69eba5f0f6813f
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+  checksum: 10c0/167f5e1f407be021bbc92fadd01f7e314fced4153d5390afe68802ce9385df6e166229238ee828a8b59585230936f13ff553e95256c020aba5df8c2b6e636e7b
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-swc@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/optimizer-swc@npm:2.12.0"
+"@parcel/optimizer-swc@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/optimizer-swc@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.12.0"
-    "@swc/core": "npm:^1.3.36"
+    "@parcel/utils": "npm:2.14.4"
+    "@swc/core": "npm:^1.11.5"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/52f52182769ebb76248deab85893dacf183e6ff9a87a56c3589331cb0e37debb7ae8fa819386fe23f69b15e6b39823879e20816b10fbab3d316018a94b0c653c
+  checksum: 10c0/00baacb2bfdfb07ec3e4d0a459bf11f1f6f60ca69bfd607047c4fc9322db74733d4bfba3f2091aea3f7eaf05626f4d1bd601ee3dab1572230bcadbf3981fffa0
   languageName: node
   linkType: hard
 
-"@parcel/package-manager@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/package-manager@npm:2.12.0"
+"@parcel/package-manager@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/package-manager@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/fs": "npm:2.12.0"
-    "@parcel/logger": "npm:2.12.0"
-    "@parcel/node-resolver-core": "npm:3.3.0"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    "@parcel/workers": "npm:2.12.0"
-    "@swc/core": "npm:^1.3.36"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/fs": "npm:2.14.4"
+    "@parcel/logger": "npm:2.14.4"
+    "@parcel/node-resolver-core": "npm:3.5.4"
+    "@parcel/types": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    "@parcel/workers": "npm:2.14.4"
+    "@swc/core": "npm:^1.11.5"
     semver: "npm:^7.5.2"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/3ebffe05b293332f69c34479ea0b51a9fa3449ab56eef1b0ec9487c4feacf45df6dec9d8dcb67203398249093370f7d884dc0cb6b6ee15ee8c5db9768579060c
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/f3b2278e7244fd588845feb69ce604637f55af8d1ba267a7b90bc0f74fc86cf23e902d4260fbc474f0e36949831c7137cfee5ace6159a3967c06809f1625f6c3
   languageName: node
   linkType: hard
 
-"@parcel/packager-css@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/packager-css@npm:2.12.0"
+"@parcel/packager-css@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/packager-css@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/utils": "npm:2.14.4"
     lightningcss: "npm:^1.22.1"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/a7293c84c67b9e07b8b8cdc48d96037e05bc50daa8a2aba64b23797fea87e259bf7046a5b969917531db33b8f2387463c817e569a34f42d791bbfacb074268ea
+  checksum: 10c0/c8eec3a8614be47a38fffc61c073f49139c54e8ae3aa4de9eaa9a8fe4f372175f2f704a2c9f6070c3340889c16699aedd557cad2b0a3fcfdcba0f647a4150c31
   languageName: node
   linkType: hard
 
-"@parcel/packager-html@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/packager-html@npm:2.12.0"
+"@parcel/packager-html@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/packager-html@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/types": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
     posthtml: "npm:^0.16.5"
-  checksum: 10c0/099eccde796af61cb6f153fcd69c49d22b4acc430d3652a4f2e5d4124c1cf2d6782213048436fd8e9e5521a52b1219e7bc02d38be89ce97e6f70899d3be31d7f
+  checksum: 10c0/351d1a769c83378a8337659caefbc61067318d88bdfe7b7fdfc7d4e71ac32b154464e88a33f57c95ea080e2057c9102bfd6efd08e065eb42c0ae33845b36d853
   languageName: node
   linkType: hard
 
-"@parcel/packager-js@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/packager-js@npm:2.12.0"
+"@parcel/packager-js@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/packager-js@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/types": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     globals: "npm:^13.2.0"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/89214e8d35f6dc35c2fd0c2b11ec608703dbc52435a7a6141e0b8fc676610fa09c2210cc93490ea4b3581ae0bc13f307dd5515402c939980e1c6bf90148d34e2
+  checksum: 10c0/f3bec9beedc378a0eb14e4d4fcc3614ac74ed57ce2500b363f15a7941ec4f916e079baa7b952374e4272cf3e4bea444ee6552749c8cff6783d2255a66c000b99
   languageName: node
   linkType: hard
 
-"@parcel/packager-raw@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/packager-raw@npm:2.12.0"
+"@parcel/packager-raw@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/packager-raw@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-  checksum: 10c0/c1539179a62674460fea65c9fd1b150aedd596723e79d4e949bf5bd667defd6a72ed73552033e4cdd2b854aa6d5022201797b746e5deb633b41f1de716716af9
+    "@parcel/plugin": "npm:2.14.4"
+  checksum: 10c0/0e40c2a9a6ff20530c7ebdb4876bfc5e5d1812c4c5b2006cf50e8345710100b5e777e14e36163644bf8a2f527769b552c8216ebf75489db29844e61cf93c321f
   languageName: node
   linkType: hard
 
-"@parcel/packager-svg@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/packager-svg@npm:2.12.0"
+"@parcel/packager-svg@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/packager-svg@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/types": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     posthtml: "npm:^0.16.4"
-  checksum: 10c0/58f877d470e5b50adb7eca837f571cbd221cf6681bc83d08146e4aeae4e1430a2e3363beb4a62cfc6952f4f8ded1746889545b4c946300258268a11b298047fd
+  checksum: 10c0/762097b954e9b3eb2445323d814c791ba82d8d1e7d0e2349bd187b92178e4cc1ddceda38994c733ce0f58ab58a80f4cdffc6b1c5ce66713d9bf1cd13c82054aa
   languageName: node
   linkType: hard
 
-"@parcel/packager-wasm@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/packager-wasm@npm:2.12.0"
+"@parcel/packager-wasm@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/packager-wasm@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-  checksum: 10c0/bd3ccd6f9a0506b26b0d708ded6cea3ac53df5c49426086b556ba7f9f1351aba010da3e0795a1f6944cdc306cffc08eed249bb8444aa4f44d9de0e3d1592810d
+    "@parcel/plugin": "npm:2.14.4"
+  checksum: 10c0/52d4fc9083b953c99f2e81ee034b807075ee8e3ea1ae8e9d0f1fbf1e154b9691091af9894af1828701a8e6ca678fa098651f8f31ecf7bc22d96e06dd42b7851d
   languageName: node
   linkType: hard
 
-"@parcel/plugin@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/plugin@npm:2.12.0"
+"@parcel/plugin@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/plugin@npm:2.14.4"
   dependencies:
-    "@parcel/types": "npm:2.12.0"
-  checksum: 10c0/2030a3e1ee6b8cdfdf07935b085f7731e286651d7455b84a7f635016c580af715deffb893c5bc9fb3e0126db4511d3f2b592ee17b61108d001339d51ef56f9bf
+    "@parcel/types": "npm:2.14.4"
+  checksum: 10c0/85fdd310831f53b7cb1a72785612c867636e3ba290f08ed369153bd80dcef4e8af45a18f8815a9490da809e628590e2dc1c9146e993b9b5679f3108537268757
   languageName: node
   linkType: hard
 
-"@parcel/profiler@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/profiler@npm:2.12.0"
+"@parcel/profiler@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/profiler@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/events": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/events": "npm:2.14.4"
+    "@parcel/types-internal": "npm:2.14.4"
     chrome-trace-event: "npm:^1.0.2"
-  checksum: 10c0/3caa9014da88f7435c43396fd1bb413c35134801699943717079a92fcd3ab0a0974c98b98473c5bc1ef434ce8203483fb96af642c1d64e20266625499ca4b4fe
+  checksum: 10c0/dcd0e2797a1a58c9963aa1c4ceefd965bc9f94304c85174af2c7b5115e58d94d7f532d1c3351a88399edfa042986770bb4358efb692c8529cf397f685ed81a56
   languageName: node
   linkType: hard
 
-"@parcel/reporter-cli@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/reporter-cli@npm:2.12.0"
+"@parcel/reporter-cli@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/reporter-cli@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    chalk: "npm:^4.1.0"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/types": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    chalk: "npm:^4.1.2"
     term-size: "npm:^2.2.1"
-  checksum: 10c0/0fee616377d540e11e61fd827a8886d8b8fc4985f87da694945b5a7f3da821bcbb0c5d7a31d72cdf12546c7bf555f7ef5c15d75b71ab157d93cacf0972b29006
+  checksum: 10c0/f4b7c204f4fc5a1b48c7fef0942c446bd6b9d8cfd83cf479943a39969b90a9c072cae05905f3d9f931fa91a63a98b0733165d2af678aab51489137263faf2a9b
   languageName: node
   linkType: hard
 
-"@parcel/reporter-dev-server@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/reporter-dev-server@npm:2.12.0"
+"@parcel/reporter-dev-server@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/reporter-dev-server@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-  checksum: 10c0/bd875c937214aa877805413dbfce89d95dc2578098693991cce26624366cc19807a678c2779edbc620f9618db244807a2271027fb5e328318618a4666b33e512
+    "@parcel/codeframe": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/source-map": "npm:^2.1.1"
+    "@parcel/utils": "npm:2.14.4"
+  checksum: 10c0/db22106a757a65ef088a2b7d3752e8ecadf6569b6fba13d883ec480a0c2901d91fdc31070f76f35e5c1442526f3162a5608cce509bc59523beea794b79071bd8
   languageName: node
   linkType: hard
 
-"@parcel/reporter-tracer@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/reporter-tracer@npm:2.12.0"
+"@parcel/reporter-tracer@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/reporter-tracer@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     chrome-trace-event: "npm:^1.0.3"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/5ab33196ce4a62681d5017d908da354e25a6d367cdf0a849cd408c673bac61d3674316438a4c4c7eebb26f865e5ee3c1b8cda897c92dfa7211c0107c48d04388
+  checksum: 10c0/214994e42adcdba7fdd7733594e0e78c6f8661faf709e57a246a4d0cb6161772bca8b4927f78eefd8d8dc05907054bbe0449d023489dc6e90271e3afe309f486
   languageName: node
   linkType: hard
 
-"@parcel/resolver-default@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/resolver-default@npm:2.12.0"
+"@parcel/resolver-default@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/resolver-default@npm:2.14.4"
   dependencies:
-    "@parcel/node-resolver-core": "npm:3.3.0"
-    "@parcel/plugin": "npm:2.12.0"
-  checksum: 10c0/22b1e4223070c962570928390c6cb77e866d4a3ede1a7019ad3ed2fed75604a2d78c335d65aa646dd753f05916397b56416aef52009cace9b56fd39bf6362457
+    "@parcel/node-resolver-core": "npm:3.5.4"
+    "@parcel/plugin": "npm:2.14.4"
+  checksum: 10c0/575f31d224c2dc59b79228ae083cef8dff1ab76b17a5d8df241d4369b46e4faf4216222ddb8f4c61bed066b54ee72b35287631c0d4eecc9fafd941447014992d
   languageName: node
   linkType: hard
 
-"@parcel/runtime-browser-hmr@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/runtime-browser-hmr@npm:2.12.0"
+"@parcel/runtime-browser-hmr@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/runtime-browser-hmr@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-  checksum: 10c0/126babc8dbd7937e94a38bed1527190a203c20bcba7b66f85b1ddbce81ec54b3fb0579f371284cb7290b70fc46b88eaaa1ee6c9d9e3b739b6267d6902dc82f93
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+  checksum: 10c0/ae55f9f3743efff037d47b904b6fb74a75073cbba3b0dea4ec2d1620df4955ace52ddbc4fdc68aa9343dae775770e3e7acc22d53ca237071592dfc13c7949909
   languageName: node
   linkType: hard
 
-"@parcel/runtime-js@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/runtime-js@npm:2.12.0"
+"@parcel/runtime-js@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/runtime-js@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/01cb236c0ab6f6a170ead43d519ba02092d9b1805f2b8e8cce6f0fec4cb2c37e885c8ce0ff8ae4c7025499d1e36d1ff755f5e8018172c4245c01e97c7a3e9a21
+  checksum: 10c0/cb8048e103a52cd82c54b59b487d65663660c42aab03ae61729ce541637e4c5182dc297dd92c35e1dde48c2ed76fd5bc85d9f9b621c43f35452ebdb98e01a645
   languageName: node
   linkType: hard
 
-"@parcel/runtime-react-refresh@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/runtime-react-refresh@npm:2.12.0"
+"@parcel/runtime-rsc@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/runtime-rsc@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    react-error-overlay: "npm:6.0.9"
-    react-refresh: "npm:^0.9.0"
-  checksum: 10c0/9efd3903118169f1eb4c176afbc4b8ee38d8b516a72dd189fec4d05c5b216e105aa6a77dd87aa5966923a648ed2c227e83feaed6c706a6fd5ebe0cdf255d5d46
-  languageName: node
-  linkType: hard
-
-"@parcel/runtime-service-worker@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/runtime-service-worker@npm:2.12.0"
-  dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/014e44aa15bcc81002713af1cfc88a1d010f3ba6565ec5ea560231540a79cb76fecb11336ac019fb4c9c21a59477a1ce2d9f1a67f85e07be6b7da4498cfa17b3
+  checksum: 10c0/07c2282b9935fdfd9ffda3cd74a66f3ff544ddc920310fc9fffc1034c58b1e62b6ee6cc9c1e6988b045f87fb3ab7dbcae0a7bfc3f14c30f05902971a5119a98f
   languageName: node
   linkType: hard
 
-"@parcel/rust@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/rust@npm:2.12.0"
-  checksum: 10c0/38d8e5c69b31b3f7eb431f479c250f7a4e37f7814ce0aa16d42c300fffa25659da0ea8ca8e22534fa2b935dc8559507829d0cdebb588756aa4c3619565dcd3e3
+"@parcel/runtime-service-worker@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/runtime-service-worker@npm:2.14.4"
+  dependencies:
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    nullthrows: "npm:^1.1.1"
+  checksum: 10c0/64de50e8b69e2310124a8c7b354b7fddb5c8d0b1ed4496b294766a9b55204b16c592d7c28559ec6f13939b3dc5000729878a8270d639442de321215113d51cfc
+  languageName: node
+  linkType: hard
+
+"@parcel/rust@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/rust@npm:2.14.4"
+  peerDependencies:
+    napi-wasm: ^1.1.2
+  peerDependenciesMeta:
+    napi-wasm:
+      optional: true
+  checksum: 10c0/96af083b0dd79113fc4cd23bf54056eece272ea1b553a17207c8c6e14d6f33ba80c2083576ac751ca8da63c94bb45e5dac18bc9626f37625ac31454792fd72af
   languageName: node
   linkType: hard
 
@@ -674,194 +699,211 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-babel@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-babel@npm:2.12.0"
+"@parcel/transformer-babel@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-babel@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/utils": "npm:2.14.4"
     browserslist: "npm:^4.6.6"
     json5: "npm:^2.2.0"
     nullthrows: "npm:^1.1.1"
     semver: "npm:^7.5.2"
-  checksum: 10c0/b7398cc2ef02fd76010bb522fc72e562ce835643365a37ccfc56368121e5c9d890bef14fffa40a8c69e4a26f13ee7d6da8d8e8590957bd4f363b5aa1c4f7d43d
+  checksum: 10c0/fffb60b72808753dfe21b9996d1226b78a1a1161211342b77aeaf9efb3a379a623cedc5c6a1007eb797fe060f1eaf938311334443714f66d4c501e90316af712
   languageName: node
   linkType: hard
 
-"@parcel/transformer-css@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-css@npm:2.12.0"
+"@parcel/transformer-css@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-css@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/utils": "npm:2.14.4"
     browserslist: "npm:^4.6.6"
     lightningcss: "npm:^1.22.1"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/b3ad2591bca09a5696791b9a50bfb8efb825e92313740d6e3988ae1345d70965e92f9d42d58ae5571749e422d9018681aa49bddeafa939f3948a6993cc1cb4c8
+  checksum: 10c0/391e1e71c5e4233a6f5800db71e10b12935bed743d38d2dc74da7ec0daa005f6e60895dfe2155e64205fc8d02f647ea0ad1bb33bc2353ccdf396c7f6c200982c
   languageName: node
   linkType: hard
 
-"@parcel/transformer-html@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-html@npm:2.12.0"
+"@parcel/transformer-html@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-html@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
     posthtml: "npm:^0.16.5"
-    posthtml-parser: "npm:^0.10.1"
+    posthtml-parser: "npm:^0.12.1"
     posthtml-render: "npm:^3.0.0"
     semver: "npm:^7.5.2"
     srcset: "npm:4"
-  checksum: 10c0/1e73c1afe87b8db36e358752fe1b89d466cd9bfe66dda34fca58ad28ab10931553b16ba82096eeb266a0d90e62d6c9e455e3b32dbdf550f4212193898d4c45fd
+  checksum: 10c0/afdae02ee361cb21e8201d9667211d1f27595198b9fc8ecc30c7271b438ca9857e13c1e7df26e68f65d03bf4a932108e8da4b3a3e390b162ee5880c6f8818b8b
   languageName: node
   linkType: hard
 
-"@parcel/transformer-image@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-image@npm:2.12.0"
+"@parcel/transformer-image@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-image@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    "@parcel/workers": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    "@parcel/workers": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/e361fa97d81b3dc2dfe011342321f1d2afd4fd41a9c2791522d8f39e2dc94714a2a0b9d291eb73437b2023fd1493ad37046d6b1ee925ec80daa18261cd5767a4
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/837afac1157f625b6e3176a5e7f45bda47bf795fe365ad63c7002b0ef266418a84d0facd18c2c9b8166b3e7a11568cd82607172fae24d59d57825572ed690dc6
   languageName: node
   linkType: hard
 
-"@parcel/transformer-js@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-js@npm:2.12.0"
+"@parcel/transformer-js@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-js@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.12.0"
-    "@parcel/workers": "npm:2.12.0"
+    "@parcel/utils": "npm:2.14.4"
+    "@parcel/workers": "npm:2.14.4"
     "@swc/helpers": "npm:^0.5.0"
     browserslist: "npm:^4.6.6"
     nullthrows: "npm:^1.1.1"
-    regenerator-runtime: "npm:^0.13.7"
+    regenerator-runtime: "npm:^0.14.1"
     semver: "npm:^7.5.2"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/8a438f0ae93539338ac3f2e2666377e75fb8a5a5386c84485d6cf5f0ad5e52862a80da89c35ca01fae10184ccc7567f1347679fd3b514f7b86643dc83dbce6a6
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/1da9bf8405c1db4cf78ab4c15b74f00cc2f28a97f5ea62e9f6aef5420269f074d540cde502d7784cce1b568c741fdf7bf8d43f7ead1aecd497f324c07e36ecc4
   languageName: node
   linkType: hard
 
-"@parcel/transformer-json@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-json@npm:2.12.0"
+"@parcel/transformer-json@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-json@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
     json5: "npm:^2.2.0"
-  checksum: 10c0/41f931eacf89b5a792ca906594eeafa75d9fe5d0af85af7cf42e77f04e1d31de5bd64d3da9fcf0bdf745f3af252dd727ac318b12cc1c3a1345d19c5096ad98d8
+  checksum: 10c0/542783530d0d7341814c259a7854e3b984d95d25026b8a2c6ef40f32dba946509dcd02f38ef783436f1efc1554b1374ff99b4f4f9f6c7dcfa4e11ea25db8aa48
   languageName: node
   linkType: hard
 
-"@parcel/transformer-postcss@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-postcss@npm:2.12.0"
+"@parcel/transformer-node@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-node@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
+  checksum: 10c0/7a23590769bb7a69a305c6f8a89e580f102a9a498ff9d371889b1b7e33fc6883548520f50e0b3e4805163da2e596036c6ea6e9af2734b6477827de86bc8cb024
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-postcss@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-postcss@npm:2.14.4"
+  dependencies:
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     clone: "npm:^2.1.1"
     nullthrows: "npm:^1.1.1"
     postcss-value-parser: "npm:^4.2.0"
     semver: "npm:^7.5.2"
-  checksum: 10c0/24c3a7eedd741ec1df43bed64b7e02e0132e1c85b9a93322fc994fd2a7f457c4a45f624edf3c064630f947749eb1eb89cb5a502db3f6a39286880afe09020e5a
+  checksum: 10c0/3cc99ab67b893c1dae8412d897fef057dfe29a3814ca36f5ab7bd03418d396fabc16edb67fad866b84b9b27f1b2d045b6f7b47ed05b562a5a4330f0f72f56104
   languageName: node
   linkType: hard
 
-"@parcel/transformer-posthtml@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-posthtml@npm:2.12.0"
+"@parcel/transformer-posthtml@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-posthtml@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
     posthtml: "npm:^0.16.5"
-    posthtml-parser: "npm:^0.10.1"
+    posthtml-parser: "npm:^0.12.1"
     posthtml-render: "npm:^3.0.0"
     semver: "npm:^7.5.2"
-  checksum: 10c0/ae626c15d5dda547850511a8aed41ba35e9496861dbba24efcb904693ced003a74f25c454b0f4bb96500725dd7e09ed4d09becccc48c0c8cdf8fde3ba02aa3f0
+  checksum: 10c0/1fc4c4e99f347e432c32a9712c223c9957caf4d71d5a7ada366d50d1c95becb29690eaeeef12cb947e7ebb7a30e841dc3f58ad7bed689bab34d0fb173408bca5
   languageName: node
   linkType: hard
 
-"@parcel/transformer-raw@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-raw@npm:2.12.0"
+"@parcel/transformer-raw@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-raw@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-  checksum: 10c0/3a23729c6f91ef22c106995f730483dd375f81c11f8bb37ff485d6f3c111f64445d437796d470b42bdd2ee75cc3c4a142911fbcddd1676c8659dfc5e886917d2
+    "@parcel/plugin": "npm:2.14.4"
+  checksum: 10c0/9265c3ef82caebf20517c0725e043a9e6214c78447c8bc664fd701a05e08033bbbba0917b029d68046f9d05d92ab8b8064f1ea95d0dc3aa52c3927f54864e1c9
   languageName: node
   linkType: hard
 
-"@parcel/transformer-react-refresh-wrap@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.12.0"
+"@parcel/transformer-react-refresh-wrap@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.14.4"
   dependencies:
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    react-refresh: "npm:^0.9.0"
-  checksum: 10c0/37dd835182bf71fcee5858f0ab16d5683d2827b4930095ed9fffbd496e431a7f1c53de598f294220b7ff27cd5264d5f1fa750d974a1ee02fb39342fd867b6f9c
+    "@parcel/error-overlay": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    react-refresh: "npm:>=0.9 <=0.16"
+  checksum: 10c0/4ab6f9263b3f7a56c45e25323ef4569860c7a8cb24db48fc06cbf2fff25585f9d838c85c67c519d048770a319358b350eb64785ae3bb59ab1863c122b65ce570
   languageName: node
   linkType: hard
 
-"@parcel/transformer-svg@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/transformer-svg@npm:2.12.0"
+"@parcel/transformer-svg@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/transformer-svg@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/plugin": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/plugin": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
     posthtml: "npm:^0.16.5"
-    posthtml-parser: "npm:^0.10.1"
+    posthtml-parser: "npm:^0.12.1"
     posthtml-render: "npm:^3.0.0"
     semver: "npm:^7.5.2"
-  checksum: 10c0/8916bdc0b36c60b32963e015c43a8bcd8cc2b15cc11b7611c49af6a4e4d63c2aabea0aa0fde31a78278eec25f88b52b3e56d8382dc2db5f3a401e63312115f3a
+  checksum: 10c0/ce0b9c54b26a8698b31c4691ef8e42160f4f969b2336a8c7abb57d4877517f51efc1627e7b4df9f171f376f82ade67c1d1a3eac8341fb42ee4399ac7daecde59
   languageName: node
   linkType: hard
 
-"@parcel/types@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/types@npm:2.12.0"
+"@parcel/types-internal@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/types-internal@npm:2.14.4"
   dependencies:
-    "@parcel/cache": "npm:2.12.0"
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/fs": "npm:2.12.0"
-    "@parcel/package-manager": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/feature-flags": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/workers": "npm:2.12.0"
     utility-types: "npm:^3.10.0"
-  checksum: 10c0/a8aa61ad7cc8218a41fe27c206031b30c55eab59cd4affdfac7d15ddcfb80a1969c22086760b7d4fbdd63016dbfe3278d462e04b9c12e474780fe154caf08150
+  checksum: 10c0/299249de7b29692868c5ebf283e88c859a38cb1ec7340a61e967b59796e79ab3725c4695551bebe8e65b48932e02f2a4bfe2fe9a5f2a20999914110b1dd3b6e7
   languageName: node
   linkType: hard
 
-"@parcel/utils@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/utils@npm:2.12.0"
+"@parcel/types@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/types@npm:2.14.4"
   dependencies:
-    "@parcel/codeframe": "npm:2.12.0"
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/logger": "npm:2.12.0"
-    "@parcel/markdown-ansi": "npm:2.12.0"
-    "@parcel/rust": "npm:2.12.0"
+    "@parcel/types-internal": "npm:2.14.4"
+    "@parcel/workers": "npm:2.14.4"
+  checksum: 10c0/ad2301411469817507c15141018cb975a0d4535f24b09e9eea12987239086cb003ffb59cc457c521edd75ca0d0eb4404ef8a0206f899611d2e82fea6424f4d3e
+  languageName: node
+  linkType: hard
+
+"@parcel/utils@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/utils@npm:2.14.4"
+  dependencies:
+    "@parcel/codeframe": "npm:2.14.4"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/logger": "npm:2.14.4"
+    "@parcel/markdown-ansi": "npm:2.14.4"
+    "@parcel/rust": "npm:2.14.4"
     "@parcel/source-map": "npm:^2.1.1"
-    chalk: "npm:^4.1.0"
+    chalk: "npm:^4.1.2"
     nullthrows: "npm:^1.1.1"
-  checksum: 10c0/888e2352d056ceff4e81d0cf4ae4eb8f322b0a8c4eb9e6f6aa5f916adc3f27c90369d5580b4f316029bf5160294a607795181a6bb368741524c177a14b2aa7c7
+  checksum: 10c0/90a95531b32ead4ad7ee3770dc9bb6aad2bfe9a70376fe53ce9df99d33d75451802c3ef4ae6e21109d4dd723eb1b4541bbec060b81dc106dea96e6ddfd3393fb
   languageName: node
   linkType: hard
 
@@ -999,19 +1041,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/workers@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@parcel/workers@npm:2.12.0"
+"@parcel/workers@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@parcel/workers@npm:2.14.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/logger": "npm:2.12.0"
-    "@parcel/profiler": "npm:2.12.0"
-    "@parcel/types": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/logger": "npm:2.14.4"
+    "@parcel/profiler": "npm:2.14.4"
+    "@parcel/types-internal": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
-    "@parcel/core": ^2.12.0
-  checksum: 10c0/0f5e12e7997d806d6694e91a6c5968c34e1967f50bab3c09296589b2b279ffcd1c8de735845448de350e510a5657ba0aeb4b2c5c04cab81c4c7a57f70d567f5e
+    "@parcel/core": ^2.14.4
+  checksum: 10c0/be7254534dce0d90d1d5b59cf989ba5ec039843166958f898071ed76d9666334ad67e322a084e85819d77975e115023b72a68c289d421d5d0bafbc41bb61b0e1
   languageName: node
   linkType: hard
 
@@ -1022,92 +1064,92 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-darwin-arm64@npm:1.6.5"
+"@swc/core-darwin-arm64@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-darwin-arm64@npm:1.11.18"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-darwin-x64@npm:1.6.5"
+"@swc/core-darwin-x64@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-darwin-x64@npm:1.11.18"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.6.5"
+"@swc/core-linux-arm-gnueabihf@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.11.18"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.6.5"
+"@swc/core-linux-arm64-gnu@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.11.18"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-linux-arm64-musl@npm:1.6.5"
+"@swc/core-linux-arm64-musl@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-linux-arm64-musl@npm:1.11.18"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-linux-x64-gnu@npm:1.6.5"
+"@swc/core-linux-x64-gnu@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-linux-x64-gnu@npm:1.11.18"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-linux-x64-musl@npm:1.6.5"
+"@swc/core-linux-x64-musl@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-linux-x64-musl@npm:1.11.18"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.6.5"
+"@swc/core-win32-arm64-msvc@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.11.18"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.6.5"
+"@swc/core-win32-ia32-msvc@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.11.18"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.6.5":
-  version: 1.6.5
-  resolution: "@swc/core-win32-x64-msvc@npm:1.6.5"
+"@swc/core-win32-x64-msvc@npm:1.11.18":
+  version: 1.11.18
+  resolution: "@swc/core-win32-x64-msvc@npm:1.11.18"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.3.36":
-  version: 1.6.5
-  resolution: "@swc/core@npm:1.6.5"
+"@swc/core@npm:^1.11.5":
+  version: 1.11.18
+  resolution: "@swc/core@npm:1.11.18"
   dependencies:
-    "@swc/core-darwin-arm64": "npm:1.6.5"
-    "@swc/core-darwin-x64": "npm:1.6.5"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.6.5"
-    "@swc/core-linux-arm64-gnu": "npm:1.6.5"
-    "@swc/core-linux-arm64-musl": "npm:1.6.5"
-    "@swc/core-linux-x64-gnu": "npm:1.6.5"
-    "@swc/core-linux-x64-musl": "npm:1.6.5"
-    "@swc/core-win32-arm64-msvc": "npm:1.6.5"
-    "@swc/core-win32-ia32-msvc": "npm:1.6.5"
-    "@swc/core-win32-x64-msvc": "npm:1.6.5"
+    "@swc/core-darwin-arm64": "npm:1.11.18"
+    "@swc/core-darwin-x64": "npm:1.11.18"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.11.18"
+    "@swc/core-linux-arm64-gnu": "npm:1.11.18"
+    "@swc/core-linux-arm64-musl": "npm:1.11.18"
+    "@swc/core-linux-x64-gnu": "npm:1.11.18"
+    "@swc/core-linux-x64-musl": "npm:1.11.18"
+    "@swc/core-win32-arm64-msvc": "npm:1.11.18"
+    "@swc/core-win32-ia32-msvc": "npm:1.11.18"
+    "@swc/core-win32-x64-msvc": "npm:1.11.18"
     "@swc/counter": "npm:^0.1.3"
-    "@swc/types": "npm:^0.1.9"
+    "@swc/types": "npm:^0.1.21"
   peerDependencies:
     "@swc/helpers": "*"
   dependenciesMeta:
@@ -1134,7 +1176,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: 10c0/4fba746667d71641ea8db256561cb47e996f03c091ad62aff6856487f14dffa333eee086d514564ee7c79f657ffc6360a37b06ea136dad08a2aaa8d538681197
+  checksum: 10c0/d92826b03e41587695b2423f0fc070dd1d0a1805bd5a936aa042ff9cafd4cd58481b7961008ebaa0e863f8f9d482e611edf61096f487ade9aa4e852546845910
   languageName: node
   linkType: hard
 
@@ -1154,26 +1196,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/types@npm:^0.1.9":
-  version: 0.1.9
-  resolution: "@swc/types@npm:0.1.9"
+"@swc/types@npm:^0.1.21":
+  version: 0.1.21
+  resolution: "@swc/types@npm:0.1.21"
   dependencies:
     "@swc/counter": "npm:^0.1.3"
-  checksum: 10c0/e47db2a06189f100696837ac3d56feaf67e8e68541b236c2de497e066689230f5cbb538fc0ca77c04739ae7653c20a2d79c7ab57ecf7506e2d008cb5e523f724
+  checksum: 10c0/2baa89c824426e0de0c84e212278010e2df8dc2d6ffaa6f1e306e1b2930c6404b3d3f8989307e8c42ceb95ac143ab7a80be138af6a014d5c782dce5be94dcd5e
   languageName: node
   linkType: hard
 
-"@trysound/sax@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@trysound/sax@npm:0.2.0"
-  checksum: 10c0/44907308549ce775a41c38a815f747009ac45929a45d642b836aa6b0a536e4978d30b8d7d680bbd116e9dd73b7dbe2ef0d1369dcfc2d09e83ba381e485ecbe12
-  languageName: node
-  linkType: hard
-
-"@types/alpinejs@npm:^3.13.10":
-  version: 3.13.10
-  resolution: "@types/alpinejs@npm:3.13.10"
-  checksum: 10c0/dbf285b68a746fd02e8f5cc07faeaade3ffe4fae149c46274302e5e3126b09e31936d047dc8418460b66216182542420cda46ecf35fd73a46a691049d15dd535
+"@types/alpinejs@npm:^3.13.11":
+  version: 3.13.11
+  resolution: "@types/alpinejs@npm:3.13.11"
+  checksum: 10c0/181dcff0af59211043e4121f68548bc2efabe74f71ac397bc20aac7a497f76344e8f327745e621ec5db5b4991d12834b88840ad87e7a28c4a1554930b9e32ad6
   languageName: node
   linkType: hard
 
@@ -1193,12 +1228,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/color@npm:^3.0.2":
-  version: 3.0.6
-  resolution: "@types/color@npm:3.0.6"
+"@types/color@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@types/color@npm:4.2.0"
   dependencies:
     "@types/color-convert": "npm:*"
-  checksum: 10c0/79267eeb67f9d11761aecee36bb1503fb8daa699b9ae7e036fc23a74380e5b130c5c0f6d7adafabba89256e46f36ee4d3e28e0ac7e107e8258550eae7d091acf
+  checksum: 10c0/d09b68390bfd4ae6d57115e047be9dbd3ad4d30e9b7c20e6004c778057a94eec9f5c61689c1b6b09a743f8c2491536870dd0c9a2c79bfcaa37f594b54fc9c96d
   languageName: node
   linkType: hard
 
@@ -1225,13 +1260,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abortcontroller-polyfill@npm:^1.1.9":
-  version: 1.7.5
-  resolution: "abortcontroller-polyfill@npm:1.7.5"
-  checksum: 10c0/d7a5ab6fda4f9a54f22ddeb233a2564d2f4f857ec17be25fee21a91bb5090bee57c630c454634b5c4b93fc06bd90d592d1f2fc69f77cd28791ac0fe361feb7d2
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.1":
   version: 7.1.1
   resolution: "agent-base@npm:7.1.1"
@@ -1251,12 +1279,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"alpinejs@npm:^3.14.1":
-  version: 3.14.1
-  resolution: "alpinejs@npm:3.14.1"
+"alpinejs@npm:^3.14.9":
+  version: 3.14.9
+  resolution: "alpinejs@npm:3.14.9"
   dependencies:
     "@vue/reactivity": "npm:~3.1.1"
-  checksum: 10c0/121be09a8e4e068b7ca1a85d9a0f986650f2b32f86640063cb40ea7bd3b1face1562626b1f6e01868f10ea2f6cd4e0c5f308ad0f938f07020107c2312932ea1a
+  checksum: 10c0/6fef55b68b63557459851382279b44a69701b37be7e46d7147f87d26acda1edd1246ed96e5ffcf31cc52e7c57a3acf3af2abe2e5190038d3d5f2f387ff24da21
   languageName: node
   linkType: hard
 
@@ -1319,13 +1347,6 @@ __metadata:
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/e6bbeae30b24f748b546005affb710c5fbc8b11a83f6cd0ca999bd1ab7ad3a22e42888addc40cd145adc4edfe62fcfab4ebc91da22e4259aae441f95a77aee1a
-  languageName: node
-  linkType: hard
-
-"boolbase@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "boolbase@npm:1.0.0"
-  checksum: 10c0/e4b53deb4f2b85c52be0e21a273f2045c7b6a6ea002b0e139c744cb6f95e9ec044439a52883b0d74dedd1ff3da55ed140cfdddfed7fb0cccbed373de5dce1bcf
   languageName: node
   linkType: hard
 
@@ -1406,7 +1427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.0":
+"chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -1462,6 +1483,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "color-convert@npm:3.0.1"
+  dependencies:
+    color-name: "npm:^2.0.0"
+  checksum: 10c0/1ff3db76f4b247aec9062c079b96050f3bcde4fe2183fabf60652b25933fecb85b191bd92044ca60abece39927ad08a3e6d829d9fda9f505c1a1273d13dbc780
+  languageName: node
+  linkType: hard
+
 "color-name@npm:1.1.3":
   version: 1.1.3
   resolution: "color-name@npm:1.1.3"
@@ -1469,37 +1499,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
+"color-name@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "color-name@npm:2.0.0"
+  checksum: 10c0/fc0304606e5c5941f4649a9975c03a2ecd52a22aba3dadb3309b3e4ee61d78c3e13ff245e80b9a930955d38c5f32a9004196a7456c4542822aa1fcfea8e928ed
+  languageName: node
+  linkType: hard
+
+"color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
   languageName: node
   linkType: hard
 
-"color-string@npm:^1.9.0":
-  version: 1.9.1
-  resolution: "color-string@npm:1.9.1"
+"color-string@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "color-string@npm:2.0.1"
   dependencies:
-    color-name: "npm:^1.0.0"
-    simple-swizzle: "npm:^0.2.2"
-  checksum: 10c0/b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
+    color-name: "npm:^2.0.0"
+  checksum: 10c0/8547edb171cfcc9b56d54664560fba98afd065deedd6812e9545be6448c9c38f89dff51e38d18249b3670fa11647824cbcb77bfbb0c8bff8e37c53c9c0baecc1
   languageName: node
   linkType: hard
 
-"color@npm:^4.2.0":
-  version: 4.2.3
-  resolution: "color@npm:4.2.3"
+"color@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "color@npm:5.0.0"
   dependencies:
-    color-convert: "npm:^2.0.1"
-    color-string: "npm:^1.9.0"
-  checksum: 10c0/7fbe7cfb811054c808349de19fb380252e5e34e61d7d168ec3353e9e9aacb1802674bddc657682e4e9730c2786592a4de6f8283e7e0d3870b829bb0b7b2f6118
+    color-convert: "npm:^3.0.1"
+    color-string: "npm:^2.0.0"
+  checksum: 10c0/fa5f2e84add2e1622abe016b917cca739535fc9845305db32043a5bde4b8164033f179fd1807ac3fe52c9ee7888f82d80e5ff90d1e2652454a2341ab3d23d086
   languageName: node
   linkType: hard
 
-"commander@npm:^7.0.0, commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 10c0/8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
+"commander@npm:^12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
   languageName: node
   linkType: hard
 
@@ -1528,45 +1564,6 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
-  languageName: node
-  linkType: hard
-
-"css-select@npm:^4.1.3":
-  version: 4.3.0
-  resolution: "css-select@npm:4.3.0"
-  dependencies:
-    boolbase: "npm:^1.0.0"
-    css-what: "npm:^6.0.1"
-    domhandler: "npm:^4.3.1"
-    domutils: "npm:^2.8.0"
-    nth-check: "npm:^2.0.1"
-  checksum: 10c0/a489d8e5628e61063d5a8fe0fa1cc7ae2478cb334a388a354e91cf2908154be97eac9fa7ed4dffe87a3e06cf6fcaa6016553115335c4fd3377e13dac7bd5a8e1
-  languageName: node
-  linkType: hard
-
-"css-tree@npm:^1.1.2, css-tree@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "css-tree@npm:1.1.3"
-  dependencies:
-    mdn-data: "npm:2.0.14"
-    source-map: "npm:^0.6.1"
-  checksum: 10c0/499a507bfa39b8b2128f49736882c0dd636b0cd3370f2c69f4558ec86d269113286b7df469afc955de6a68b0dba00bc533e40022a73698081d600072d5d83c1c
-  languageName: node
-  linkType: hard
-
-"css-what@npm:^6.0.1":
-  version: 6.1.0
-  resolution: "css-what@npm:6.1.0"
-  checksum: 10c0/a09f5a6b14ba8dcf57ae9a59474722e80f20406c53a61e9aedb0eedc693b135113ffe2983f4efc4b5065ae639442e9ae88df24941ef159c218b231011d733746
-  languageName: node
-  linkType: hard
-
-"csso@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "csso@npm:4.2.0"
-  dependencies:
-    css-tree: "npm:^1.1.2"
-  checksum: 10c0/f8c6b1300efaa0f8855a7905ae3794a29c6496e7f16a71dec31eb6ca7cfb1f058a4b03fd39b66c4deac6cb06bf6b4ba86da7b67d7320389cb9994d52b924b903
   languageName: node
   linkType: hard
 
@@ -1609,19 +1606,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domelementtype@npm:^2.0.1, domelementtype@npm:^2.2.0":
+"dom-serializer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "dom-serializer@npm:2.0.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.2"
+    entities: "npm:^4.2.0"
+  checksum: 10c0/d5ae2b7110ca3746b3643d3ef60ef823f5f078667baf530cec096433f1627ec4b6fa8c072f09d079d7cda915fd2c7bc1b7b935681e9b09e591e1e15f4040b8e2
+  languageName: node
+  linkType: hard
+
+"domelementtype@npm:^2.0.1, domelementtype@npm:^2.2.0, domelementtype@npm:^2.3.0":
   version: 2.3.0
   resolution: "domelementtype@npm:2.3.0"
   checksum: 10c0/686f5a9ef0fff078c1412c05db73a0dce096190036f33e400a07e2a4518e9f56b1e324f5c576a0a747ef0e75b5d985c040b0d51945ce780c0dd3c625a18cd8c9
   languageName: node
   linkType: hard
 
-"domhandler@npm:^4.2.0, domhandler@npm:^4.2.2, domhandler@npm:^4.3.1":
+"domhandler@npm:^4.2.0, domhandler@npm:^4.2.2":
   version: 4.3.1
   resolution: "domhandler@npm:4.3.1"
   dependencies:
     domelementtype: "npm:^2.2.0"
   checksum: 10c0/5c199c7468cb052a8b5ab80b13528f0db3d794c64fc050ba793b574e158e67c93f8336e87fd81e9d5ee43b0e04aea4d8b93ed7be4899cb726a1601b3ba18538b
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+  checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
   languageName: node
   linkType: hard
 
@@ -1636,17 +1653,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-expand@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "dotenv-expand@npm:5.1.0"
-  checksum: 10c0/24ac633de853ef474d0421cc639328b7134109c8dc2baaa5e3afb7495af5e9237136d7e6971e55668e4dce915487eb140967cdd2b3e99aa439e0f6bf8b56faeb
+"domutils@npm:^3.1.0":
+  version: 3.2.2
+  resolution: "domutils@npm:3.2.2"
+  dependencies:
+    dom-serializer: "npm:^2.0.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+  checksum: 10c0/47938f473b987ea71cd59e59626eb8666d3aa8feba5266e45527f3b636c7883cca7e582d901531961f742c519d7514636b7973353b648762b2e3bedbf235fada
   languageName: node
   linkType: hard
 
-"dotenv@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "dotenv@npm:7.0.0"
-  checksum: 10c0/4d834d09d23ebd284e701c4204172659a7dcd51116f11c29c575ae6d918ccd4760a3383bdfd83cfbed42f061266b787f8e56452b952638867ea5476be875eb27
+"dotenv-expand@npm:^11.0.6":
+  version: 11.0.7
+  resolution: "dotenv-expand@npm:11.0.7"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  checksum: 10c0/d80b8a7be085edf351270b96ac0e794bc3ddd7f36157912939577cb4d33ba6492ebee349d59798b71b90e36f498d24a2a564fb4aa00073b2ef4c2a3a49c467b1
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.5":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: 10c0/be9f597e36a8daf834452daa1f4cc30e5375a5968f98f46d89b16b983c567398a330580c88395069a77473943c06b877d1ca25b4afafcdd6d4adb549e8293462
   languageName: node
   linkType: hard
 
@@ -1698,6 +1728,13 @@ __metadata:
   version: 3.0.1
   resolution: "entities@npm:3.0.1"
   checksum: 10c0/2d93f48fd86de0b0ed8ee34456aa47b4e74a916a5e663cfcc7048302e2c7e932002926daf5a00ad6d5691e3c90673a15d413704d86d7e1b9532f9bc00d975590
+  languageName: node
+  linkType: hard
+
+"entities@npm:^4.2.0, entities@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "entities@npm:4.5.0"
+  checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
   languageName: node
   linkType: hard
 
@@ -1884,6 +1921,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"htmlparser2@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    entities: "npm:^4.5.0"
+  checksum: 10c0/394f6323efc265bbc791d8c0d96bfe95984e0407565248521ab92e2dc7668e5ceeca7bc6ed18d408b9ee3b25032c5743368a4280d280332d782821d5d467ad8f
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -1958,13 +2007,6 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: 10c0/e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
-  languageName: node
-  linkType: hard
-
-"is-arrayish@npm:^0.3.1":
-  version: 0.3.2
-  resolution: "is-arrayish@npm:0.3.2"
-  checksum: 10c0/f59b43dc1d129edb6f0e282595e56477f98c40278a2acdc8b0a5c57097c9eff8fe55470493df5775478cf32a4dc8eaf6d3a749f07ceee5bc263a78b2434f6a54
   languageName: node
   linkType: hard
 
@@ -2253,31 +2295,24 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "map@workspace:."
   dependencies:
-    "@parcel/core": "npm:^2.2.0"
-    "@types/alpinejs": "npm:^3.13.10"
-    "@types/color": "npm:^3.0.2"
-    alpinejs: "npm:^3.14.1"
-    color: "npm:^4.2.0"
-    parcel: "npm:^2.2.0"
-    rainbowvis.js: "npm:^1.0.1"
-    typescript: "npm:^5.5.3"
+    "@parcel/core": "npm:^2.14.4"
+    "@types/alpinejs": "npm:^3.13.11"
+    "@types/color": "npm:^4.2.0"
+    alpinejs: "npm:^3.14.9"
+    color: "npm:^5.0.0"
+    parcel: "npm:^2.14.4"
+    rainbowvis.js: "npm:^1.1.1"
+    typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 
-"mdn-data@npm:2.0.14":
-  version: 2.0.14
-  resolution: "mdn-data@npm:2.0.14"
-  checksum: 10c0/67241f8708c1e665a061d2b042d2d243366e93e5bf1f917693007f6d55111588b952dcbfd3ea9c2d0969fb754aad81b30fdcfdcc24546495fc3b24336b28d4bd
-  languageName: node
-  linkType: hard
-
 "micromatch@npm:^4.0.5":
-  version: 4.0.7
-  resolution: "micromatch@npm:4.0.7"
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
   dependencies:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
-  checksum: 10c0/58fa99bc5265edec206e9163a1d2cec5fabc46a5b473c45f4a700adce88c2520456ae35f2b301e4410fb3afb27e9521fb2813f6fc96be0a48a89430e0916a772
+  checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
   languageName: node
   linkType: hard
 
@@ -2522,15 +2557,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nth-check@npm:^2.0.1":
-  version: 2.1.1
-  resolution: "nth-check@npm:2.1.1"
-  dependencies:
-    boolbase: "npm:^1.0.0"
-  checksum: 10c0/5fee7ff309727763689cfad844d979aedd2204a817fbaaf0e1603794a7c20db28548d7b024692f953557df6ce4a0ee4ae46cd8ebd9b36cfb300b9226b567c479
-  languageName: node
-  linkType: hard
-
 "nullthrows@npm:^1.1.1":
   version: 1.1.1
   resolution: "nullthrows@npm:1.1.1"
@@ -2561,27 +2587,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parcel@npm:^2.2.0":
-  version: 2.12.0
-  resolution: "parcel@npm:2.12.0"
+"parcel@npm:^2.14.4":
+  version: 2.14.4
+  resolution: "parcel@npm:2.14.4"
   dependencies:
-    "@parcel/config-default": "npm:2.12.0"
-    "@parcel/core": "npm:2.12.0"
-    "@parcel/diagnostic": "npm:2.12.0"
-    "@parcel/events": "npm:2.12.0"
-    "@parcel/fs": "npm:2.12.0"
-    "@parcel/logger": "npm:2.12.0"
-    "@parcel/package-manager": "npm:2.12.0"
-    "@parcel/reporter-cli": "npm:2.12.0"
-    "@parcel/reporter-dev-server": "npm:2.12.0"
-    "@parcel/reporter-tracer": "npm:2.12.0"
-    "@parcel/utils": "npm:2.12.0"
-    chalk: "npm:^4.1.0"
-    commander: "npm:^7.0.0"
+    "@parcel/config-default": "npm:2.14.4"
+    "@parcel/core": "npm:2.14.4"
+    "@parcel/diagnostic": "npm:2.14.4"
+    "@parcel/events": "npm:2.14.4"
+    "@parcel/feature-flags": "npm:2.14.4"
+    "@parcel/fs": "npm:2.14.4"
+    "@parcel/logger": "npm:2.14.4"
+    "@parcel/package-manager": "npm:2.14.4"
+    "@parcel/reporter-cli": "npm:2.14.4"
+    "@parcel/reporter-dev-server": "npm:2.14.4"
+    "@parcel/reporter-tracer": "npm:2.14.4"
+    "@parcel/utils": "npm:2.14.4"
+    chalk: "npm:^4.1.2"
+    commander: "npm:^12.1.0"
     get-port: "npm:^4.2.0"
   bin:
     parcel: lib/bin.js
-  checksum: 10c0/1853858c22cb728d3e3f524df04fbdc42aa27a0c8a3a0dbe2314d618ac13a3fe81836ce1560cdfce17338f61ec238d9b616073c181ab77af56664a0221af1b2a
+  checksum: 10c0/e1330d87d73c01cdcc3486be73b12da47aef192cde520a7902654c9a4adfb8280c179bb8f7d01bb41d9bef75186976aab786108d0c26277cdb535575fcff1b5d
   languageName: node
   linkType: hard
 
@@ -2644,21 +2671,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"posthtml-parser@npm:^0.10.1":
-  version: 0.10.2
-  resolution: "posthtml-parser@npm:0.10.2"
-  dependencies:
-    htmlparser2: "npm:^7.1.1"
-  checksum: 10c0/90c7c2e0892c18577a56a5dd60a54c40feb0be7c712a79f711e1730b5eea468f8d521d387af9f08d78e6bca9df613286c3ff8a95ac9426671cbe9021d7ec2ae5
-  languageName: node
-  linkType: hard
-
 "posthtml-parser@npm:^0.11.0":
   version: 0.11.0
   resolution: "posthtml-parser@npm:0.11.0"
   dependencies:
     htmlparser2: "npm:^7.1.1"
   checksum: 10c0/89bf980a60124790f776a9f21aec0f154eba5412d16f0f3a95de7a53d31b9acb9264bf317ab40c080413e3018a8e65c86278e6e8c0731c8e0363418982ed4296
+  languageName: node
+  linkType: hard
+
+"posthtml-parser@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "posthtml-parser@npm:0.12.1"
+  dependencies:
+    htmlparser2: "npm:^9.0.0"
+  checksum: 10c0/24c7986a03350625fa9b55e43ce81e0b8a7b477583de2f74c68b289e7343ec71ea52e33a9c1076c5b14e1e44cfc9f027f523ed7c6ac5b543ed583b4ecc0774ae
   languageName: node
   linkType: hard
 
@@ -2705,31 +2732,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rainbowvis.js@npm:^1.0.1":
+"rainbowvis.js@npm:^1.1.1":
   version: 1.1.1
   resolution: "rainbowvis.js@npm:1.1.1"
   checksum: 10c0/00048b833e284074d140b76b3b2faef4c321e3da1c64dd0f271055fc2facd4a4e16e15d996d07e314e3ef1e12d4519ea34e29ab8b805a7f1a5ad74f9d9b52fd3
   languageName: node
   linkType: hard
 
-"react-error-overlay@npm:6.0.9":
-  version: 6.0.9
-  resolution: "react-error-overlay@npm:6.0.9"
-  checksum: 10c0/02f51337f34589305f827249acb597446489794cc5b5e721a6260111325b56942a7471b76967cba304e797d7e4ef16dd0bd989c112dd0bb9586270df0d75a4a9
+"react-refresh@npm:>=0.9 <=0.16":
+  version: 0.16.0
+  resolution: "react-refresh@npm:0.16.0"
+  checksum: 10c0/122525dbd7a44140757f46b8b93df6a349126e64b270809a8f082809662be5837a97310e56df2cfc7dac98b8adfaaafa570ec579c8b269c374e6928394307c68
   languageName: node
   linkType: hard
 
-"react-refresh@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "react-refresh@npm:0.9.0"
-  checksum: 10c0/fa20f605e19dc10342e5cec8dcbb88cd4a473d26a7ff0acf1f0402e78f94ec309837be07a3cc3646f88d19f9ed07fa13a275f4656b5e3ced8fa23ce488984609
-  languageName: node
-  linkType: hard
-
-"regenerator-runtime@npm:^0.13.7":
-  version: 0.13.11
-  resolution: "regenerator-runtime@npm:0.13.11"
-  checksum: 10c0/12b069dc774001fbb0014f6a28f11c09ebfe3c0d984d88c9bced77fdb6fedbacbca434d24da9ae9371bfbf23f754869307fb51a4c98a8b8b18e5ef748677ca24
+"regenerator-runtime@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 10c0/1b16eb2c4bceb1665c89de70dcb64126a22bc8eb958feef3cd68fe11ac6d2a4899b5cd1b80b0774c7c03591dc57d16631a7f69d2daa2ec98100e2f29f7ec4cc4
   languageName: node
   linkType: hard
 
@@ -2793,15 +2813,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-swizzle@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "simple-swizzle@npm:0.2.2"
-  dependencies:
-    is-arrayish: "npm:^0.3.1"
-  checksum: 10c0/df5e4662a8c750bdba69af4e8263c5d96fe4cd0f9fe4bdfa3cbdeb45d2e869dff640beaaeb1ef0e99db4d8d2ec92f85508c269f50c972174851bc1ae5bd64308
-  languageName: node
-  linkType: hard
-
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
@@ -2830,13 +2841,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "source-map@npm:0.6.1"
-  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
-  languageName: node
-  linkType: hard
-
 "sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
@@ -2857,13 +2861,6 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/e5a1e23a4057a86a97971465418f22ea89bd439ac36ade88812dd920e4e61873e8abd6a9b72a03a67ef50faa00a2daf1ab745c5a15b46d03e0544a0296354227
-  languageName: node
-  linkType: hard
-
-"stable@npm:^0.1.8":
-  version: 0.1.8
-  resolution: "stable@npm:0.1.8"
-  checksum: 10c0/df74b5883075076e78f8e365e4068ecd977af6c09da510cfc3148a303d4b87bc9aa8f7c48feb67ed4ef970b6140bd9eabba2129e28024aa88df5ea0114cba39d
   languageName: node
   linkType: hard
 
@@ -2925,23 +2922,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svgo@npm:^2.4.0":
-  version: 2.8.0
-  resolution: "svgo@npm:2.8.0"
-  dependencies:
-    "@trysound/sax": "npm:0.2.0"
-    commander: "npm:^7.2.0"
-    css-select: "npm:^4.1.3"
-    css-tree: "npm:^1.1.3"
-    csso: "npm:^4.2.0"
-    picocolors: "npm:^1.0.0"
-    stable: "npm:^0.1.8"
-  bin:
-    svgo: bin/svgo
-  checksum: 10c0/0741f5d5cad63111a90a0ce7a1a5a9013f6d293e871b75efe39addb57f29a263e45294e485a4d2ff9cc260a5d142c8b5937b2234b4ef05efdd2706fb2d360ecc
-  languageName: node
-  linkType: hard
-
 "tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.2.1
   resolution: "tar@npm:6.2.1"
@@ -2993,23 +2973,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "typescript@npm:5.5.3"
+"typescript@npm:^5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/f52c71ccbc7080b034b9d3b72051d563601a4815bf3e39ded188e6ce60813f75dbedf11ad15dd4d32a12996a9ed8c7155b46c93a9b9c9bad1049766fe614bbdd
+  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.5.3#optional!builtin<compat/typescript>":
-  version: 5.5.3
-  resolution: "typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=379a07"
+"typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/911c7811d61f57f07df79c4a35f56a0f426a65426a020e5fcd792f66559f399017205f5f10255329ab5a3d8c2d1f1d19530aeceffda70758a521fae1d469432e
+  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
   languageName: node
   linkType: hard
 

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -29,8 +29,8 @@
 // 2000/MAR/21	Azthar Septragen	Added roads.
 // 2001/Feb/21	Joseph Traub		Added FACLIM_UNLIMITED
 
-#include <stdlib.h>
 #include <random>
+#include <stdlib.h>
 
 #include "game.h"
 #include "gamedata.h"
@@ -41,792 +41,770 @@ using namespace std;
 
 void Game::RunMovementOrders()
 {
-	int phase, error;
-	Unit *u;
-	std::list<Location *>locs;
-	Location *l;
-	AString order;
+    int phase, error;
+    Unit *u;
+    std::list<Location *> locs;
+    Location *l;
+    AString order;
 
-	for (phase = 0; phase < Globals->MAX_SPEED; phase++) {
-		for(const auto r : regions) {
-			for(const auto o : r->objects) {
-				for(const auto u : o->units) {
-					DoMoveEnter(u, r);
-				}
-			}
-		}
-		for(const auto r : regions) {
-			for(const auto o : r->objects) {
-				error = 1;
-				if (o->IsFleet()) {
-					u = o->GetOwner();
-					if (!u) continue;
-					if (u->phase >= phase) continue;
-					if (u->nomove) {
-						error = 4;
-					} else if (u->monthorders && u->monthorders->type == O_SAIL) {
-						u->phase = phase;
-						if (o->incomplete < 50) {
-							l = Do1SailOrder(r, o, u);
-							if (l) locs.push_back(l);
-							error = 0;
-						} else {
-							error = 3;
-						}
-					} else {
-						error = 2;
-					}
-				}
-				if (error > 0) {
-					for(const auto u : o->units) {
-						if (u && u->monthorders && u->monthorders->type == O_SAIL) {
-							switch (error) {
-								case 1:
-									u->error("SAIL: Must be on a ship.");
-									break;
-								case 2:
-									u->error("SAIL: Owner must issue fleet directions.");
-									break;
-								case 3:
-									u->error("SAIL: Fleet is too damaged to sail.");
-									break;
-								case 4:
-									u->error("SAIL: Unable to sail due to combat losses.");
-									break;
-							}
-							delete u->monthorders;
-							u->monthorders = nullptr;
-						}
-					}
-				}
-			}
-		}
-		for(const auto r : regions) {
-			for(auto o : r->objects) {
-				for(const auto u : o->units) {
-					if (u->phase >= phase) continue;
-					u->phase = phase;
-					if (u && !u->nomove && u->monthorders &&
-						(u->monthorders->type == O_MOVE || u->monthorders->type == O_ADVANCE)
-					) {
-						l = DoAMoveOrder(u, r, o);
-						if (l) locs.push_back(l);
-					}
-				}
-			}
-		}
-		DoMovementAttacks(locs);
-		std::for_each(locs.begin(), locs.end(), [](Location *loc) { delete loc; });
-		locs.clear();
-	}
+    for (phase = 0; phase < Globals->MAX_SPEED; phase++) {
+        for (const auto r : regions) {
+            for (const auto o : r->objects) {
+                for (const auto u : o->units) { DoMoveEnter(u, r); }
+            }
+        }
+        for (const auto r : regions) {
+            for (const auto o : r->objects) {
+                error = 1;
+                if (o->IsFleet()) {
+                    u = o->GetOwner();
+                    if (!u) continue;
+                    if (u->phase >= phase) continue;
+                    if (u->nomove) {
+                        error = 4;
+                    } else if (u->monthorders && u->monthorders->type == O_SAIL) {
+                        u->phase = phase;
+                        if (o->incomplete < 50) {
+                            l = Do1SailOrder(r, o, u);
+                            if (l) locs.push_back(l);
+                            error = 0;
+                        } else {
+                            error = 3;
+                        }
+                    } else {
+                        error = 2;
+                    }
+                }
+                if (error > 0) {
+                    for (const auto u : o->units) {
+                        if (u && u->monthorders && u->monthorders->type == O_SAIL) {
+                            switch (error) {
+                            case 1: u->error("SAIL: Must be on a ship."); break;
+                            case 2: u->error("SAIL: Owner must issue fleet directions."); break;
+                            case 3: u->error("SAIL: Fleet is too damaged to sail."); break;
+                            case 4: u->error("SAIL: Unable to sail due to combat losses."); break;
+                            }
+                            delete u->monthorders;
+                            u->monthorders = nullptr;
+                        }
+                    }
+                }
+            }
+        }
+        for (const auto r : regions) {
+            for (auto o : r->objects) {
+                for (const auto u : o->units) {
+                    if (u->phase >= phase) continue;
+                    u->phase = phase;
+                    if (u && !u->nomove && u->monthorders &&
+                        (u->monthorders->type == O_MOVE || u->monthorders->type == O_ADVANCE)) {
+                        l = DoAMoveOrder(u, r, o);
+                        if (l) locs.push_back(l);
+                    }
+                }
+            }
+        }
+        DoMovementAttacks(locs);
+        std::for_each(locs.begin(), locs.end(), [](Location *loc) { delete loc; });
+        locs.clear();
+    }
 
-	// Do a final round of Enters after the phased movement is done,
-	// in case such a thing is at the end of a move chain
-	for(const auto r : regions) {
-		for(const auto o : r->objects) {
-			for(const auto u : o->units) {
-				DoMoveEnter(u, r);
-			}
-		}
-	}
+    // Do a final round of Enters after the phased movement is done,
+    // in case such a thing is at the end of a move chain
+    for (const auto r : regions) {
+        for (const auto o : r->objects) {
+            for (const auto u : o->units) { DoMoveEnter(u, r); }
+        }
+    }
 
-	// Queue remaining moves
-	for(const auto r : regions) {
-		for(const auto o : r->objects) {
-			for(const auto u : o->units) {
-				MoveOrder *mo = dynamic_cast<MoveOrder *>(u->monthorders);
-				if (!mo  || (mo->type != O_MOVE && mo->type != O_ADVANCE)) {
-					u->savedmovement = 0;
-					u->savedmovedir = -1;
-					continue;
-				}
+    // Queue remaining moves
+    for (const auto r : regions) {
+        for (const auto o : r->objects) {
+            for (const auto u : o->units) {
+                MoveOrder *mo = dynamic_cast<MoveOrder *>(u->monthorders);
+                if (!mo || (mo->type != O_MOVE && mo->type != O_ADVANCE)) {
+                    u->savedmovement = 0;
+                    u->savedmovedir = -1;
+                    continue;
+                }
 
-				if (mo->dirs.size() > 0) {
-					if (u->nomove) {
-						u->savedmovedir = -1;
-						u->savedmovement = 0;
-					} else {
-						auto d = mo->dirs.front();
-						if (u->savedmovedir != d->dir) {
-							u->savedmovement = 0;
-						}
-						u->savedmovement += u->movepoints / Globals->MAX_SPEED;
-						u->savedmovedir = d->dir;
-					}
+                if (mo->dirs.size() > 0) {
+                    if (u->nomove) {
+                        u->savedmovedir = -1;
+                        u->savedmovement = 0;
+                    } else {
+                        auto d = mo->dirs.front();
+                        if (u->savedmovedir != d->dir) { u->savedmovement = 0; }
+                        u->savedmovement += u->movepoints / Globals->MAX_SPEED;
+                        u->savedmovedir = d->dir;
+                    }
 
-					string tOrder = (mo->advancing ? "ADVANCE" : "MOVE");
-					string temp = tOrder + ": Unit has insufficient movement points; remaining moves queued.";
-					u->event(temp, "movement");
+                    string tOrder = (mo->advancing ? "ADVANCE" : "MOVE");
+                    string temp = tOrder + ": Unit has insufficient movement points; remaining moves queued.";
+                    u->event(temp, "movement");
 
-					for(const auto d : mo->dirs) {
-						tOrder += " ";
+                    for (const auto d : mo->dirs) {
+                        tOrder += " ";
 
-						// Add the appropriate direction token
-						if (d->dir < NDIRS) tOrder += DirectionAbrs[d->dir];
-						else if (d->dir == MOVE_IN) tOrder += "IN";
-						else if (d->dir == MOVE_OUT) tOrder += "OUT";
-						else if (d->dir == MOVE_PAUSE) tOrder += "P";
-						else tOrder += d->dir - MOVE_ENTER;
-					}
-					u->oldorders.push_front(tOrder);
-				}
-			}
-			u = o->GetOwner();
-			if (o->IsFleet() && u && !u->nomove && u->monthorders && u->monthorders->type == O_SAIL) {
-				SailOrder *so = dynamic_cast<SailOrder *>(u->monthorders);
-				if (so->dirs.size() > 0) {
-					u->event("SAIL: Can't sail that far; remaining moves queued.", "movement");
-					string tOrder = "SAIL";
-					for(const auto d : so->dirs) {
-						tOrder += " ";
-						if (d->dir == MOVE_PAUSE) tOrder += "P";
-						else tOrder += DirectionAbrs[d->dir];
-					}
-					u->oldorders.push_front(tOrder);
-				}
-			}
-		}
-	}
+                        // Add the appropriate direction token
+                        if (d->dir < NDIRS)
+                            tOrder += DirectionAbrs[d->dir];
+                        else if (d->dir == MOVE_IN)
+                            tOrder += "IN";
+                        else if (d->dir == MOVE_OUT)
+                            tOrder += "OUT";
+                        else if (d->dir == MOVE_PAUSE)
+                            tOrder += "P";
+                        else
+                            tOrder += d->dir - MOVE_ENTER;
+                    }
+                    u->oldorders.push_front(tOrder);
+                }
+            }
+            u = o->GetOwner();
+            if (o->IsFleet() && u && !u->nomove && u->monthorders && u->monthorders->type == O_SAIL) {
+                SailOrder *so = dynamic_cast<SailOrder *>(u->monthorders);
+                if (so->dirs.size() > 0) {
+                    u->event("SAIL: Can't sail that far; remaining moves queued.", "movement");
+                    string tOrder = "SAIL";
+                    for (const auto d : so->dirs) {
+                        tOrder += " ";
+                        if (d->dir == MOVE_PAUSE)
+                            tOrder += "P";
+                        else
+                            tOrder += DirectionAbrs[d->dir];
+                    }
+                    u->oldorders.push_front(tOrder);
+                }
+            }
+        }
+    }
 }
 
 Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
 {
-	SailOrder *o = dynamic_cast<SailOrder *>(cap->monthorders);
-	int stop, wgt, slr, nomove, cost;
-	std::set<Faction *> facs;
-	ARegion *newreg;
-	Location *loc;
+    SailOrder *o = dynamic_cast<SailOrder *>(cap->monthorders);
+    int stop, wgt, slr, nomove, cost;
+    std::set<Faction *> facs;
+    ARegion *newreg;
+    Location *loc;
 
-	fleet->movepoints += fleet->GetFleetSpeed(0);
-	stop = 0;
-	wgt = 0;
-	slr = 0;
-	nomove = 0;
-	for(const auto unit : fleet->units) {
-		facs.insert(unit->faction);
-		wgt += unit->Weight();
-		if (unit->nomove) {
-			// If any unit on-board was in a fight (and
-			// suffered > 5% casualties), then halt movement
-			nomove = 1;
-		}
-		if (unit->monthorders && unit->monthorders->type == O_SAIL) {
-			slr += unit->GetSkill(S_SAILING) * unit->GetMen();
-		}
-	}
+    fleet->movepoints += fleet->GetFleetSpeed(0);
+    stop = 0;
+    wgt = 0;
+    slr = 0;
+    nomove = 0;
+    for (const auto unit : fleet->units) {
+        facs.insert(unit->faction);
+        wgt += unit->Weight();
+        if (unit->nomove) {
+            // If any unit on-board was in a fight (and
+            // suffered > 5% casualties), then halt movement
+            nomove = 1;
+        }
+        if (unit->monthorders && unit->monthorders->type == O_SAIL) {
+            slr += unit->GetSkill(S_SAILING) * unit->GetMen();
+        }
+    }
 
-	if (nomove) {
-		stop = 1;
-	} else if (!o->dirs.size()) {
-		stop = 1;
-	} else if (wgt > fleet->FleetCapacity()) {
-		cap->error("SAIL: Fleet is overloaded.");
-		stop = 1;
-	} else if (slr < fleet->GetFleetSize()) {
-		cap->error("SAIL: Not enough sailors.");
-		stop = 1;
-	} else {
-		auto x = o->dirs.front();
-		if (x->dir == MOVE_PAUSE) {
-			newreg = reg;
-		} else {
-			newreg = reg->neighbors[x->dir];
-		}
-		cost = 1;
+    if (nomove) {
+        stop = 1;
+    } else if (!o->dirs.size()) {
+        stop = 1;
+    } else if (wgt > fleet->FleetCapacity()) {
+        cap->error("SAIL: Fleet is overloaded.");
+        stop = 1;
+    } else if (slr < fleet->GetFleetSize()) {
+        cap->error("SAIL: Not enough sailors.");
+        stop = 1;
+    } else {
+        auto x = o->dirs.front();
+        if (x->dir == MOVE_PAUSE) {
+            newreg = reg;
+        } else {
+            newreg = reg->neighbors[x->dir];
+        }
+        cost = 1;
 
-		// Blizzard effect
-		if (newreg && newreg->weather == W_BLIZZARD && !newreg->clearskies) {
-			cost = 4;
-		}
+        // Blizzard effect
+        if (newreg && newreg->weather == W_BLIZZARD && !newreg->clearskies) { cost = 4; }
 
-		if (Globals->WEATHER_EXISTS) {
-			if (newreg && newreg->weather != W_NORMAL &&
-					!newreg->clearskies)
-				cost = 2;
-		}
-		if (x->dir == MOVE_PAUSE) {
-			cost = 1;
-		}
-		// We probably shouldn't see terrain-based errors until
-		// we accumulate enough movement points to get there
-		if (fleet->movepoints < cost * Globals->MAX_SPEED)
-			return 0;
-		if (!newreg) {
-			cap->error("SAIL: Can't sail that way.");
-			stop = 1;
-		} else if (x->dir == MOVE_PAUSE) {
-			// Can always do maneuvers
-		} else if (fleet->flying < 1 && !newreg->IsCoastalOrLakeside()) {
-			cap->error("SAIL: Can't sail inland.");
-			stop = 1;
-		} else if ((fleet->flying < 1) &&
-			(TerrainDefs[reg->type].similar_type != R_OCEAN) &&
-			(TerrainDefs[newreg->type].similar_type != R_OCEAN)) {
-			cap->error("SAIL: Can't sail inland.");
-			stop = 1;
-		} else if (fleet->SailThroughCheck(x->dir) < 1) {
-			cap->error("SAIL: Could not sail " + DirectionStrs[x->dir] + " from " +
-				reg->ShortPrint().const_str() +	". Cannot sail through land.");
-			stop = 1;
-		}
+        if (Globals->WEATHER_EXISTS) {
+            if (newreg && newreg->weather != W_NORMAL && !newreg->clearskies) cost = 2;
+        }
+        if (x->dir == MOVE_PAUSE) { cost = 1; }
+        // We probably shouldn't see terrain-based errors until
+        // we accumulate enough movement points to get there
+        if (fleet->movepoints < cost * Globals->MAX_SPEED) return 0;
+        if (!newreg) {
+            cap->error("SAIL: Can't sail that way.");
+            stop = 1;
+        } else if (x->dir == MOVE_PAUSE) {
+            // Can always do maneuvers
+        } else if (fleet->flying < 1 && !newreg->IsCoastalOrLakeside()) {
+            cap->error("SAIL: Can't sail inland.");
+            stop = 1;
+        } else if ((fleet->flying < 1) && (TerrainDefs[reg->type].similar_type != R_OCEAN) &&
+                   (TerrainDefs[newreg->type].similar_type != R_OCEAN)) {
+            cap->error("SAIL: Can't sail inland.");
+            stop = 1;
+        } else if (fleet->SailThroughCheck(x->dir) < 1) {
+            cap->error(
+                "SAIL: Could not sail " + DirectionStrs[x->dir] + " from " + reg->ShortPrint().const_str() +
+                ". Cannot sail through land."
+            );
+            stop = 1;
+        }
 
-		if (!stop) {
-			// Check the new region for barriers and the fleet units for keys to the barriers
-			int needed_key = -1;
-			for(auto o : newreg->objects) {
-				if (ObjectDefs[o->type].flags & ObjectType::KEYBARRIER) {
-					needed_key = ObjectDefs[o->type].key_item;
-				}
-			}
-			if (needed_key != -1) { // we found a barrier
-				bool has_key = false;
-				for(const auto u : fleet->units) {
-					if (u->items.GetNum(needed_key) > 0) {
-						has_key = true;
-						break;
-					}
-				}
-				if (!has_key) {
-					cap->error("SAIL: Can't sail " + DirectionStrs[x->dir] + " from " +
-						reg->ShortPrint().const_str() + " due to mystical barrier.");
-					stop = 1;
-				}
-			}
-		}
+        if (!stop) {
+            // Check the new region for barriers and the fleet units for keys to the barriers
+            int needed_key = -1;
+            for (auto o : newreg->objects) {
+                if (ObjectDefs[o->type].flags & ObjectType::KEYBARRIER) { needed_key = ObjectDefs[o->type].key_item; }
+            }
+            if (needed_key != -1) { // we found a barrier
+                bool has_key = false;
+                for (const auto u : fleet->units) {
+                    if (u->items.GetNum(needed_key) > 0) {
+                        has_key = true;
+                        break;
+                    }
+                }
+                if (!has_key) {
+                    cap->error(
+                        "SAIL: Can't sail " + DirectionStrs[x->dir] + " from " + reg->ShortPrint().const_str() +
+                        " due to mystical barrier."
+                    );
+                    stop = 1;
+                }
+            }
+        }
 
-		// We could have been stopped by not having the key above.
-		if (!stop) {
-			fleet->movepoints -= cost * Globals->MAX_SPEED;
-			if (x->dir != MOVE_PAUSE) {
-				// this can invalidate the object iterator if we are in an iteration
-				fleet->MoveObject(newreg);
-				fleet->SetPrevDir(reg->GetRealDirComp(x->dir));
-			}
-			for(const auto unit : fleet->units) {
-				unit->moved += cost;
-				if (unit->guard == GUARD_GUARD)
-					unit->guard = GUARD_NONE;
-				unit->alias = 0;
-				unit->PracticeAttribute("wind");
-				if (unit->monthorders) {
-					if (unit->monthorders->type == O_SAIL)
-						unit->Practice(S_SAILING);
-					if (unit->monthorders->type == O_MOVE) {
-						delete unit->monthorders;
-						unit->monthorders = nullptr;
-					}
-				}
-				unit->DiscardUnfinishedShips();
-				facs.insert(unit->faction);
-			}
+        // We could have been stopped by not having the key above.
+        if (!stop) {
+            fleet->movepoints -= cost * Globals->MAX_SPEED;
+            if (x->dir != MOVE_PAUSE) {
+                // this can invalidate the object iterator if we are in an iteration
+                fleet->MoveObject(newreg);
+                fleet->SetPrevDir(reg->GetRealDirComp(x->dir));
+            }
+            for (const auto unit : fleet->units) {
+                unit->moved += cost;
+                if (unit->guard == GUARD_GUARD) unit->guard = GUARD_NONE;
+                unit->alias = 0;
+                unit->PracticeAttribute("wind");
+                if (unit->monthorders) {
+                    if (unit->monthorders->type == O_SAIL) unit->Practice(S_SAILING);
+                    if (unit->monthorders->type == O_MOVE) {
+                        delete unit->monthorders;
+                        unit->monthorders = nullptr;
+                    }
+                }
+                unit->DiscardUnfinishedShips();
+                facs.insert(unit->faction);
+            }
 
-			for(const auto f : facs) {
-				string temp = fleet->name->const_str();
-				temp += (x->dir == MOVE_PAUSE ? " performs maneuvers in " : " sails from ") +
-					string(reg->ShortPrint().const_str());
-				if(x->dir != MOVE_PAUSE) {
-					temp  += " to " + string(newreg->ShortPrint().const_str());
-				}
-				f->event(temp, "sail");
-			}
-			if (Globals->TRANSIT_REPORT != GameDefs::REPORT_NOTHING &&
-					x->dir != MOVE_PAUSE) {
-				if (!(cap->faction->is_npc)) newreg->visited = 1;
-				for(const auto unit : fleet->units) {
-					// Everyone onboard gets to see the sights
-					// Note the hex being left
-					for(const auto f : reg->passers) {
-						if (f->unit == unit) {
-							// We moved into here this turn
-							f->exits_used[x->dir] = 1;
-						}
-					}
-					// And mark the hex being entered
-					Farsight *f = new Farsight;
-					f->faction = unit->faction;
-					f->level = 0;
-					f->unit = unit;
-					f->exits_used[reg->GetRealDirComp(x->dir)] = 1;
-					newreg->passers.push_back(f);
-				}
-			}
-			reg = newreg;
-			if (newreg->ForbiddenShip(fleet)) {
-				string temp = string(fleet->name->const_str()) + " is stopped by guards in " +
-					newreg->ShortPrint().const_str() + ".";
-				cap->faction->event(temp, "sail");
-				stop = 1;
-			}
-			std::erase(o->dirs, x);
-			delete x;
-		}
-	}
+            for (const auto f : facs) {
+                string temp = fleet->name->const_str();
+                temp += (x->dir == MOVE_PAUSE ? " performs maneuvers in " : " sails from ") +
+                        string(reg->ShortPrint().const_str());
+                if (x->dir != MOVE_PAUSE) { temp += " to " + string(newreg->ShortPrint().const_str()); }
+                f->event(temp, "sail");
+            }
+            if (Globals->TRANSIT_REPORT != GameDefs::REPORT_NOTHING && x->dir != MOVE_PAUSE) {
+                if (!(cap->faction->is_npc)) newreg->visited = 1;
+                for (const auto unit : fleet->units) {
+                    // Everyone onboard gets to see the sights
+                    // Note the hex being left
+                    for (const auto f : reg->passers) {
+                        if (f->unit == unit) {
+                            // We moved into here this turn
+                            f->exits_used[x->dir] = 1;
+                        }
+                    }
+                    // And mark the hex being entered
+                    Farsight *f = new Farsight;
+                    f->faction = unit->faction;
+                    f->level = 0;
+                    f->unit = unit;
+                    f->exits_used[reg->GetRealDirComp(x->dir)] = 1;
+                    newreg->passers.push_back(f);
+                }
+            }
+            reg = newreg;
+            if (newreg->ForbiddenShip(fleet)) {
+                string temp = string(fleet->name->const_str()) + " is stopped by guards in " +
+                              newreg->ShortPrint().const_str() + ".";
+                cap->faction->event(temp, "sail");
+                stop = 1;
+            }
+            std::erase(o->dirs, x);
+            delete x;
+        }
+    }
 
-	if (stop) {
-		// Clear out everyone's orders
-		for(const auto unit : fleet->units) {
-			if (unit->monthorders && unit->monthorders->type == O_SAIL) {
-				delete unit->monthorders;
-				unit->monthorders = nullptr;
-			}
-		}
-	}
+    if (stop) {
+        // Clear out everyone's orders
+        for (const auto unit : fleet->units) {
+            if (unit->monthorders && unit->monthorders->type == O_SAIL) {
+                delete unit->monthorders;
+                unit->monthorders = nullptr;
+            }
+        }
+    }
 
-	loc = new Location;
-	loc->unit = cap;
-	loc->region = reg;
-	loc->obj = fleet;
-	return loc;
+    loc = new Location;
+    loc->unit = cap;
+    loc->region = reg;
+    loc->obj = fleet;
+    return loc;
 }
 
 void Game::RunTeachOrders()
 {
-	for(const auto r : regions) {
-		for(const auto obj : r->objects) {
-			for(const auto u : obj->units) {
-				if (u->monthorders) {
-					if (u->monthorders->type == O_TEACH) {
-						Do1TeachOrder(r,u);
-						delete u->monthorders;
-						u->monthorders = nullptr;
-					}
-				}
-			}
-		}
-	}
+    for (const auto r : regions) {
+        for (const auto obj : r->objects) {
+            for (const auto u : obj->units) {
+                if (u->monthorders) {
+                    if (u->monthorders->type == O_TEACH) {
+                        Do1TeachOrder(r, u);
+                        delete u->monthorders;
+                        u->monthorders = nullptr;
+                    }
+                }
+            }
+        }
+    }
 }
 
 void Game::Do1TeachOrder(ARegion *reg, Unit *unit)
 {
-	/* First pass, find how many to teach */
-	if (Globals->LEADERS_EXIST && !unit->IsLeader()) {
-		/* small change to handle Ceran's mercs */
-		if (!unit->GetMen(I_MERC)) {
-			// Mercs can teach even though they are not leaders.
-			// They cannot however improve their own skills
-			unit->error("TEACH: Only leaders can teach.");
-			return;
-		}
-	}
+    /* First pass, find how many to teach */
+    if (Globals->LEADERS_EXIST && !unit->IsLeader()) {
+        /* small change to handle Ceran's mercs */
+        if (!unit->GetMen(I_MERC)) {
+            // Mercs can teach even though they are not leaders.
+            // They cannot however improve their own skills
+            unit->error("TEACH: Only leaders can teach.");
+            return;
+        }
+    }
 
-	int students = 0;
-	TeachOrder *order = dynamic_cast<TeachOrder *>(unit->monthorders);
-	reg->deduplicate_unit_list(order->targets, unit->faction->num);
-	for(auto it = order->targets.begin(); it != order->targets.end();) {
-		UnitId *id = *it;
-		Unit *target = reg->GetUnitId(id, unit->faction->num);
-		if (!target) {
-			unit->error("TEACH: No such unit.");
-			it = order->targets.erase(it);
-			delete id;
-			continue;
-		}
-		if (target->faction->get_attitude(unit->faction->num) < A_FRIENDLY) {
-			unit->error(string("TEACH: ") + target->name->const_str() + " is not a member of a friendly faction.");
-			it = order->targets.erase(it);
-			delete id;
-			continue;
-		}
-		if (!target->monthorders || target->monthorders->type != O_STUDY) {
-			unit->error(string("TEACH: ") + target->name->const_str() + " is not studying.");
-			it = order->targets.erase(it);
-			delete id;
-			continue;
-		}
+    int students = 0;
+    TeachOrder *order = dynamic_cast<TeachOrder *>(unit->monthorders);
+    reg->deduplicate_unit_list(order->targets, unit->faction->num);
+    for (auto it = order->targets.begin(); it != order->targets.end();) {
+        UnitId *id = *it;
+        Unit *target = reg->GetUnitId(id, unit->faction->num);
+        if (!target) {
+            unit->error("TEACH: No such unit.");
+            it = order->targets.erase(it);
+            delete id;
+            continue;
+        }
+        if (target->faction->get_attitude(unit->faction->num) < A_FRIENDLY) {
+            unit->error(string("TEACH: ") + target->name->const_str() + " is not a member of a friendly faction.");
+            it = order->targets.erase(it);
+            delete id;
+            continue;
+        }
+        if (!target->monthorders || target->monthorders->type != O_STUDY) {
+            unit->error(string("TEACH: ") + target->name->const_str() + " is not studying.");
+            it = order->targets.erase(it);
+            delete id;
+            continue;
+        }
 
-		StudyOrder *so = dynamic_cast<StudyOrder *>(target->monthorders);
-		int sk = so->skill;
-		if (unit->GetRealSkill(sk) <= target->GetRealSkill(sk)) {
-			unit->error(string("TEACH: ") + target->name->const_str() + " is not studying a skill you can teach.");
-			it = order->targets.erase(it);
-			delete id;
-			continue;
-		}
-		// Check whether it's a valid skill to teach
-		if (SkillDefs[sk].flags & SkillType::NOTEACH) {
-			unit->error(string("TEACH: ") + SkillDefs[sk].name + " cannot be taught.");
-			it = order->targets.erase(it);
-			delete id;
-			continue;
-		}
-		students += target->GetMen();
-		++it;
-	}
+        StudyOrder *so = dynamic_cast<StudyOrder *>(target->monthorders);
+        int sk = so->skill;
+        if (unit->GetRealSkill(sk) <= target->GetRealSkill(sk)) {
+            unit->error(string("TEACH: ") + target->name->const_str() + " is not studying a skill you can teach.");
+            it = order->targets.erase(it);
+            delete id;
+            continue;
+        }
+        // Check whether it's a valid skill to teach
+        if (SkillDefs[sk].flags & SkillType::NOTEACH) {
+            unit->error(string("TEACH: ") + SkillDefs[sk].name + " cannot be taught.");
+            it = order->targets.erase(it);
+            delete id;
+            continue;
+        }
+        students += target->GetMen();
+        ++it;
+    }
 
-	if (!students) return;
+    if (!students) return;
 
-	int days = (30 * unit->GetMen() * Globals->STUDENTS_PER_TEACHER);
+    int days = (30 * unit->GetMen() * Globals->STUDENTS_PER_TEACHER);
 
-	/* We now have a list of valid targets */
-	for(const auto id : order->targets) {
-		Unit * u = reg->GetUnitId(id, unit->faction->num);
+    /* We now have a list of valid targets */
+    for (const auto id : order->targets) {
+        Unit *u = reg->GetUnitId(id, unit->faction->num);
 
-		int umen = u->GetMen();
-		int tempdays = (umen * days) / students;
-		if (tempdays > 30 * umen) tempdays = 30 * umen;
-		days -= tempdays;
-		students -= umen;
+        int umen = u->GetMen();
+        int tempdays = (umen * days) / students;
+        if (tempdays > 30 * umen) tempdays = 30 * umen;
+        days -= tempdays;
+        students -= umen;
 
-		StudyOrder *o = dynamic_cast<StudyOrder *>(u->monthorders);
-		o->days += tempdays;
-		if (o->days > 30 * umen) {
-			days += o->days - 30 * umen;
-			o->days = 30 * umen;
-		}
-		unit->event("Teaches " + SkillDefs[o->skill].name +	" to " + u->name->const_str() + ".", "teach");
-		// The TEACHER may learn something in this process!
-		unit->Practice(o->skill);
-	}
-	std::for_each (order->targets.begin(), order->targets.end(), [](UnitId *id) { delete id; });
-	order->targets.clear();
+        StudyOrder *o = dynamic_cast<StudyOrder *>(u->monthorders);
+        o->days += tempdays;
+        if (o->days > 30 * umen) {
+            days += o->days - 30 * umen;
+            o->days = 30 * umen;
+        }
+        unit->event("Teaches " + SkillDefs[o->skill].name + " to " + u->name->const_str() + ".", "teach");
+        // The TEACHER may learn something in this process!
+        unit->Practice(o->skill);
+    }
+    std::for_each(order->targets.begin(), order->targets.end(), [](UnitId *id) { delete id; });
+    order->targets.clear();
 }
 
 void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
 {
-	Object *buildobj;
-	int questcomplete = 0;
-	string quest_rewards;
+    Object *buildobj;
+    int questcomplete = 0;
+    string quest_rewards;
 
-	if (!Globals->BUILD_NO_TRADE && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
-		u->error("BUILD: Faction can't produce in that many regions.");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    if (!Globals->BUILD_NO_TRADE && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
+        u->error("BUILD: Faction can't produce in that many regions.");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	buildobj = r->GetObject(u->build);
-	// plain "BUILD" order needs to check that the unit is in something
-	// that can be built AFTER enter/leave orders have executed
-	if (!buildobj || buildobj->type == O_DUMMY) {
-		buildobj = obj;
-	}
-	if (!buildobj || buildobj->type == O_DUMMY) {
-		u->error("BUILD: Nothing to build.");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
-	int type = buildobj->type;
-	AString skname = ObjectDefs[type].skill;
-	int sk = LookupSkill(&skname);
-	if (sk == -1) {
-		u->error("BUILD: Can't build " + string(ObjectDefs[type].name) + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    buildobj = r->GetObject(u->build);
+    // plain "BUILD" order needs to check that the unit is in something
+    // that can be built AFTER enter/leave orders have executed
+    if (!buildobj || buildobj->type == O_DUMMY) buildobj = obj;
 
-	int usk = u->GetSkill(sk);
-	if (usk < ObjectDefs[type].level) {
-		u->error("BUILD: Can't build " + string(ObjectDefs[type].name) + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    if (!buildobj || buildobj->type == O_DUMMY) {
+        u->error("BUILD: Nothing to build.");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
+    int type = buildobj->type;
+    AString skname = ObjectDefs[type].skill;
+    int sk = LookupSkill(&skname);
+    if (sk == -1) {
+        u->error("BUILD: Can't build " + string(ObjectDefs[type].name) + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	int needed = buildobj->incomplete;
-	// AS
-	if (((ObjectDefs[type].flags & ObjectType::NEVERDECAY) || !Globals->DECAY) && needed < 1) {
-		u->error("BUILD: " + string(ObjectDefs[type].name) + " is finished.");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    int usk = u->GetSkill(sk);
+    if (usk < ObjectDefs[type].level) {
+        u->error("BUILD: Can't build " + string(ObjectDefs[type].name) + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	// AS
-	if (needed <= -(ObjectDefs[type].maxMaintenance)) {
-		u->error("BUILD: " + string(ObjectDefs[type].name) + " does not yet require maintenance.");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    int needed = buildobj->incomplete;
+    // AS
+    if (((ObjectDefs[type].flags & ObjectType::NEVERDECAY) || !Globals->DECAY) && needed < 1) {
+        u->error("BUILD: " + string(ObjectDefs[type].name) + " is finished.");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	int it = ObjectDefs[type].item;
-	int itn;
-	if (it == I_WOOD_OR_STONE) {
-		itn = u->GetSharedNum(I_WOOD) + u->GetSharedNum(I_STONE);
-	} else {
-		itn = u->GetSharedNum(it);
-	}
+    // AS
+    if (needed <= -(ObjectDefs[type].maxMaintenance)) {
+        u->error("BUILD: " + string(ObjectDefs[type].name) + " does not yet require maintenance.");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	if (itn == 0) {
-		u->error("BUILD: Don't have the required materials to build " + string(ObjectDefs[type].name) + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    int it = ObjectDefs[type].item;
+    int itn;
+    if (it == I_WOOD_OR_STONE) {
+        itn = u->GetSharedNum(I_WOOD) + u->GetSharedNum(I_STONE);
+    } else {
+        itn = u->GetSharedNum(it);
+    }
 
-	int num = u->GetMen() * usk;
+    if (itn == 0) {
+        u->error("BUILD: Don't have the required materials to build " + string(ObjectDefs[type].name) + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	// AS
-	string job;
-	if (needed < 1) {
-		// This looks wrong, but isn't.
-		// If a building has a maxMaintenance of 75 and the road is at
-		// -70 (ie, 5 from max) then we want the value of maintMax to be
-		// 5 here.  Then we divide by maintFactor (some things are easier
-		// to refix than others) to get how many items we need to fix it.
-		// Then we fix it by that many items * maintFactor
-		int maintMax = ObjectDefs[type].maxMaintenance + needed;
-		maintMax /= ObjectDefs[type].maintFactor;
-		if (num > maintMax) num = maintMax;
-		if (itn < num) num = itn;
-		job = "Performs maintenance on ";
-		buildobj->incomplete -= (num * ObjectDefs[type].maintFactor);
-		if (buildobj->incomplete < -(ObjectDefs[type].maxMaintenance))
-			buildobj->incomplete = -(ObjectDefs[type].maxMaintenance);
-	} else if (needed > 0) {
-		if (num > needed) num = needed;
-		if (itn < num) num = itn;
-		job = "Performs construction on ";
-		buildobj->incomplete -= num;
-		if (buildobj->incomplete == 0) {
-			job = "Completes construction of ";
-			buildobj->incomplete = -(ObjectDefs[type].maxMaintenance);
-			if (quests.check_build_target(r, type, u, &quest_rewards)) {
-				questcomplete = 1;
-			}
-		}
-	}
+    int num = u->GetMen() * usk;
 
-	/* Perform the build */
+    // AS
+    string job;
+    if (needed < 1) {
+        // This looks wrong, but isn't.
+        // If a building has a maxMaintenance of 75 and the road is at
+        // -70 (ie, 5 from max) then we want the value of maintMax to be
+        // 5 here.  Then we divide by maintFactor (some things are easier
+        // to refix than others) to get how many items we need to fix it.
+        // Then we fix it by that many items * maintFactor
+        int maintMax = ObjectDefs[type].maxMaintenance + needed;
+        maintMax /= ObjectDefs[type].maintFactor;
+        if (num > maintMax) num = maintMax;
+        if (itn < num) num = itn;
+        job = "Performs maintenance on ";
+        buildobj->incomplete -= (num * ObjectDefs[type].maintFactor);
+        if (buildobj->incomplete < -(ObjectDefs[type].maxMaintenance))
+            buildobj->incomplete = -(ObjectDefs[type].maxMaintenance);
+    } else if (needed > 0) {
+        if (num > needed) num = needed;
+        if (itn < num) num = itn;
+        job = "Performs construction on ";
+        buildobj->incomplete -= num;
+        if (buildobj->incomplete == 0) {
+            job = "Completes construction of ";
+            buildobj->incomplete = -(ObjectDefs[type].maxMaintenance);
+            if (quests.check_build_target(r, type, u, &quest_rewards)) { questcomplete = 1; }
+        }
+    }
 
-	if (obj != buildobj)
-		u->MoveUnit(buildobj);
+    /* Perform the build */
 
-	if (it == I_WOOD_OR_STONE) {
-		if (num > u->GetSharedNum(I_STONE)) {
-			num -= u->GetSharedNum(I_STONE);
-			u->ConsumeShared(I_STONE, u->GetSharedNum(I_STONE));
-			u->ConsumeShared(I_WOOD, num);
-		} else {
-			u->ConsumeShared(I_STONE, num);
-		}
-	} else {
-		u->ConsumeShared(it, num);
-	}
+    if (obj != buildobj) u->MoveUnit(buildobj);
 
-	/* Regional economic improvement */
-	r->improvement += num;
+    if (it == I_WOOD_OR_STONE) {
+        if (num > u->GetSharedNum(I_STONE)) {
+            num -= u->GetSharedNum(I_STONE);
+            u->ConsumeShared(I_STONE, u->GetSharedNum(I_STONE));
+            u->ConsumeShared(I_WOOD, num);
+        } else {
+            u->ConsumeShared(I_STONE, num);
+        }
+    } else {
+        u->ConsumeShared(it, num);
+    }
 
-	// AS
-	u->event(job + buildobj->name->const_str(), "build");
-	if (questcomplete) {
-		u->event("You have completed a quest! " + quest_rewards, "quest");
-	}
-	u->Practice(sk);
+    /* Regional economic improvement */
+    r->improvement += num;
 
-	delete u->monthorders;
-	u->monthorders = nullptr;
+    // AS
+    u->event(job + buildobj->name->const_str(), "build");
+    if (questcomplete) { u->event("You have completed a quest! " + quest_rewards, "quest"); }
+    u->Practice(sk);
 }
 
 /* Alternate processing for building item-type ship
  * objects and instantiating fleets.
  */
-void Game::RunBuildShipOrder(ARegion * r,Object * obj,Unit * u)
+void Game::RunBuildShipOrder(ARegion *r, Object *obj, Unit *u)
 {
-	int ship, skill, level, maxbuild, unfinished, output, percent;
-	AString skname;
+    int ship, skill, level, maxbuild, unfinished, output, percent;
+    AString skname;
 
-	ship = abs(u->build);
-	skname = ItemDefs[ship].pSkill;
-	skill = LookupSkill(&skname);
-	level = u->GetSkill(skill);
+    ship = abs(u->build);
+    skname = ItemDefs[ship].pSkill;
+    skill = LookupSkill(&skname);
+    level = u->GetSkill(skill);
 
-	if (skill == -1) {
-		u->error("BUILD: Can't build " + string(ItemDefs[ship].name) + ".");
-		return;
-	}
+    if (skill == -1) {
+        u->error("BUILD: Can't build " + string(ItemDefs[ship].name) + ".");
+        return;
+    }
 
-	// get needed to complete
-	maxbuild = 0;
-	if ((u->monthorders) && (u->monthorders->type == O_BUILD)) {
-		BuildOrder *b = dynamic_cast<BuildOrder *>(u->monthorders);
-		maxbuild = b->needtocomplete;
-	}
-	if (maxbuild < 1) {
-		// Our helpers have already finished the hard work, so
-		// just put the finishing touches on the new vessel
-		unfinished = 0;
-	} else {
-		output = ShipConstruction(r, u, u, level, maxbuild, ship);
+    // get needed to complete
+    maxbuild = 0;
+    if ((u->monthorders) && (u->monthorders->type == O_BUILD)) {
+        BuildOrder *b = dynamic_cast<BuildOrder *>(u->monthorders);
+        maxbuild = b->needtocomplete;
+    }
+    if (maxbuild < 1) {
+        // Our helpers have already finished the hard work, so
+        // just put the finishing touches on the new vessel
+        unfinished = 0;
+    } else {
+        output = ShipConstruction(r, u, u, level, maxbuild, ship);
 
-		if (output < 1) return;
+        if (output < 1) return;
 
-		// are there unfinished ship items of the given type?
-		unfinished = u->items.GetNum(ship);
+        // are there unfinished ship items of the given type?
+        unfinished = u->items.GetNum(ship);
 
-		if (unfinished == 0) {
-			// Start a new ship's construction from scratch
-			unfinished = ItemDefs[ship].pMonths;
-			u->items.SetNum(ship, unfinished);
-		}
+        if (unfinished == 0) {
+            // Start a new ship's construction from scratch
+            unfinished = ItemDefs[ship].pMonths;
+            u->items.SetNum(ship, unfinished);
+        }
 
-		// Now reduce unfinished by produced amount
-		unfinished -= output;
-		if (unfinished < 0) unfinished = 0;
-	}
-	u->items.SetNum(ship, unfinished);
+        // Now reduce unfinished by produced amount
+        unfinished -= output;
+        if (unfinished < 0) unfinished = 0;
+    }
+    u->items.SetNum(ship, unfinished);
 
-	// practice
-	u->Practice(skill);
+    // practice
+    u->Practice(skill);
 
-	if (unfinished == 0) {
-		u->event("Finishes building a " + ItemDefs[ship].name + " in " +
-			r->ShortPrint().const_str() + ".", "build");
-		CreateShip(r, u, ship);
-	} else {
-		percent = 100 * output / ItemDefs[ship].pMonths;
-		u->event("Performs construction work on a " + ItemDefs[ship].name + " (" + to_string(percent) +
-			"%) in " +	r->ShortPrint().const_str() + ".", "build", r);
-	}
-
-	delete u->monthorders;
-	u->monthorders = nullptr;
+    if (unfinished == 0) {
+        u->event("Finishes building a " + ItemDefs[ship].name + " in " + r->ShortPrint().const_str() + ".", "build");
+        CreateShip(r, u, ship);
+    } else {
+        percent = 100 * output / ItemDefs[ship].pMonths;
+        u->event(
+            "Performs construction work on a " + ItemDefs[ship].name + " (" + to_string(percent) + "%) in " +
+                r->ShortPrint().const_str() + ".",
+            "build", r
+        );
+    }
 }
 
 void Game::AddNewBuildings(ARegion *r)
 {
-	int i;
-	for(const auto obj : r->objects) {
-		for(const auto u : obj->units) {
-			if (u->monthorders && u->monthorders->type == O_BUILD) {
-				BuildOrder *o = dynamic_cast<BuildOrder *>(u->monthorders);
+    int i;
+    for (const auto obj : r->objects) {
+        for (const auto u : obj->units) {
+            if (u->monthorders && u->monthorders->type == O_BUILD) {
+                BuildOrder *o = dynamic_cast<BuildOrder *>(u->monthorders);
 
-				// If BUILD order was marked for creating new building
-				// in parse phase, it is time to create one now.
-				if (o->new_building != -1) {
-					for (i = 1; i < 100; i++) {
-						if (!r->GetObject(i)) break;
-					}
-					if (i < 100) {
-						Object * obj = new Object(r);
-						obj->type = o->new_building;
-						obj->incomplete = ObjectDefs[obj->type].cost;
-						obj->num = i;
-						obj->SetName(new AString("Building"));
-						u->build = obj->num;
-						r->objects.push_back(obj);
+                // If BUILD order was marked for creating new building
+                // in parse phase, it is time to create one now.
+                if (o->new_building != -1) {
+                    if (o->new_building == u->object->type && u->object->incomplete > 0) {
+                        // we have a complete for the type of building we are in and it's not finished, so no new
+                        // building.
+                        u->build = u->object->num; // keep the current building as the build target
+                        break;
+                    }
 
-						// This moves unit to a new building.
-						// This unit might be processed again but from new object.
-						u->MoveUnit(obj);
-						// This why we need to unset new_building so it will not
-						// try to create new object again.
-						o->new_building = -1;
-					} else {
-						u->error("BUILD: The region is full.");
-					}
-				}
-			}
-		}
-	}
+                    for (i = 1; i < 100; i++) {
+                        if (!r->GetObject(i)) break;
+                    }
+                    if (i < 100) {
+                        Object *obj = new Object(r);
+                        obj->type = o->new_building;
+                        obj->incomplete = ObjectDefs[obj->type].cost;
+                        obj->num = i;
+                        obj->SetName(new AString("Building"));
+                        u->build = obj->num;
+                        r->objects.push_back(obj);
+
+                        // This moves unit to a new building.
+                        // This unit might be processed again but from new object.
+                        u->MoveUnit(obj);
+                        // This why we need to unset new_building so it will not
+                        // try to create new object again.
+                        o->new_building = -1;
+                    } else {
+                        u->error("BUILD: The region is full.");
+                    }
+                }
+            }
+        }
+    }
 }
 
 void Game::RunBuildHelpers(ARegion *r)
 {
-	for(const auto obj : r->objects) {
-		for(const auto u : obj->units) {
-			if (u->monthorders && u->monthorders->type == O_BUILD) {
-				BuildOrder *o = dynamic_cast<BuildOrder *>(u->monthorders);
-				Object *tarobj = NULL;
-				if (o->target) {
-					Unit *target = r->GetUnitId(o->target,u->faction->num);
-					if (!target) {
-						u->error("BUILD: No such unit to help.");
-						delete u->monthorders;
-						u->monthorders = nullptr;
-						continue;
-					}
-					// Make sure that unit is building
-					if (!target->monthorders || target->monthorders->type != O_BUILD) {
-						u->error("BUILD: Unit isn't building.");
-						delete u->monthorders;
-						u->monthorders = nullptr;
-						continue;
-					}
-					// Make sure that unit considers you friendly!
-					if (target->faction->get_attitude(u->faction->num) < A_FRIENDLY) {
-						u->error("BUILD: Unit you are helping rejects your help.");
-						delete u->monthorders;
-						u->monthorders = nullptr;
-						continue;
-					}
-					if (target->build == 0) {
-						// Help with whatever building the target is in
-						tarobj = target->object;
-						u->build = tarobj->num;
-					} else if (target->build > 0) {
-						u->build = target->build;
-						tarobj = r->GetObject(target->build);
-					} else {
-						// help build ships
-						int ship = abs(target->build);
-						AString skname = ItemDefs[ship].pSkill;
-						int skill = LookupSkill(&skname);
-						int level = u->GetSkill(skill);
-						int needed = 0;
-						if (target->monthorders && (target->monthorders->type == O_BUILD)) {
-							BuildOrder *border = dynamic_cast<BuildOrder *>(target->monthorders);
-							needed = border->needtocomplete;
-						}
-						if (needed < 1) {
-							u->error("BUILD: Construction is already complete.");
-							delete u->monthorders;
-							u->monthorders = nullptr;
-							continue;
-						}
-						int output = ShipConstruction(r, u, target, level, needed, ship);
-						if (output < 1) continue;
+    for (const auto obj : r->objects) {
+        for (const auto u : obj->units) {
+            if (u->monthorders && u->monthorders->type == O_BUILD) {
+                BuildOrder *o = dynamic_cast<BuildOrder *>(u->monthorders);
+                Object *tarobj = NULL;
+                if (o->target) {
+                    Unit *target = r->GetUnitId(o->target, u->faction->num);
+                    if (!target) {
+                        u->error("BUILD: No such unit to help.");
+                        delete u->monthorders;
+                        u->monthorders = nullptr;
+                        continue;
+                    }
+                    // Make sure that unit is building
+                    if (!target->monthorders || target->monthorders->type != O_BUILD) {
+                        u->error("BUILD: Unit isn't building.");
+                        delete u->monthorders;
+                        u->monthorders = nullptr;
+                        continue;
+                    }
+                    // Make sure that unit considers you friendly!
+                    if (target->faction->get_attitude(u->faction->num) < A_FRIENDLY) {
+                        u->error("BUILD: Unit you are helping rejects your help.");
+                        delete u->monthorders;
+                        u->monthorders = nullptr;
+                        continue;
+                    }
+                    if (target->build == 0) {
+                        // Help with whatever building the target is in
+                        tarobj = target->object;
+                        u->build = tarobj->num;
+                    } else if (target->build > 0) {
+                        u->build = target->build;
+                        tarobj = r->GetObject(target->build);
+                    } else {
+                        // help build ships
+                        int ship = abs(target->build);
+                        AString skname = ItemDefs[ship].pSkill;
+                        int skill = LookupSkill(&skname);
+                        int level = u->GetSkill(skill);
+                        int needed = 0;
+                        if (target->monthorders && (target->monthorders->type == O_BUILD)) {
+                            BuildOrder *border = dynamic_cast<BuildOrder *>(target->monthorders);
+                            needed = border->needtocomplete;
+                        }
+                        if (needed < 1) {
+                            u->error("BUILD: Construction is already complete.");
+                            delete u->monthorders;
+                            u->monthorders = nullptr;
+                            continue;
+                        }
+                        int output = ShipConstruction(r, u, target, level, needed, ship);
+                        if (output < 1) continue;
 
-						int unfinished = target->items.GetNum(ship);
-						if (unfinished == 0) {
-							// Start construction on a new ship
-							unfinished = ItemDefs[ship].pMonths;
-							target->items.SetNum(ship, unfinished);
-						}
-						unfinished -= output;
+                        int unfinished = target->items.GetNum(ship);
+                        if (unfinished == 0) {
+                            // Start construction on a new ship
+                            unfinished = ItemDefs[ship].pMonths;
+                            target->items.SetNum(ship, unfinished);
+                        }
+                        unfinished -= output;
 
-						// practice
-						u->Practice(skill);
+                        // practice
+                        u->Practice(skill);
 
-						if (unfinished > 0) {
-							target->items.SetNum(ship, unfinished);
-							if (target->monthorders && (target->monthorders->type == O_BUILD)) {
-								BuildOrder *border = dynamic_cast<BuildOrder *>(target->monthorders);
-								border->needtocomplete = unfinished;
-							}
-						} else {
-							// CreateShip(r, target, ship);
-							// don't create the ship yet; leave that for the unit we're helping
-							target->items.SetNum(ship, 1);
-							if (target->monthorders && (target->monthorders->type == O_BUILD)) {
-								BuildOrder *border = dynamic_cast<BuildOrder *>(target->monthorders);
-								border->needtocomplete = 0;
-							}
-						}
-						int percent = 100 * output / ItemDefs[ship].pMonths;
-						u->event("Helps " + string(target->name->const_str()) + " with construction of a " +
-							ItemDefs[ship].name + " (" + to_string(percent) + "%) in " +
-							r->ShortPrint().const_str() + ".", "build", r);
-					}
-					// no need to move unit if item-type ships
-					// are being built. (leave this commented out)
-					// if (tarobj == NULL) tarobj = target->object;
-					if ((tarobj != NULL) && (u->object != tarobj))
-						u->MoveUnit(tarobj);
-				} else {
-					Object *buildobj;
-					if (u->build > 0) {
-						buildobj = r->GetObject(u->build);
-						if (buildobj && buildobj != r->GetDummy() && buildobj != u->object) {
-							u->MoveUnit(buildobj);
-						}
-					}
-				}
-			}
-		}
-	}
+                        if (unfinished > 0) {
+                            target->items.SetNum(ship, unfinished);
+                            if (target->monthorders && (target->monthorders->type == O_BUILD)) {
+                                BuildOrder *border = dynamic_cast<BuildOrder *>(target->monthorders);
+                                border->needtocomplete = unfinished;
+                            }
+                        } else {
+                            // CreateShip(r, target, ship);
+                            // don't create the ship yet; leave that for the unit we're helping
+                            target->items.SetNum(ship, 1);
+                            if (target->monthorders && (target->monthorders->type == O_BUILD)) {
+                                BuildOrder *border = dynamic_cast<BuildOrder *>(target->monthorders);
+                                border->needtocomplete = 0;
+                            }
+                        }
+                        int percent = 100 * output / ItemDefs[ship].pMonths;
+                        u->event(
+                            "Helps " + string(target->name->const_str()) + " with construction of a " +
+                                ItemDefs[ship].name + " (" + to_string(percent) + "%) in " +
+                                r->ShortPrint().const_str() + ".",
+                            "build", r
+                        );
+                    }
+                    // no need to move unit if item-type ships
+                    // are being built. (leave this commented out)
+                    // if (tarobj == NULL) tarobj = target->object;
+                    if ((tarobj != NULL) && (u->object != tarobj)) u->MoveUnit(tarobj);
+                } else {
+                    Object *buildobj;
+                    if (u->build > 0) {
+                        buildobj = r->GetObject(u->build);
+                        if (buildobj && buildobj != r->GetDummy() && buildobj != u->object) { u->MoveUnit(buildobj); }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /* Creates a new ship - either by adding it to a
@@ -834,30 +812,30 @@ void Game::RunBuildHelpers(ARegion *r)
  * object with Unit u as owner consisting of exactly
  * ONE ship of the given type.
  */
-void Game::CreateShip(ARegion *r, Unit * u, int ship)
+void Game::CreateShip(ARegion *r, Unit *u, int ship)
 {
-	Object * obj = u->object;
-	// Do we need to create a new fleet?
-	int newfleet = 1;
-	if (u->object->IsFleet()) {
-		newfleet = 0;
-		int flying = obj->flying;
-		// are the fleets compatible?
-		if ((flying > 0) && (ItemDefs[ship].fly < 1)) newfleet = 1;
-		if ((flying < 1) && (ItemDefs[ship].fly > 0)) newfleet = 1;
-	}
-	if (newfleet != 0) {
-		// create a new fleet
-		Object * fleet = new Object(r);
-		fleet->type = O_FLEET;
-		fleet->num = shipseq++;
-		fleet->name = new AString(AString("Ship [") + fleet->num + "]");
-		fleet->AddShip(ship);
-		u->object->region->objects.push_back(fleet);
-		u->MoveUnit(fleet);
-	} else {
-		obj->AddShip(ship);
-	}
+    Object *obj = u->object;
+    // Do we need to create a new fleet?
+    int newfleet = 1;
+    if (u->object->IsFleet()) {
+        newfleet = 0;
+        int flying = obj->flying;
+        // are the fleets compatible?
+        if ((flying > 0) && (ItemDefs[ship].fly < 1)) newfleet = 1;
+        if ((flying < 1) && (ItemDefs[ship].fly > 0)) newfleet = 1;
+    }
+    if (newfleet != 0) {
+        // create a new fleet
+        Object *fleet = new Object(r);
+        fleet->type = O_FLEET;
+        fleet->num = shipseq++;
+        fleet->name = new AString(AString("Ship [") + fleet->num + "]");
+        fleet->AddShip(ship);
+        u->object->region->objects.push_back(fleet);
+        u->MoveUnit(fleet);
+    } else {
+        obj->AddShip(ship);
+    }
 }
 
 // This is a utility function used by both ship building and unit production to correctly consume
@@ -866,85 +844,81 @@ void Game::CreateShip(ARegion *r, Unit * u, int ship)
 // Returns the number of items created.
 int Game::consume_production_inputs(Unit *u, int item, int maxproduced)
 {
-	unsigned int maxInputs = sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]);
+    unsigned int maxInputs = sizeof(ItemDefs->pInput) / sizeof(ItemDefs->pInput[0]);
 
-	if (ItemDefs[item].flags & ItemType::ORINPUTS) {
-		// Figure out the max we can produce based on the inputs
-		int count = 0;
-		unsigned int c;
-		for (c = 0; c < sizeof(ItemDefs->pInput)/sizeof(ItemDefs->pInput[0]); c++) {
-			int i = ItemDefs[item].pInput[c].item;
-			if (i != -1)
-				count += u->GetSharedNum(i) / ItemDefs[item].pInput[c].amt;
-		}
-		if (maxproduced > count) maxproduced = count;
-		count = maxproduced;
+    if (ItemDefs[item].flags & ItemType::ORINPUTS) {
+        // Figure out the max we can produce based on the inputs
+        int count = 0;
+        unsigned int c;
+        for (c = 0; c < sizeof(ItemDefs->pInput) / sizeof(ItemDefs->pInput[0]); c++) {
+            int i = ItemDefs[item].pInput[c].item;
+            if (i != -1) count += u->GetSharedNum(i) / ItemDefs[item].pInput[c].amt;
+        }
+        if (maxproduced > count) maxproduced = count;
+        count = maxproduced;
 
-		if (count < 1) return 0;
+        if (count < 1) return 0;
 
-		// Now consume the items from the unit itself first if possible.
-		for (c = 0; c < maxInputs; c++) {
-			int i = ItemDefs[item].pInput[c].item;
-			int a = ItemDefs[item].pInput[c].amt;
-			if (i != -1) {
-				// Consume from the unit's own items first
-				int amt = u->items.GetNum(i);
-				if (count > amt / a) {
-					count -= amt / a;
-					u->items.SetNum(i, amt - ((amt / a) * a));
-				} else {
-					u->items.SetNum(i, amt - (count * a));
-					count = 0;
-				}
-			}
-		}
+        // Now consume the items from the unit itself first if possible.
+        for (c = 0; c < maxInputs; c++) {
+            int i = ItemDefs[item].pInput[c].item;
+            int a = ItemDefs[item].pInput[c].amt;
+            if (i != -1) {
+                // Consume from the unit's own items first
+                int amt = u->items.GetNum(i);
+                if (count > amt / a) {
+                    count -= amt / a;
+                    u->items.SetNum(i, amt - ((amt / a) * a));
+                } else {
+                    u->items.SetNum(i, amt - (count * a));
+                    count = 0;
+                }
+            }
+        }
 
-		// If we paid for everything, return now.
-		if (count == 0) return maxproduced;
+        // If we paid for everything, return now.
+        if (count == 0) return maxproduced;
 
-		// Deduct the items spent
-		for (c = 0; c < maxInputs; c++) {
-			int i = ItemDefs[item].pInput[c].item;
-			int a = ItemDefs[item].pInput[c].amt;
-			if (i != -1) {
-				int amt = u->GetSharedNum(i);
-				if (count > amt / a) {
-					count -= amt / a;
-					u->ConsumeShared(i, (amt / a) * a);
-				} else {
-					u->ConsumeShared(i, count * a);
-					count = 0;
-				}
-			}
-		}
-	} else {
-		// Figure out the max we can produce based on the inputs
-		unsigned int c;
-		for (c = 0; c < maxInputs; c++) {
-			int i = ItemDefs[item].pInput[c].item;
-			if (i != -1) {
-				int amt = u->GetSharedNum(i);
-				if ((amt / ItemDefs[item].pInput[c].amt) < maxproduced) {
-					maxproduced = amt / ItemDefs[item].pInput[c].amt;
-				}
-			}
-		}
+        // Deduct the items spent
+        for (c = 0; c < maxInputs; c++) {
+            int i = ItemDefs[item].pInput[c].item;
+            int a = ItemDefs[item].pInput[c].amt;
+            if (i != -1) {
+                int amt = u->GetSharedNum(i);
+                if (count > amt / a) {
+                    count -= amt / a;
+                    u->ConsumeShared(i, (amt / a) * a);
+                } else {
+                    u->ConsumeShared(i, count * a);
+                    count = 0;
+                }
+            }
+        }
+    } else {
+        // Figure out the max we can produce based on the inputs
+        unsigned int c;
+        for (c = 0; c < maxInputs; c++) {
+            int i = ItemDefs[item].pInput[c].item;
+            if (i != -1) {
+                int amt = u->GetSharedNum(i);
+                if ((amt / ItemDefs[item].pInput[c].amt) < maxproduced) {
+                    maxproduced = amt / ItemDefs[item].pInput[c].amt;
+                }
+            }
+        }
 
-		// If we can't produce anything, return 0
-		if (maxproduced < 1) return 0;
+        // If we can't produce anything, return 0
+        if (maxproduced < 1) return 0;
 
-		// Deduct the items spent
-		for (c = 0; c < maxInputs; c++) {
-			int i = ItemDefs[item].pInput[c].item;
-			int a = ItemDefs[item].pInput[c].amt;
-			if (i != -1) {
-				u->ConsumeShared(i, maxproduced * a);
-			}
-		}
-	}
-	return maxproduced;
+        // Deduct the items spent
+        for (c = 0; c < maxInputs; c++) {
+            int i = ItemDefs[item].pInput[c].item;
+            int a = ItemDefs[item].pInput[c].amt;
+            if (i != -1) { u->ConsumeShared(i, maxproduced * a); }
+        }
+    }
+    return maxproduced;
 }
-
 
 /* Checks and returns the amount of ship construction,
  * handles material use and practice for both the main
@@ -952,882 +926,904 @@ int Game::consume_production_inputs(Unit *u, int item, int maxproduced)
  */
 int Game::ShipConstruction(ARegion *r, Unit *u, Unit *target, int level, int needed, int ship)
 {
-	if (!Globals->BUILD_NO_TRADE && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
-		u->error("BUILD: Faction can't produce in that many regions.");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return 0;
-	}
+    if (!Globals->BUILD_NO_TRADE && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
+        u->error("BUILD: Faction can't produce in that many regions.");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return 0;
+    }
 
-	if (level < ItemDefs[ship].pLevel) {
-		u->error("BUILD: Can't build " + ItemDefs[ship].name + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return 0;
-	}
+    if (level < ItemDefs[ship].pLevel) {
+        u->error("BUILD: Can't build " + ItemDefs[ship].name + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return 0;
+    }
 
-	// are there unfinished ship items of the given type?
-	int unfinished = target->items.GetNum(ship);
+    // are there unfinished ship items of the given type?
+    int unfinished = target->items.GetNum(ship);
 
-	int number = u->GetMen() * level + u->GetProductionBonus(ship);
+    int number = u->GetMen() * level + u->GetProductionBonus(ship);
 
-	// find the max we can possibly produce based on man-months of labor
-	int maxproduced = (ItemDefs[ship].flags & ItemType::SKILLOUT) ? u->GetMen() : number;
+    // find the max we can possibly produce based on man-months of labor
+    int maxproduced = (ItemDefs[ship].flags & ItemType::SKILLOUT) ? u->GetMen() : number;
 
-	// adjust maxproduced for items needed until completion
-	if (needed < maxproduced) maxproduced = needed;
+    // adjust maxproduced for items needed until completion
+    if (needed < maxproduced) maxproduced = needed;
 
-	// adjust maxproduced for unfinished ships
-	if ((unfinished > 0) && (maxproduced > unfinished))
-		maxproduced = unfinished;
+    // adjust maxproduced for unfinished ships
+    if ((unfinished > 0) && (maxproduced > unfinished)) maxproduced = unfinished;
 
-	maxproduced = consume_production_inputs(u, ship, maxproduced);
-	if (maxproduced < 1) {
-		// We don't have enough input items to produce anything
-		u->error("BUILD: Don't have the required materials to build " + ItemDefs[ship].name + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return 0;
-	}
-	r->improvement += maxproduced; // regional economic improvement
+    maxproduced = consume_production_inputs(u, ship, maxproduced);
+    if (maxproduced < 1) {
+        // We don't have enough input items to produce anything
+        u->error("BUILD: Don't have the required materials to build " + ItemDefs[ship].name + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return 0;
+    }
+    r->improvement += maxproduced; // regional economic improvement
 
-	int output = maxproduced * ItemDefs[ship].pOut;
-	if (ItemDefs[ship].flags & ItemType::SKILLOUT) output *= level;
+    int output = maxproduced * ItemDefs[ship].pOut;
+    if (ItemDefs[ship].flags & ItemType::SKILLOUT) output *= level;
 
-	delete u->monthorders;
-	u->monthorders = nullptr;
+    delete u->monthorders;
+    u->monthorders = nullptr;
 
-	return output;
+    return output;
 }
 
 void Game::RunMonthOrders()
 {
-	for(const auto r : regions) {
-		RunIdleOrders(r);
-		RunStudyOrders(r);
-		AddNewBuildings(r);
-		RunBuildHelpers(r);
-		RunProduceOrders(r);
-	}
+    for (const auto r : regions) {
+        RunIdleOrders(r);
+        RunStudyOrders(r);
+        AddNewBuildings(r);
+        RunBuildHelpers(r);
+        RunProduceOrders(r);
+    }
 }
 
 void Game::RunUnitProduce(ARegion *r, Unit *u)
 {
-	ProduceOrder *o = (ProduceOrder *) u->monthorders;
+    ProduceOrder *o = (ProduceOrder *)u->monthorders;
 
-	for (const auto& p : r->products) {
-		// PRODUCE orders for producing goods from the land
-		// are shared among factions, and therefore handled
-		// specially by the RunAProduction() function
-		if (o->skill == p->skill && o->item == p->itemtype)
-			return;
-	}
+    for (const auto& p : r->products) {
+        // PRODUCE orders for producing goods from the land
+        // are shared among factions, and therefore handled
+        // specially by the RunAProduction() function
+        if (o->skill == p->skill && o->item == p->itemtype) return;
+    }
 
-	if (o->item == I_SILVER) {
-		if (!o->quiet) u->error("Can't do that in this region.");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    if (o->item == I_SILVER) {
+        if (!o->quiet) u->error("Can't do that in this region.");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	if (o->item == -1 || ItemDefs[o->item].flags & ItemType::DISABLED) {
-		std::string name = (o->item == -1) ? "that" : ItemString(o->item, 1, ALWAYSPLURAL);
-		u->error("PRODUCE: Can't produce " + name + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    if (o->item == -1 || ItemDefs[o->item].flags & ItemType::DISABLED) {
+        std::string name = (o->item == -1) ? "that" : ItemString(o->item, 1, ALWAYSPLURAL);
+        u->error("PRODUCE: Can't produce " + name + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	int input = ItemDefs[o->item].pInput[0].item;
-	if (input == -1) {
-		u->error("PRODUCE: Can't produce " + ItemString(o->item, 1, ALWAYSPLURAL) + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    int input = ItemDefs[o->item].pInput[0].item;
+    if (input == -1) {
+        u->error("PRODUCE: Can't produce " + ItemString(o->item, 1, ALWAYSPLURAL) + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	int level = u->GetSkill(o->skill);
-	if (level < ItemDefs[o->item].pLevel) {
-		u->error("PRODUCE: Can't produce " + ItemString(o->item, 1, ALWAYSPLURAL) + ".");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    int level = u->GetSkill(o->skill);
+    if (level < ItemDefs[o->item].pLevel) {
+        u->error("PRODUCE: Can't produce " + ItemString(o->item, 1, ALWAYSPLURAL) + ".");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	// LLS
-	int number = u->GetMen() * level + u->GetProductionBonus(o->item);
+    // LLS
+    int number = u->GetMen() * level + u->GetProductionBonus(o->item);
 
-	if (!ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
-		u->error("PRODUCE: Faction can't produce in that many regions.");
-		delete u->monthorders;
-		u->monthorders = nullptr;
-		return;
-	}
+    if (!ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
+        u->error("PRODUCE: Faction can't produce in that many regions.");
+        delete u->monthorders;
+        u->monthorders = nullptr;
+        return;
+    }
 
-	// find the max we can possibly produce based on man-months of labor
-	int maxproduced;
-	if (ItemDefs[o->item].flags & ItemType::SKILLOUT)
-		maxproduced = u->GetMen();
-	else if (ItemDefs[o->item].flags & ItemType::SKILLOUT_HALF)
-		maxproduced = u->GetMen();
-	else
-		maxproduced = number/ItemDefs[o->item].pMonths;
+    // find the max we can possibly produce based on man-months of labor
+    int maxproduced;
+    if (ItemDefs[o->item].flags & ItemType::SKILLOUT)
+        maxproduced = u->GetMen();
+    else if (ItemDefs[o->item].flags & ItemType::SKILLOUT_HALF)
+        maxproduced = u->GetMen();
+    else
+        maxproduced = number / ItemDefs[o->item].pMonths;
 
-	if (o->target > 0 && maxproduced > o->target)
-		maxproduced = o->target;
+    if (o->target > 0 && maxproduced > o->target) maxproduced = o->target;
 
-	maxproduced = consume_production_inputs(u, o->item, maxproduced);
-	r->improvement += maxproduced; // regional economic improvement
+    maxproduced = consume_production_inputs(u, o->item, maxproduced);
+    r->improvement += maxproduced; // regional economic improvement
 
-	// Now give the items produced
-	int output = maxproduced * ItemDefs[o->item].pOut;
-	if (ItemDefs[o->item].flags & ItemType::SKILLOUT)
-		output *= level;
-	if (ItemDefs[o->item].flags & ItemType::SKILLOUT_HALF) {
-		output *= (level + 1) / 2;
-	}
+    // Now give the items produced
+    int output = maxproduced * ItemDefs[o->item].pOut;
+    if (ItemDefs[o->item].flags & ItemType::SKILLOUT) output *= level;
+    if (ItemDefs[o->item].flags & ItemType::SKILLOUT_HALF) { output *= (level + 1) / 2; }
 
-	u->items.SetNum(o->item,u->items.GetNum(o->item) + output);
-	u->event("Produces " + ItemString(o->item,output) + " in " + r->ShortPrint().const_str() + ".",
-		"produce", r);
-	u->Practice(o->skill);
-	o->target -= output;
-	if (o->target > 0) {
-		TurnOrder *tOrder = new TurnOrder;
-		tOrder->repeating = 0;
-		std::string order = "PRODUCE " + to_string(o->target) + " " + ItemDefs[o->item].abr;
-		tOrder->turnOrders.push_back(order);
-		u->turnorders.push_front(tOrder);
-	}
-	delete u->monthorders;
-	u->monthorders = nullptr;
+    u->items.SetNum(o->item, u->items.GetNum(o->item) + output);
+    u->event("Produces " + ItemString(o->item, output) + " in " + r->ShortPrint().const_str() + ".", "produce", r);
+    u->Practice(o->skill);
+    o->target -= output;
+    if (o->target > 0) {
+        TurnOrder *tOrder = new TurnOrder;
+        tOrder->repeating = 0;
+        std::string order = "PRODUCE " + to_string(o->target) + " " + ItemDefs[o->item].abr;
+        tOrder->turnOrders.push_back(order);
+        u->turnorders.push_front(tOrder);
+    }
+    delete u->monthorders;
+    u->monthorders = nullptr;
 }
 
-void Game::RunProduceOrders(ARegion * r)
+void Game::RunProduceOrders(ARegion *r)
 {
-	for(const auto obj : r->objects) {
-		for(const auto u :obj->units) {
-			if (u->monthorders) {
-				if (u->monthorders->type == O_PRODUCE) {
-					RunUnitProduce(r,u);
-				} else {
-					if (u->monthorders->type == O_BUILD) {
-						if (u->build >= 0) {
-							Run1BuildOrder(r, obj, u);
-						} else {
-							RunBuildShipOrder(r, obj, u);
-						}
-					}
-				}
-			}
-		}
-	}
-	for (const auto& p : r->products) RunAProduction(r, p);
+    for (const auto obj : r->objects) {
+        for (const auto u : obj->units) {
+            if (u->monthorders) {
+                if (u->monthorders->type == O_PRODUCE) {
+                    RunUnitProduce(r, u);
+                } else {
+                    if (u->monthorders->type == O_BUILD) {
+                        if (u->build >= 0) {
+                            Run1BuildOrder(r, obj, u);
+                        } else {
+                            RunBuildShipOrder(r, obj, u);
+                        }
+                    }
+                }
+            }
+        }
+        // Cleanup any build 'complete' orders where the object has been built or save them off for next month if not
+        for (const auto u : obj->units) {
+            if (u->monthorders && u->monthorders->type == O_BUILD) {
+                BuildOrder *o = dynamic_cast<BuildOrder *>(u->monthorders);
+                if (o->until_complete) {
+                    if ((u->build > 0 || o->target) && u->object->incomplete > 0) {
+                        string order = "BUILD ";
+                        if (o->target) {
+                            Unit *t = r->GetUnitId(o->target, u->faction->num);
+                            order += "HELP " + to_string(t->num);
+                        } else {
+                            string name = ObjectDefs[u->object->type].name;
+                            if (name.find(" ") != std::string::npos) {
+                                // If the name has spaces, we need to quote it
+                                order += "\"" + name + "\"";
+                            } else {
+                                order += name;
+                            }
+                        }
+                        order += " COMPLETE";
+                        u->oldorders.push_front(order);
+                    } else if (u->build < 0 || o->target) {
+                        string order = "BUILD ";
+                        BuildOrder *border = nullptr;
+                        Unit *t;
+                        if (o->target) {
+                            t = r->GetUnitId(o->target, u->faction->num);
+                            if (t->monthorders && (t->monthorders->type == O_BUILD)) {
+                                border = dynamic_cast<BuildOrder *>(t->monthorders);
+                            }
+                        } else {
+                            border = dynamic_cast<BuildOrder *>(u->monthorders);
+                        }
+                        if (border && border->needtocomplete > 0) {
+                            if (o->target) {
+                                order += "HELP " + to_string(t->num);
+                            } else {
+                                order += ItemDefs[-(u->build)].abr;
+                            }
+                            order += " COMPLETE";
+                            u->oldorders.push_front(order);
+                        }
+                    }
+                }
+                delete u->monthorders;
+                u->monthorders = nullptr; // clear the monthorders to avoid reprocessing
+            }
+        }
+    }
+    for (const auto& p : r->products) RunAProduction(r, p);
 }
 
-int Game::ValidProd(Unit * u,ARegion * r, Production * p)
+int Game::ValidProd(Unit *u, ARegion *r, Production *p)
 {
-	if (u->monthorders->type != O_PRODUCE) return 0;
+    if (u->monthorders->type != O_PRODUCE) return 0;
 
-	ProduceOrder *po = dynamic_cast<ProduceOrder *>(u->monthorders);
-	if (p->itemtype == po->item && p->skill == po->skill) {
-		if (p->skill == -1) {
-			/* Factor for fractional productivity: 10 */
-			po->productivity = (int) ((float) (u->GetMen() * p->productivity / 10));
-			return po->productivity;
-		}
-		int level = u->GetSkill(p->skill);
-		if (level < ItemDefs[p->itemtype].pLevel) {
-			u->error("PRODUCE: Unit isn't skilled enough to produce " + ItemDefs[p->itemtype].name + ".");
-			delete u->monthorders;
-			u->monthorders = nullptr;
-			return 0;
-		}
+    ProduceOrder *po = dynamic_cast<ProduceOrder *>(u->monthorders);
+    if (p->itemtype == po->item && p->skill == po->skill) {
+        if (p->skill == -1) {
+            /* Factor for fractional productivity: 10 */
+            po->productivity = (int)((float)(u->GetMen() * p->productivity / 10));
+            return po->productivity;
+        }
+        int level = u->GetSkill(p->skill);
+        if (level < ItemDefs[p->itemtype].pLevel) {
+            u->error("PRODUCE: Unit isn't skilled enough to produce " + ItemDefs[p->itemtype].name + ".");
+            delete u->monthorders;
+            u->monthorders = nullptr;
+            return 0;
+        }
 
-		//
-		// Check faction limits on production. If the item is silver, then the
-		// unit is entertaining or working, and the limit does not apply
-		//
-		if (p->itemtype != I_SILVER && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
-			u->error("PRODUCE: Faction can't produce in that many regions.");
-			delete u->monthorders;
-			u->monthorders = nullptr;
-			return 0;
-		}
+        //
+        // Check faction limits on production. If the item is silver, then the
+        // unit is entertaining or working, and the limit does not apply
+        //
+        if (p->itemtype != I_SILVER && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
+            u->error("PRODUCE: Faction can't produce in that many regions.");
+            delete u->monthorders;
+            u->monthorders = nullptr;
+            return 0;
+        }
 
-		/* check for bonus production */
-		// LLS
-		int bonus = u->GetProductionBonus(p->itemtype);
-		/* Factor for fractional productivity: 10 */
-		po->productivity = (int) ((float) (u->GetMen() * level * p->productivity / 10)) + bonus;
-		if (po->target > 0 && po->productivity > po->target)
-			po->productivity = po->target;
-		return po->productivity;
-	}
-	return 0;
+        /* check for bonus production */
+        // LLS
+        int bonus = u->GetProductionBonus(p->itemtype);
+        /* Factor for fractional productivity: 10 */
+        po->productivity = (int)((float)(u->GetMen() * level * p->productivity / 10)) + bonus;
+        if (po->target > 0 && po->productivity > po->target) po->productivity = po->target;
+        return po->productivity;
+    }
+    return 0;
 }
 
-int Game::FindAttemptedProd(ARegion * r, Production * p)
+int Game::FindAttemptedProd(ARegion *r, Production *p)
 {
-	int attempted = 0;
-	for(const auto obj : r->objects) {
-		for(const auto u : obj->units) {
-			if ((u->monthorders) && (u->monthorders->type == O_PRODUCE)) {
-				attempted += ValidProd(u, r, p);
-			}
-		}
-	}
-	return attempted;
+    int attempted = 0;
+    for (const auto obj : r->objects) {
+        for (const auto u : obj->units) {
+            if ((u->monthorders) && (u->monthorders->type == O_PRODUCE)) { attempted += ValidProd(u, r, p); }
+        }
+    }
+    return attempted;
 }
 
-void Game::RunAProduction(ARegion * r, Production * p)
+void Game::RunAProduction(ARegion *r, Production *p)
 {
-	int questcomplete;
-	string quest_rewards;
+    int questcomplete;
+    string quest_rewards;
 
-	p->activity = 0;
-	if (p->amount == 0) return;
+    p->activity = 0;
+    if (p->amount == 0) return;
 
-	/* First, see how many units are trying to work */
-	int attempted = FindAttemptedProd(r,p);
-	int amt = p->amount;
-	if (attempted < amt) attempted = amt;
-	for(const auto obj : r->objects) {
-		for(const auto u : obj->units) {
-			questcomplete = 0;
-			if (!u->monthorders || u->monthorders->type != O_PRODUCE) continue;
+    /* First, see how many units are trying to work */
+    int attempted = FindAttemptedProd(r, p);
+    int amt = p->amount;
+    if (attempted < amt) attempted = amt;
+    for (const auto obj : r->objects) {
+        for (const auto u : obj->units) {
+            questcomplete = 0;
+            if (!u->monthorders || u->monthorders->type != O_PRODUCE) continue;
 
-			ProduceOrder *po = dynamic_cast<ProduceOrder *>(u->monthorders);
-			if (po->skill != p->skill || po->item != p->itemtype) continue;
+            ProduceOrder *po = dynamic_cast<ProduceOrder *>(u->monthorders);
+            if (po->skill != p->skill || po->item != p->itemtype) continue;
 
-			/* We need to implement a hack to avoid overflowing */
-			int uatt, ubucks;
+            /* We need to implement a hack to avoid overflowing */
+            int uatt, ubucks;
 
-			uatt = po->productivity;
-			if (uatt && amt && attempted) {
-				double dUbucks = ((double)amt) * ((double)uatt) / ((double)attempted);
-				ubucks = (int)dUbucks;
-				questcomplete = quests.check_harvest_target(r, po->item, ubucks, amt, u, &quest_rewards);
-			} else {
-				ubucks = 0;
-			}
+            uatt = po->productivity;
+            if (uatt && amt && attempted) {
+                double dUbucks = ((double)amt) * ((double)uatt) / ((double)attempted);
+                ubucks = (int)dUbucks;
+                questcomplete = quests.check_harvest_target(r, po->item, ubucks, amt, u, &quest_rewards);
+            } else {
+                ubucks = 0;
+            }
 
-			amt -= ubucks;
-			attempted -= uatt;
-			u->items.SetNum(po->item,u->items.GetNum(po->item) + ubucks);
-			u->faction->DiscoverItem(po->item, 0, 1);
-			p->activity += ubucks;
-			po->target -= ubucks;
-			if (po->target > 0) {
-				TurnOrder *tOrder = new TurnOrder;
-				tOrder->repeating = 0;
-				std::string order = "PRODUCE " + to_string(po->target) + " " + ItemDefs[po->item].abr;
-				tOrder->turnOrders.push_back(order);
-				u->turnorders.push_front(tOrder);
-			}
+            amt -= ubucks;
+            attempted -= uatt;
+            u->items.SetNum(po->item, u->items.GetNum(po->item) + ubucks);
+            u->faction->DiscoverItem(po->item, 0, 1);
+            p->activity += ubucks;
+            po->target -= ubucks;
+            if (po->target > 0) {
+                TurnOrder *tOrder = new TurnOrder;
+                tOrder->repeating = 0;
+                std::string order = "PRODUCE " + to_string(po->target) + " " + ItemDefs[po->item].abr;
+                tOrder->turnOrders.push_back(order);
+                u->turnorders.push_front(tOrder);
+            }
 
-			/* Show in unit's events section */
-			if (po->item == I_SILVER) {
-				//
-				// WORK
-				//
-				if (po->skill == -1) {
-					u->event("Earns " + to_string(ubucks) + " silver working in " +
-						r->ShortPrint().const_str() + ".", "work", r);
-				} else {
-					//
-					// ENTERTAIN
-					//
-					u->event("Earns " + to_string(ubucks) + " silver entertaining in " +
-							 r->ShortPrint().const_str() + ".", "entertain", r);
-					// If they don't have PHEN, then this will fail safely
-					u->Practice(S_PHANTASMAL_ENTERTAINMENT);
-					u->Practice(S_ENTERTAINMENT);
-				}
-			} else {
-				/* Everything else */
-				u->event("Produces " + ItemString(po->item,ubucks) + " in " +
-					r->ShortPrint().const_str() + ".", "produce", r);
-				u->Practice(po->skill);
-			}
-			delete u->monthorders;
-			u->monthorders = nullptr;
-			if (questcomplete) {
-				u->event("You have completed a quest! " + quest_rewards, "quest");
-			}
-		}
-	}
+            /* Show in unit's events section */
+            if (po->item == I_SILVER) {
+                //
+                // WORK
+                //
+                if (po->skill == -1) {
+                    u->event(
+                        "Earns " + to_string(ubucks) + " silver working in " + r->ShortPrint().const_str() + ".",
+                        "work", r
+                    );
+                } else {
+                    //
+                    // ENTERTAIN
+                    //
+                    u->event(
+                        "Earns " + to_string(ubucks) + " silver entertaining in " + r->ShortPrint().const_str() + ".",
+                        "entertain", r
+                    );
+                    // If they don't have PHEN, then this will fail safely
+                    u->Practice(S_PHANTASMAL_ENTERTAINMENT);
+                    u->Practice(S_ENTERTAINMENT);
+                }
+            } else {
+                /* Everything else */
+                u->event(
+                    "Produces " + ItemString(po->item, ubucks) + " in " + r->ShortPrint().const_str() + ".", "produce",
+                    r
+                );
+                u->Practice(po->skill);
+            }
+            delete u->monthorders;
+            u->monthorders = nullptr;
+            if (questcomplete) { u->event("You have completed a quest! " + quest_rewards, "quest"); }
+        }
+    }
 }
 
-void Game::RunStudyOrders(ARegion * r)
+void Game::RunStudyOrders(ARegion *r)
 {
-	for(const auto obj : r->objects) {
-		for(const auto u : obj->units) {
-			if (u->monthorders) {
-				if (u->monthorders->type == O_STUDY) {
-					Do1StudyOrder(u,obj);
-					delete u->monthorders;
-					u->monthorders = nullptr;
-				}
-			}
-		}
-	}
+    for (const auto obj : r->objects) {
+        for (const auto u : obj->units) {
+            if (u->monthorders) {
+                if (u->monthorders->type == O_STUDY) {
+                    Do1StudyOrder(u, obj);
+                    delete u->monthorders;
+                    u->monthorders = nullptr;
+                }
+            }
+        }
+    }
 }
 
 void Game::RunIdleOrders(ARegion *r)
 {
-	for(const auto obj : r->objects) {
-		for(const auto u : obj->units) {
-			if (u->monthorders && u->monthorders->type == O_IDLE) {
-				u->event("Sits idle.", "idle");
-				delete u->monthorders;
-				u->monthorders = nullptr;
-			}
-		}
-	}
+    for (const auto obj : r->objects) {
+        for (const auto u : obj->units) {
+            if (u->monthorders && u->monthorders->type == O_IDLE) {
+                u->event("Sits idle.", "idle");
+                delete u->monthorders;
+                u->monthorders = nullptr;
+            }
+        }
+    }
 }
 
-void Game::Do1StudyOrder(Unit *u,Object *obj)
+void Game::Do1StudyOrder(Unit *u, Object *obj)
 {
-	StudyOrder *o = dynamic_cast<StudyOrder *>(u->monthorders);
-	int sk, cost, reset_man, skmax, taughtdays, days;
+    StudyOrder *o = dynamic_cast<StudyOrder *>(u->monthorders);
+    int sk, cost, reset_man, skmax, taughtdays, days;
 
-	reset_man = -1;
-	sk = o->skill;
-	if (sk == -1 || SkillDefs[sk].flags & SkillType::DISABLED ||
-		(SkillDefs[sk].flags & SkillType::APPRENTICE && !Globals->APPRENTICES_EXIST)
-	) {
-		std::string name = (sk == -1) ? "that" : SkillDefs[sk].name;
-		u->error("STUDY: Can't study " + name + ".");
-		return;
-	}
+    reset_man = -1;
+    sk = o->skill;
+    if (sk == -1 || SkillDefs[sk].flags & SkillType::DISABLED ||
+        (SkillDefs[sk].flags & SkillType::APPRENTICE && !Globals->APPRENTICES_EXIST)) {
+        std::string name = (sk == -1) ? "that" : SkillDefs[sk].name;
+        u->error("STUDY: Can't study " + name + ".");
+        return;
+    }
 
-	// Check that the skill can be studied
-	if (SkillDefs[sk].flags & SkillType::NOSTUDY) {
-		u->error("STUDY: " + SkillDefs[sk].name + " cannot be studied.");
-		return;
-	}
+    // Check that the skill can be studied
+    if (SkillDefs[sk].flags & SkillType::NOSTUDY) {
+        u->error("STUDY: " + SkillDefs[sk].name + " cannot be studied.");
+        return;
+    }
 
-	// Small patch for Ceran Mercs
-	if (u->GetMen(I_MERC)) {
-		u->error("STUDY: Mercenaries are not allowed to study.");
-		return;
-	}
+    // Small patch for Ceran Mercs
+    if (u->GetMen(I_MERC)) {
+        u->error("STUDY: Mercenaries are not allowed to study.");
+        return;
+    }
 
-	if (o->level != -1) {
-		skmax = u->GetSkillMax(sk);
-		if (skmax < o->level) {
-			o->level = skmax;
-			if (u->GetRealSkill(sk) >= o->level) {
-				u->error("STUDY: Cannot study " + SkillDefs[sk].name + " beyond level " + to_string(o->level) + ".");
-				return;
-			} else {
-				u->error("STUDY: set study goal for " + SkillDefs[sk].name + " to the maximum achievable level (" +
-					to_string(o->level) + ").");
-			}
-		}
-		if (u->GetRealSkill(sk) >= o->level) {
-			u->error("STUDY: already reached specified level; nothing to study.");
-			return;
-		}
-	}
+    if (o->level != -1) {
+        skmax = u->GetSkillMax(sk);
+        if (skmax < o->level) {
+            o->level = skmax;
+            if (u->GetRealSkill(sk) >= o->level) {
+                u->error("STUDY: Cannot study " + SkillDefs[sk].name + " beyond level " + to_string(o->level) + ".");
+                return;
+            } else {
+                u->error(
+                    "STUDY: set study goal for " + SkillDefs[sk].name + " to the maximum achievable level (" +
+                    to_string(o->level) + ")."
+                );
+            }
+        }
+        if (u->GetRealSkill(sk) >= o->level) {
+            u->error("STUDY: already reached specified level; nothing to study.");
+            return;
+        }
+    }
 
-	cost = SkillCost(sk) * u->GetMen();
-	if (cost > u->GetSharedMoney()) {
-		u->error("STUDY: Not enough funds to study " + SkillDefs[sk].name + ".");
-		return;
-	}
+    cost = SkillCost(sk) * u->GetMen();
+    if (cost > u->GetSharedMoney()) {
+        u->error("STUDY: Not enough funds to study " + SkillDefs[sk].name + ".");
+        return;
+    }
 
-	if ((SkillDefs[sk].flags & SkillType::MAGIC) && u->type != U_MAGE) {
-		if (u->type == U_APPRENTICE) {
-			u->error(string("STUDY: An ") + Globals->APPRENTICE_NAME + " cannot be made into a mage.");
-			return;
-		}
-		if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
-			if (CountMages(u->faction) >= AllowedMages(u->faction)) {
-				u->error("STUDY: Can't have another magician.");
-				return;
-			}
-		}
-		if (u->GetMen() != 1) {
-			u->error("STUDY: Only 1-man units can be magicians.");
-			return;
-		}
-		if (!(Globals->MAGE_NONLEADERS)) {
-			if (u->GetLeaders() != 1) {
-				u->error("STUDY: Only leaders may study magic.");
-				return;
-			}
-		}
-		reset_man = u->type;
-		u->type = U_MAGE;
-	}
+    if ((SkillDefs[sk].flags & SkillType::MAGIC) && u->type != U_MAGE) {
+        if (u->type == U_APPRENTICE) {
+            u->error(string("STUDY: An ") + Globals->APPRENTICE_NAME + " cannot be made into a mage.");
+            return;
+        }
+        if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
+            if (CountMages(u->faction) >= AllowedMages(u->faction)) {
+                u->error("STUDY: Can't have another magician.");
+                return;
+            }
+        }
+        if (u->GetMen() != 1) {
+            u->error("STUDY: Only 1-man units can be magicians.");
+            return;
+        }
+        if (!(Globals->MAGE_NONLEADERS)) {
+            if (u->GetLeaders() != 1) {
+                u->error("STUDY: Only leaders may study magic.");
+                return;
+            }
+        }
+        reset_man = u->type;
+        u->type = U_MAGE;
+    }
 
-	if ((SkillDefs[sk].flags&SkillType::APPRENTICE) && u->type != U_APPRENTICE) {
-		if (u->type == U_MAGE) {
-			u->error(string("STUDY: A mage cannot be made into an ") + Globals->APPRENTICE_NAME + ".");
-			return;
-		}
+    if ((SkillDefs[sk].flags & SkillType::APPRENTICE) && u->type != U_APPRENTICE) {
+        if (u->type == U_MAGE) {
+            u->error(string("STUDY: A mage cannot be made into an ") + Globals->APPRENTICE_NAME + ".");
+            return;
+        }
 
-		if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
-			if (CountApprentices(u->faction)>=AllowedApprentices(u->faction)) {
-				u->error(string("STUDY: Can't have another ") + Globals->APPRENTICE_NAME + ".");
-				return;
-			}
-		}
-		if (u->GetMen() != 1) {
-			u->error(string("STUDY: Only 1-man units can be ") + Globals->APPRENTICE_NAME + "s.");
-			return;
-		}
-		if (!(Globals->MAGE_NONLEADERS)) {
-			if (u->GetLeaders() != 1) {
-				u->error(string("STUDY: Only leaders may be ") + Globals->APPRENTICE_NAME + "s.");
-				return;
-			}
-		}
-		reset_man = u->type;
-		u->type = U_APPRENTICE;
-	}
+        if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
+            if (CountApprentices(u->faction) >= AllowedApprentices(u->faction)) {
+                u->error(string("STUDY: Can't have another ") + Globals->APPRENTICE_NAME + ".");
+                return;
+            }
+        }
+        if (u->GetMen() != 1) {
+            u->error(string("STUDY: Only 1-man units can be ") + Globals->APPRENTICE_NAME + "s.");
+            return;
+        }
+        if (!(Globals->MAGE_NONLEADERS)) {
+            if (u->GetLeaders() != 1) {
+                u->error(string("STUDY: Only leaders may be ") + Globals->APPRENTICE_NAME + "s.");
+                return;
+            }
+        }
+        reset_man = u->type;
+        u->type = U_APPRENTICE;
+    }
 
-	if ((Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT) &&
-		(sk == S_QUARTERMASTER) && (u->GetSkill(S_QUARTERMASTER) == 0) &&
-		(Globals->FACTION_LIMIT_TYPE == GameDefs::FACLIM_FACTION_TYPES)
-	) {
-		if (CountQuarterMasters(u->faction) >= AllowedQuarterMasters(u->faction)) {
-			u->error("STUDY: Can't have another quartermaster.");
-			return;
-		}
-		if (u->GetMen() != 1) {
-			u->error("STUDY: Only 1-man units can be quartermasters.");
-			return;
-		}
-	}
+    if ((Globals->TRANSPORT & GameDefs::ALLOW_TRANSPORT) && (sk == S_QUARTERMASTER) &&
+        (u->GetSkill(S_QUARTERMASTER) == 0) && (Globals->FACTION_LIMIT_TYPE == GameDefs::FACLIM_FACTION_TYPES)) {
+        if (CountQuarterMasters(u->faction) >= AllowedQuarterMasters(u->faction)) {
+            u->error("STUDY: Can't have another quartermaster.");
+            return;
+        }
+        if (u->GetMen() != 1) {
+            u->error("STUDY: Only 1-man units can be quartermasters.");
+            return;
+        }
+    }
 
-	// If TACTICS_NEEDS_WAR is enabled, and the unit is trying to study to tact-5,
-	// check that there's still space...
-	if (Globals->TACTICS_NEEDS_WAR && sk == S_TACTICS &&
-		u->GetSkill(sk) == 4 && u->skills.GetDays(sk)/u->GetMen() >= 300
-	) {
-		if (CountTacticians(u->faction) >= AllowedTacticians(u->faction)) {
-			u->error("STUDY: Can't start another level 5 tactics leader.");
-			return;
-		}
-		if (u->GetMen() != 1) {
-			u->error("STUDY: Only 1-man units can study to level 5 in tactics.");
-			return;
-		}
+    // If TACTICS_NEEDS_WAR is enabled, and the unit is trying to study to tact-5,
+    // check that there's still space...
+    if (Globals->TACTICS_NEEDS_WAR && sk == S_TACTICS && u->GetSkill(sk) == 4 &&
+        u->skills.GetDays(sk) / u->GetMen() >= 300) {
+        if (CountTacticians(u->faction) >= AllowedTacticians(u->faction)) {
+            u->error("STUDY: Can't start another level 5 tactics leader.");
+            return;
+        }
+        if (u->GetMen() != 1) {
+            u->error("STUDY: Only 1-man units can study to level 5 in tactics.");
+            return;
+        }
 
-	} // end tactics check
+    } // end tactics check
 
-	// adjust teaching for study rate
-	taughtdays = ((long int) o->days * u->skills.GetStudyRate(sk, u->GetMen()) / 30);
+    // adjust teaching for study rate
+    taughtdays = ((long int)o->days * u->skills.GetStudyRate(sk, u->GetMen()) / 30);
 
-	days = u->skills.GetStudyRate(sk, u->GetMen()) * u->GetMen() + taughtdays;
+    days = u->skills.GetStudyRate(sk, u->GetMen()) * u->GetMen() + taughtdays;
 
-	if ((SkillDefs[sk].flags & SkillType::MAGIC) && u->GetRealSkill(sk) >= 2) {
-		if (obj->incomplete > 0 || obj->type == O_DUMMY) {
-			u->error("Warning: Magic study rate outside of a building cut in half above level 2.");
-			days /= 2;
-		} else if (obj->mages < 1) {
-			if (!Globals->LIMITED_MAGES_PER_BUILDING ||
-					(!obj->IsFleet() &&
-					!ObjectDefs[obj->type].maxMages)) {
-				u->error("Warning: Magic study rate cut in half above level 2 due to unsuitable building.");
-			} else {
-				u->error(
-					"Warning: Magic study rate cut in half above level 2 due to number of mages studying in structure."
-				);
-			}
-			days /= 2;
-		} else if (Globals->LIMITED_MAGES_PER_BUILDING) {
-			obj->mages--;
-		}
-	}
+    if ((SkillDefs[sk].flags & SkillType::MAGIC) && u->GetRealSkill(sk) >= 2) {
+        if (obj->incomplete > 0 || obj->type == O_DUMMY) {
+            u->error("Warning: Magic study rate outside of a building cut in half above level 2.");
+            days /= 2;
+        } else if (obj->mages < 1) {
+            if (!Globals->LIMITED_MAGES_PER_BUILDING || (!obj->IsFleet() && !ObjectDefs[obj->type].maxMages)) {
+                u->error("Warning: Magic study rate cut in half above level 2 due to unsuitable building.");
+            } else {
+                u->error(
+                    "Warning: Magic study rate cut in half above level 2 due to number of mages studying in structure."
+                );
+            }
+            days /= 2;
+        } else if (Globals->LIMITED_MAGES_PER_BUILDING) {
+            obj->mages--;
+        }
+    }
 
-	if (SkillDefs[sk].flags & SkillType::SLOWSTUDY) {
-		days /= 2;
-	}
+    if (SkillDefs[sk].flags & SkillType::SLOWSTUDY) { days /= 2; }
 
-	if (u->Study(sk,days)) {
-		u->ConsumeSharedMoney(cost);
-		string str = "Studies " + SkillDefs[sk].name;
-		taughtdays = taughtdays/u->GetMen();
-		if (taughtdays) {
-			str += " and was taught for " + to_string(taughtdays) + " days";
-		}
-		str += " at a cost of " + ItemString(I_SILVER, cost) + ".";
-		u->event(str, "study");
-		// study to level order
-		if (o->level != -1) {
-			if (u->GetRealSkill(sk) < o->level) {
-				TurnOrder *tOrder = new TurnOrder;
-				tOrder->repeating = 0;
-				std::string order = "STUDY " + string(SkillDefs[sk].abbr) + " " + to_string(o->level);
-				tOrder->turnOrders.push_back(order);
-				u->turnorders.push_front(tOrder);
-			} else {
-				string msg = "Completes study to level " + to_string(o->level) + " in " + SkillDefs[sk].name + ".";
-				u->event(msg, "study");
-			}
-		}
-	} else {
-		// if we just tried to become a mage or apprentice, but
-		// were unable to study, reset unit to whatever it was before.
-		if (reset_man != -1)
-			u->type = reset_man;
-	}
+    if (u->Study(sk, days)) {
+        u->ConsumeSharedMoney(cost);
+        string str = "Studies " + SkillDefs[sk].name;
+        taughtdays = taughtdays / u->GetMen();
+        if (taughtdays) { str += " and was taught for " + to_string(taughtdays) + " days"; }
+        str += " at a cost of " + ItemString(I_SILVER, cost) + ".";
+        u->event(str, "study");
+        // study to level order
+        if (o->level != -1) {
+            if (u->GetRealSkill(sk) < o->level) {
+                TurnOrder *tOrder = new TurnOrder;
+                tOrder->repeating = 0;
+                std::string order = "STUDY " + string(SkillDefs[sk].abbr) + " " + to_string(o->level);
+                tOrder->turnOrders.push_back(order);
+                u->turnorders.push_front(tOrder);
+            } else {
+                string msg = "Completes study to level " + to_string(o->level) + " in " + SkillDefs[sk].name + ".";
+                u->event(msg, "study");
+            }
+        }
+    } else {
+        // if we just tried to become a mage or apprentice, but
+        // were unable to study, reset unit to whatever it was before.
+        if (reset_man != -1) u->type = reset_man;
+    }
 }
 
 void Game::DoMoveEnter(Unit *unit, ARegion *region)
 {
-	if (!unit->monthorders || ((unit->monthorders->type != O_MOVE) && (unit->monthorders->type != O_ADVANCE)))
-		return;
+    if (!unit->monthorders || ((unit->monthorders->type != O_MOVE) && (unit->monthorders->type != O_ADVANCE))) return;
 
-	MoveOrder *o = dynamic_cast<MoveOrder *>(unit->monthorders);
-	while (o->dirs.size()) {
-		auto x = o->dirs.front();
-		int i = x->dir;
-		if (i != MOVE_OUT && i < MOVE_ENTER) return;
-		std::erase(o->dirs, x);
-		delete x;
+    MoveOrder *o = dynamic_cast<MoveOrder *>(unit->monthorders);
+    while (o->dirs.size()) {
+        auto x = o->dirs.front();
+        int i = x->dir;
+        if (i != MOVE_OUT && i < MOVE_ENTER) return;
+        std::erase(o->dirs, x);
+        delete x;
 
-		if (i >= MOVE_ENTER) {
-			Object * to = region->GetObject(i - MOVE_ENTER);
-			if (!to) {
-				unit->error("MOVE: Can't find object.");
-				continue;
-			}
+        if (i >= MOVE_ENTER) {
+            Object *to = region->GetObject(i - MOVE_ENTER);
+            if (!to) {
+                unit->error("MOVE: Can't find object.");
+                continue;
+            }
 
-			if (!to->CanEnter(region,unit)) {
-				unit->error("ENTER: Can't enter that.");
-				continue;
-			}
+            if (!to->CanEnter(region, unit)) {
+                unit->error("ENTER: Can't enter that.");
+                continue;
+            }
 
-			Unit *forbid = to->ForbiddenBy(region, unit);
-			if (forbid && !o->advancing) {
-				unit->error("ENTER: Is refused entry.");
-				continue;
-			}
+            Unit *forbid = to->ForbiddenBy(region, unit);
+            if (forbid && !o->advancing) {
+                unit->error("ENTER: Is refused entry.");
+                continue;
+            }
 
-			if (forbid && region->IsSafeRegion()) {
-				unit->error("ENTER: No battles allowed in safe regions.");
-				continue;
-			}
+            if (forbid && region->IsSafeRegion()) {
+                unit->error("ENTER: No battles allowed in safe regions.");
+                continue;
+            }
 
-			if (forbid && !(unit->canattack && unit->IsAlive())) {
-				unit->error(string("ENTER: Unable to attack ") + forbid->name->const_str());
-				continue;
-			}
+            if (forbid && !(unit->canattack && unit->IsAlive())) {
+                unit->error(string("ENTER: Unable to attack ") + forbid->name->const_str());
+                continue;
+            }
 
-			bool done = false;
-			while (forbid) {
-				int result = RunBattle(region, unit, forbid, 0, 0);
-				if (result == BATTLE_IMPOSSIBLE) {
-					unit->error(string("ENTER: Unable to attack ") + forbid->name->const_str());
-					done = 1;
-					break;
-				}
-				if (!unit->canattack || !unit->IsAlive()) {
-					done = true;
-					break;
-				}
-				forbid = to->ForbiddenBy(region, unit);
-			}
-			if (done) continue;
+            bool done = false;
+            while (forbid) {
+                int result = RunBattle(region, unit, forbid, 0, 0);
+                if (result == BATTLE_IMPOSSIBLE) {
+                    unit->error(string("ENTER: Unable to attack ") + forbid->name->const_str());
+                    done = 1;
+                    break;
+                }
+                if (!unit->canattack || !unit->IsAlive()) {
+                    done = true;
+                    break;
+                }
+                forbid = to->ForbiddenBy(region, unit);
+            }
+            if (done) continue;
 
-			unit->MoveUnit(to);
-			unit->event("Enters " + string(to->name->const_str()) + ".", "movement");
-		} else {
-			if (i == MOVE_OUT) {
-				bool isOcean = (TerrainDefs[region->type].similar_type == R_OCEAN);
-				if (isOcean && (!unit->CanSwim() || unit->GetFlag(FLAG_NOCROSS_WATER))) {
-					unit->error("MOVE: Can't leave ship.");
-					continue;
-				}
-				Object *to = region->GetDummy();
-				unit->MoveUnit(to);
-			}
-		}
-	}
+            unit->MoveUnit(to);
+            unit->event("Enters " + string(to->name->const_str()) + ".", "movement");
+        } else {
+            if (i == MOVE_OUT) {
+                bool isOcean = (TerrainDefs[region->type].similar_type == R_OCEAN);
+                if (isOcean && (!unit->CanSwim() || unit->GetFlag(FLAG_NOCROSS_WATER))) {
+                    unit->error("MOVE: Can't leave ship.");
+                    continue;
+                }
+                Object *to = region->GetDummy();
+                unit->MoveUnit(to);
+            }
+        }
+    }
 }
 
 Location *Game::DoAMoveOrder(Unit *unit, ARegion *region, Object *obj)
 {
-	MoveOrder *o = dynamic_cast<MoveOrder *>(unit->monthorders);
-	ARegion *newreg;
-	string road, temp;
+    MoveOrder *o = dynamic_cast<MoveOrder *>(unit->monthorders);
+    ARegion *newreg;
+    string road, temp;
 
-	int movetype, cost, startmove, weight;
-	Unit *ally, *forbid;
-	Location *loc;
-	const char *prevented = nullptr;
+    int movetype, cost, startmove, weight;
+    Unit *ally, *forbid;
+    Location *loc;
+    const char *prevented = nullptr;
 
-	if (!o->dirs.size()) {
-		delete o;
-		unit->monthorders = nullptr;
-		return 0;
-	}
+    if (!o->dirs.size()) {
+        delete o;
+        unit->monthorders = nullptr;
+        return 0;
+    }
 
-	auto x = o->dirs.front();
+    auto x = o->dirs.front();
 
-	if (x->dir == MOVE_IN) {
-		if (obj->inner == -1) {
-			unit->error("MOVE: Can't move IN there.");
-			goto done_moving;
-		}
+    if (x->dir == MOVE_IN) {
+        if (obj->inner == -1) {
+            unit->error("MOVE: Can't move IN there.");
+            goto done_moving;
+        }
 
-		// Make sure that items which cannot go through a shaft don't
-		for(auto i : unit->items) {
-			if (ItemDefs[i->type].flags & ItemType::NO_SHAFT) {
-				unit->error("MOVE: Unable to fit through the shaft.");
-				goto done_moving;
-			}
-		}
+        // Make sure that items which cannot go through a shaft don't
+        for (auto i : unit->items) {
+            if (ItemDefs[i->type].flags & ItemType::NO_SHAFT) {
+                unit->error("MOVE: Unable to fit through the shaft.");
+                goto done_moving;
+            }
+        }
 
-		newreg = regions.GetRegion(obj->inner);
-		if (obj->type == O_GATEWAY) {
-			// Gateways should only exist in the nexus, and move the
-			// user to a semi-random instance of the target terrain
-			// type, so select where they will actually move to.
-			ARegionArray *level = regions.GetRegionArray(newreg->zloc);
-			std::vector<ARegion *> start_locations = level->get_starting_region_candidates(newreg->type);
+        newreg = regions.GetRegion(obj->inner);
+        if (obj->type == O_GATEWAY) {
+            // Gateways should only exist in the nexus, and move the
+            // user to a semi-random instance of the target terrain
+            // type, so select where they will actually move to.
+            ARegionArray *level = regions.GetRegionArray(newreg->zloc);
+            std::vector<ARegion *> start_locations = level->get_starting_region_candidates(newreg->type);
 
-			// match levels to try for, in order:
-			// 0 - completely empty towns
-			// 1 - towns with only guardsmen
-			// 2 - towns with guardsmen and other players
-			// 3 - completely empty hexes
-			// 4 - anywhere that matches terrain (out of options)
-			int match = 0;
-			std::vector<ARegion *> candidates = {};
-			while (candidates.empty() && match < 5) {
-				for(const auto scanReg : start_locations) {
-					// ignore any region that isn't a town before match level 3
-					if (match < 3 && !scanReg->town) continue;
-					int guards = 0;
-					int others = 0;
-					for(const auto o : scanReg->objects) {
-						for(const auto u : o->units) {
-							if (u->faction->num == guardfaction) guards = 1;
-							else others = 1;
-						}
-					}
-					// match level 0 - ignore anything that isn't completely empty
-					if (match == 0 && (guards || others)) continue;
-					// match level 1 - ignore anything that has other players
-					if (match == 1 && (!guards || others)) continue;
-					// match level 2 - ignore anything that doesn't have guards
-					if (match == 2 && !guards) continue;
-					// match level 3 - ignore anything that has guards or others
-					if (match == 3 && (guards || others)) continue;
-					// match level 4 or we were legal by the above rules
-					candidates.push_back(scanReg);
-				}
-				// increment match level.  If we found anything above, we'll break at the top of the while
-				match++;
-			}
-			if (!candidates.empty()) {
-				int index = rng::rng::get_random(candidates.size());
-				newreg = candidates[index];
-			}
-		}
-	} else if (x->dir == MOVE_PAUSE) {
-		newreg = region;
-	} else {
-		newreg = region->neighbors[x->dir];
-	}
+            // match levels to try for, in order:
+            // 0 - completely empty towns
+            // 1 - towns with only guardsmen
+            // 2 - towns with guardsmen and other players
+            // 3 - completely empty hexes
+            // 4 - anywhere that matches terrain (out of options)
+            int match = 0;
+            std::vector<ARegion *> candidates = {};
+            while (candidates.empty() && match < 5) {
+                for (const auto scanReg : start_locations) {
+                    // ignore any region that isn't a town before match level 3
+                    if (match < 3 && !scanReg->town) continue;
+                    int guards = 0;
+                    int others = 0;
+                    for (const auto o : scanReg->objects) {
+                        for (const auto u : o->units) {
+                            if (u->faction->num == guardfaction)
+                                guards = 1;
+                            else
+                                others = 1;
+                        }
+                    }
+                    // match level 0 - ignore anything that isn't completely empty
+                    if (match == 0 && (guards || others)) continue;
+                    // match level 1 - ignore anything that has other players
+                    if (match == 1 && (!guards || others)) continue;
+                    // match level 2 - ignore anything that doesn't have guards
+                    if (match == 2 && !guards) continue;
+                    // match level 3 - ignore anything that has guards or others
+                    if (match == 3 && (guards || others)) continue;
+                    // match level 4 or we were legal by the above rules
+                    candidates.push_back(scanReg);
+                }
+                // increment match level.  If we found anything above, we'll break at the top of the while
+                match++;
+            }
+            if (!candidates.empty()) {
+                int index = rng::rng::get_random(candidates.size());
+                newreg = candidates[index];
+            }
+        }
+    } else if (x->dir == MOVE_PAUSE) {
+        newreg = region;
+    } else {
+        newreg = region->neighbors[x->dir];
+    }
 
-	if (!newreg) {
-		unit->error("MOVE: Can't move that direction.");
-		goto done_moving;
-	}
+    if (!newreg) {
+        unit->error("MOVE: Can't move that direction.");
+        goto done_moving;
+    }
 
-	// Check for any keybarrier objects in the target region
-	for(const auto o : newreg->objects) {
-		if (ObjectDefs[o->type].flags & ObjectType::KEYBARRIER) {
-			if (unit->items.GetNum(ObjectDefs[o->type].key_item) < 1) {
-				unit->error("MOVE: A mystical barrier prevents movement in that direction.");
-				goto done_moving;
-			}
-		}
-	}
+    // Check for any keybarrier objects in the target region
+    for (const auto o : newreg->objects) {
+        if (ObjectDefs[o->type].flags & ObjectType::KEYBARRIER) {
+            if (unit->items.GetNum(ObjectDefs[o->type].key_item) < 1) {
+                unit->error("MOVE: A mystical barrier prevents movement in that direction.");
+                goto done_moving;
+            }
+        }
+    }
 
-	prevented = newreg->movement_forbidden_by_ruleset(unit, region, regions);
-	if (prevented != nullptr) {
-		unit->error("MOVE: " + string(prevented) + " prevents movement in that direction.");
-		goto done_moving;
-	}
+    prevented = newreg->movement_forbidden_by_ruleset(unit, region, regions);
+    if (prevented != nullptr) {
+        unit->error("MOVE: " + string(prevented) + " prevents movement in that direction.");
+        goto done_moving;
+    }
 
-	unit->movepoints += unit->CalcMovePoints(region);
+    unit->movepoints += unit->CalcMovePoints(region);
 
-	road = "";
-	startmove = 0;
-	movetype = unit->MoveType(region);
-	cost = newreg->MoveCost(movetype, region, x->dir, &road);
-	if (x->dir == MOVE_PAUSE)
-		cost = 1;
-	if (region->type == R_NEXUS) {
-		cost = 1;
-		startmove = 1;
-	}
-	if ((TerrainDefs[region->type].similar_type == R_OCEAN) &&
-			(!unit->CanSwim() ||
-			unit->GetFlag(FLAG_NOCROSS_WATER))) {
-		unit->error("MOVE: Can't move while in the ocean.");
-		goto done_moving;
-	}
-	weight = unit->items.Weight();
-	if ((TerrainDefs[region->type].similar_type == R_OCEAN) &&
-			(TerrainDefs[newreg->type].similar_type != R_OCEAN) &&
-			!unit->CanWalk(weight) &&
-			!unit->CanRide(weight) &&
-			!unit->CanFly(weight)) {
-		unit->error("Must be able to walk to climb out of the ocean.");
-		goto done_moving;
-	}
-	if (movetype == M_NONE) {
-		unit->error("MOVE: Unit is overloaded and cannot move.");
-		goto done_moving;
-	}
+    road = "";
+    startmove = 0;
+    movetype = unit->MoveType(region);
+    cost = newreg->MoveCost(movetype, region, x->dir, &road);
+    if (x->dir == MOVE_PAUSE) cost = 1;
+    if (region->type == R_NEXUS) {
+        cost = 1;
+        startmove = 1;
+    }
+    if ((TerrainDefs[region->type].similar_type == R_OCEAN) &&
+        (!unit->CanSwim() || unit->GetFlag(FLAG_NOCROSS_WATER))) {
+        unit->error("MOVE: Can't move while in the ocean.");
+        goto done_moving;
+    }
+    weight = unit->items.Weight();
+    if ((TerrainDefs[region->type].similar_type == R_OCEAN) && (TerrainDefs[newreg->type].similar_type != R_OCEAN) &&
+        !unit->CanWalk(weight) && !unit->CanRide(weight) && !unit->CanFly(weight)) {
+        unit->error("Must be able to walk to climb out of the ocean.");
+        goto done_moving;
+    }
+    if (movetype == M_NONE) {
+        unit->error("MOVE: Unit is overloaded and cannot move.");
+        goto done_moving;
+    }
 
-	// If we're moving in the same direction as last month and
-	// have stored movement points, then add in those stored
-	// movement points, but make sure that these are only used
-	// towards entering the hex we were trying to enter
-	if (!unit->moved &&
-			unit->movepoints >= Globals->MAX_SPEED &&
-			unit->movepoints < cost * Globals->MAX_SPEED &&
-			x->dir == unit->savedmovedir) {
-		while (unit->savedmovement > 0 &&
-				unit->movepoints < cost * Globals->MAX_SPEED) {
-			unit->movepoints += Globals->MAX_SPEED;
-			unit->savedmovement--;
-		}
-		unit->savedmovement = 0;
-		unit->savedmovedir = -1;
-	}
+    // If we're moving in the same direction as last month and
+    // have stored movement points, then add in those stored
+    // movement points, but make sure that these are only used
+    // towards entering the hex we were trying to enter
+    if (!unit->moved && unit->movepoints >= Globals->MAX_SPEED && unit->movepoints < cost * Globals->MAX_SPEED &&
+        x->dir == unit->savedmovedir) {
+        while (unit->savedmovement > 0 && unit->movepoints < cost * Globals->MAX_SPEED) {
+            unit->movepoints += Globals->MAX_SPEED;
+            unit->savedmovement--;
+        }
+        unit->savedmovement = 0;
+        unit->savedmovedir = -1;
+    }
 
-	if (unit->movepoints < cost * Globals->MAX_SPEED)
-		return 0;
+    if (unit->movepoints < cost * Globals->MAX_SPEED) return 0;
 
-	if (x->dir == MOVE_PAUSE) {
-		unit->event("Pauses to admire the scenery in " + string(region->ShortPrint().const_str()) +
-			".", "movement");
-		unit->movepoints -= cost * Globals->MAX_SPEED;
-		unit->moved += cost;
-		std::erase(o->dirs, x);
-		delete x;
-		return 0;
-	}
+    if (x->dir == MOVE_PAUSE) {
+        unit->event("Pauses to admire the scenery in " + string(region->ShortPrint().const_str()) + ".", "movement");
+        unit->movepoints -= cost * Globals->MAX_SPEED;
+        unit->moved += cost;
+        std::erase(o->dirs, x);
+        delete x;
+        return 0;
+    }
 
-	if ((TerrainDefs[newreg->type].similar_type == R_OCEAN) &&
-			(!unit->CanSwim() ||
-			unit->GetFlag(FLAG_NOCROSS_WATER))) {
-		unit->event("Discovers that " + string(newreg->ShortPrint().const_str()) + " is " +
-			TerrainDefs[newreg->type].name + ".", "movement");
-		goto done_moving;
-	}
+    if ((TerrainDefs[newreg->type].similar_type == R_OCEAN) &&
+        (!unit->CanSwim() || unit->GetFlag(FLAG_NOCROSS_WATER))) {
+        unit->event(
+            "Discovers that " + string(newreg->ShortPrint().const_str()) + " is " + TerrainDefs[newreg->type].name +
+                ".",
+            "movement"
+        );
+        goto done_moving;
+    }
 
-	if (unit->type == U_WMON && newreg->town && newreg->IsGuarded()) {
-		unit->event("Monsters don't move into guarded towns.", "movement");
-		goto done_moving;
-	}
+    if (unit->type == U_WMON && newreg->town && newreg->IsGuarded()) {
+        unit->event("Monsters don't move into guarded towns.", "movement");
+        goto done_moving;
+    }
 
-	if (unit->guard == GUARD_ADVANCE) {
-		ally = newreg->ForbiddenByAlly(unit);
-		if (ally && !startmove) {
-			unit->event("Can't ADVANCE: " + string(newreg->name->const_str()) + " is guarded by " +
-				ally->name->const_str() + ", an ally.", "movement");
-			goto done_moving;
-		}
-	}
+    if (unit->guard == GUARD_ADVANCE) {
+        ally = newreg->ForbiddenByAlly(unit);
+        if (ally && !startmove) {
+            unit->event(
+                "Can't ADVANCE: " + string(newreg->name->const_str()) + " is guarded by " + ally->name->const_str() +
+                    ", an ally.",
+                "movement"
+            );
+            goto done_moving;
+        }
+    }
 
-	if (o->advancing) unit->guard = GUARD_ADVANCE;
+    if (o->advancing) unit->guard = GUARD_ADVANCE;
 
-	forbid = newreg->Forbidden(unit);
-	if (forbid && !startmove && unit->guard != GUARD_ADVANCE) {
-		int obs = unit->GetAttribute("observation");
-		unit->event("Is forbidden entry to " + string(newreg->ShortPrint().const_str()) + " by " +
-			forbid->GetName(obs).const_str() + ".", "movement");
-		obs = forbid->GetAttribute("observation");
-		forbid->event("Forbids entry to " + string(unit->GetName(obs).const_str()) + ".", "guarding");
-		goto done_moving;
-	}
+    forbid = newreg->Forbidden(unit);
+    if (forbid && !startmove && unit->guard != GUARD_ADVANCE) {
+        int obs = unit->GetAttribute("observation");
+        unit->event(
+            "Is forbidden entry to " + string(newreg->ShortPrint().const_str()) + " by " +
+                forbid->GetName(obs).const_str() + ".",
+            "movement"
+        );
+        obs = forbid->GetAttribute("observation");
+        forbid->event("Forbids entry to " + string(unit->GetName(obs).const_str()) + ".", "guarding");
+        goto done_moving;
+    }
 
-	if (unit->guard == GUARD_GUARD) unit->guard = GUARD_NONE;
+    if (unit->guard == GUARD_GUARD) unit->guard = GUARD_NONE;
 
-	unit->alias = 0;
-	unit->movepoints -= cost * Globals->MAX_SPEED;
-	unit->moved += cost;
-	unit->MoveUnit(newreg->GetDummy());
-	unit->DiscardUnfinishedShips();
+    unit->alias = 0;
+    unit->movepoints -= cost * Globals->MAX_SPEED;
+    unit->moved += cost;
+    unit->MoveUnit(newreg->GetDummy());
+    unit->DiscardUnfinishedShips();
 
-	// Track the initial region the unit started from for part of NO7 victory handling
-	if (unit->initial_region == nullptr) {
-		unit->initial_region = region;
-	}
+    // Track the initial region the unit started from for part of NO7 victory handling
+    if (unit->initial_region == nullptr) { unit->initial_region = region; }
 
-	switch (movetype) {
-		case M_WALK:
-		default:
-			temp = "Walks " + road;
-			break;
-		case M_RIDE:
-			temp = "Rides " + road;
-			unit->Practice(S_RIDING);
-			break;
-		case M_FLY:
-			temp = "Flies ";
-			unit->Practice(S_SUMMON_WIND);
-			unit->Practice(S_RIDING);
-			break;
-		case M_SWIM:
-			temp = "Swims ";
-			break;
-	}
-	unit->event(temp + "from " + string(region->ShortPrint().const_str()) + " to " +
-		newreg->ShortPrint().const_str() + ".", "movement");
+    switch (movetype) {
+    case M_WALK:
+    default: temp = "Walks " + road; break;
+    case M_RIDE:
+        temp = "Rides " + road;
+        unit->Practice(S_RIDING);
+        break;
+    case M_FLY:
+        temp = "Flies ";
+        unit->Practice(S_SUMMON_WIND);
+        unit->Practice(S_RIDING);
+        break;
+    case M_SWIM: temp = "Swims "; break;
+    }
+    unit->event(
+        temp + "from " + string(region->ShortPrint().const_str()) + " to " + newreg->ShortPrint().const_str() + ".",
+        "movement"
+    );
 
-	if (forbid) {
-		unit->advancefrom = region;
-	}
+    if (forbid) { unit->advancefrom = region; }
 
-	// TODO: Should we get a transit report on the starting region?
-	if (Globals->TRANSIT_REPORT != GameDefs::REPORT_NOTHING) {
-		if (!(unit->faction->is_npc)) newreg->visited = 1;
-		// Update our visit record in the region we are leaving.
-		for(const auto f : region->passers) {
-			if (f->unit == unit) {
-				// We moved into here this turn
-				if (x->dir < MOVE_IN) {
-					f->exits_used[x->dir] = 1;
-				}
-			}
-		}
-		// And mark the hex being entered
-		Farsight *f = new Farsight;
-		f->faction = unit->faction;
-		f->level = 0;
-		f->unit = unit;
-		if (x->dir < MOVE_IN) {
-			f->exits_used[region->GetRealDirComp(x->dir)] = 1;
-		}
-		newreg->passers.push_back(f);
-	}
+    // TODO: Should we get a transit report on the starting region?
+    if (Globals->TRANSIT_REPORT != GameDefs::REPORT_NOTHING) {
+        if (!(unit->faction->is_npc)) newreg->visited = 1;
+        // Update our visit record in the region we are leaving.
+        for (const auto f : region->passers) {
+            if (f->unit == unit) {
+                // We moved into here this turn
+                if (x->dir < MOVE_IN) { f->exits_used[x->dir] = 1; }
+            }
+        }
+        // And mark the hex being entered
+        Farsight *f = new Farsight;
+        f->faction = unit->faction;
+        f->level = 0;
+        f->unit = unit;
+        if (x->dir < MOVE_IN) { f->exits_used[region->GetRealDirComp(x->dir)] = 1; }
+        newreg->passers.push_back(f);
+    }
 
-	region = newreg;
+    region = newreg;
 
-	std::erase(o->dirs, x);
-	delete x;
+    std::erase(o->dirs, x);
+    delete x;
 
-	loc = new Location;
-	loc->unit = unit;
-	loc->region = region;
-	loc->obj = nullptr;
-	return loc;
+    loc = new Location;
+    loc->unit = unit;
+    loc->region = region;
+    loc->obj = nullptr;
+    return loc;
 
 done_moving:
-	delete o;
-	unit->monthorders = nullptr;
-	return 0;
+    delete o;
+    unit->monthorders = nullptr;
+    return 0;
 }

--- a/orders.cpp
+++ b/orders.cpp
@@ -26,380 +26,265 @@
 #include "unit.h"
 
 char const *od[] = {
-	"#atlantis",
-	"#end",
-	"unit",
-	"address",
-	"advance",
-	"annihilate",
-	"armor",
-	"assassinate",
-	"attack",
-	"autotax",
-	"avoid",
-	"behind",
-	"build",
-	"buy",
-	"cast",
-	"claim",
-	"combat",
-	"consume",
-	"declare",
-	"describe",
-	"destroy",
-	"distribute",
-	"end",
-	"endturn",
-	"enter",
-	"entertain",
-	"evict",
-	"exchange",
-	"faction",
-	"find",
-	"forget",
-	"form",
-	"give",
-	"guard",
-	"hold",
-	"idle",
-	"join",
-	"leave",
-	"move",
-	"name",
-	"noaid",
-	"nocross",
-	"nospoils",
-	"option",
-	"password",
-	"pillage",
-	"prepare",
-	"produce",
-	"promote",
-	"quit",
-	"restart",
-	"reveal",
-	"sacrifice",
-	"sail",
-	"sell",
-	"share",
-	"show",
-	"spoils",
-	"steal",
-	"study",
-	"take",
-	"tax",
-	"teach",
-	"transport",
-	"turn",
-	"weapon",
-	"withdraw",
-	"work",
+    "#atlantis",
+    "#end",
+    "unit",
+    "address",
+    "advance",
+    "annihilate",
+    "armor",
+    "assassinate",
+    "attack",
+    "autotax",
+    "avoid",
+    "behind",
+    "build",
+    "buy",
+    "cast",
+    "claim",
+    "combat",
+    "consume",
+    "declare",
+    "describe",
+    "destroy",
+    "distribute",
+    "end",
+    "endturn",
+    "enter",
+    "entertain",
+    "evict",
+    "exchange",
+    "faction",
+    "find",
+    "forget",
+    "form",
+    "give",
+    "guard",
+    "hold",
+    "idle",
+    "join",
+    "leave",
+    "move",
+    "name",
+    "noaid",
+    "nocross",
+    "nospoils",
+    "option",
+    "password",
+    "pillage",
+    "prepare",
+    "produce",
+    "promote",
+    "quit",
+    "restart",
+    "reveal",
+    "sacrifice",
+    "sail",
+    "sell",
+    "share",
+    "show",
+    "spoils",
+    "steal",
+    "study",
+    "take",
+    "tax",
+    "teach",
+    "transport",
+    "turn",
+    "weapon",
+    "withdraw",
+    "work",
 };
 
 char const **OrderStrs = od;
 
 int Parse1Order(AString *token)
 {
-	for (int i=0; i<NORDERS; i++)
-		if (*token == OrderStrs[i]) return i;
-	return -1;
+    for (int i = 0; i < NORDERS; i++)
+        if (*token == OrderStrs[i]) return i;
+    return -1;
 }
 
 Order::Order()
 {
-	type = NORDERS;
-	quiet = 0;
+    type = NORDERS;
+    quiet = 0;
 }
 
-Order::~Order() {
-}
+Order::~Order() {}
 
 ExchangeOrder::ExchangeOrder()
 {
-	type = O_EXCHANGE;
-	exchangeStatus = -1;
+    type = O_EXCHANGE;
+    exchangeStatus = -1;
 }
 
 ExchangeOrder::~ExchangeOrder()
 {
-	if (target) delete target;
+    if (target) delete target;
 }
 
 TurnOrder::TurnOrder()
 {
-	type = O_TURN;
-	repeating = 0;
+    type = O_TURN;
+    repeating = 0;
 }
 
-TurnOrder::~TurnOrder()
-{
-}
+TurnOrder::~TurnOrder() {}
 
-MoveOrder::MoveOrder()
-{
-	type = O_MOVE;
-}
+MoveOrder::MoveOrder() { type = O_MOVE; }
 
-MoveOrder::~MoveOrder()
-{
-}
+MoveOrder::~MoveOrder() {}
 
-ForgetOrder::ForgetOrder()
-{
-	type = O_FORGET;
-}
+ForgetOrder::ForgetOrder() { type = O_FORGET; }
 
-ForgetOrder::~ForgetOrder()
-{
-}
+ForgetOrder::~ForgetOrder() {}
 
-WithdrawOrder::WithdrawOrder()
-{
-	type = O_WITHDRAW;
-}
+WithdrawOrder::WithdrawOrder() { type = O_WITHDRAW; }
 
-WithdrawOrder::~WithdrawOrder()
-{
-}
+WithdrawOrder::~WithdrawOrder() {}
 
 GiveOrder::GiveOrder()
 {
-	type = O_GIVE;
-	unfinished = 0;
-	merge = 0;
+    type = O_GIVE;
+    unfinished = 0;
+    merge = 0;
 }
 
 GiveOrder::~GiveOrder()
 {
-	if (target) delete target;
+    if (target) delete target;
 }
 
-StudyOrder::StudyOrder()
-{
-	type = O_STUDY;
-}
+StudyOrder::StudyOrder() { type = O_STUDY; }
 
-StudyOrder::~StudyOrder()
-{
-}
+StudyOrder::~StudyOrder() {}
 
-TeachOrder::TeachOrder()
-{
-	type = O_TEACH;
-}
+TeachOrder::TeachOrder() { type = O_TEACH; }
 
-TeachOrder::~TeachOrder()
-{
-}
+TeachOrder::~TeachOrder() {}
 
-ProduceOrder::ProduceOrder()
-{
-	type = O_PRODUCE;
-}
+ProduceOrder::ProduceOrder() { type = O_PRODUCE; }
 
-ProduceOrder::~ProduceOrder()
-{
-}
+ProduceOrder::~ProduceOrder() {}
 
-BuyOrder::BuyOrder()
-{
-	type = O_BUY;
-}
+BuyOrder::BuyOrder() { type = O_BUY; }
 
-BuyOrder::~BuyOrder()
-{
-}
+BuyOrder::~BuyOrder() {}
 
-SellOrder::SellOrder()
-{
-	type = O_SELL;
-}
+SellOrder::SellOrder() { type = O_SELL; }
 
-SellOrder::~SellOrder()
-{
-}
+SellOrder::~SellOrder() {}
 
-AttackOrder::AttackOrder()
-{
-	type = O_ATTACK;
-}
+AttackOrder::AttackOrder() { type = O_ATTACK; }
 
-AttackOrder::~AttackOrder()
-{
-}
+AttackOrder::~AttackOrder() {}
 
 BuildOrder::BuildOrder()
 {
-	type = O_BUILD;
-	new_building = -1;
+    type = O_BUILD;
+    new_building = -1;
+    until_complete = false;
+    target = nullptr;
+    needtocomplete = 0;
 }
 
 BuildOrder::~BuildOrder()
 {
-	if (target) delete target;
+    if (target) delete target;
 }
 
-SailOrder::SailOrder()
-{
-	type = O_SAIL;
-}
+SailOrder::SailOrder() { type = O_SAIL; }
 
-SailOrder::~SailOrder()
-{
-}
+SailOrder::~SailOrder() {}
 
-FindOrder::FindOrder()
-{
-	type = O_FIND;
-}
+FindOrder::FindOrder() { type = O_FIND; }
 
-FindOrder::~FindOrder()
-{
-}
+FindOrder::~FindOrder() {}
 
-StealthOrder::StealthOrder()
-{
-}
+StealthOrder::StealthOrder() {}
 
-StealthOrder::~StealthOrder()
-{
-}
+StealthOrder::~StealthOrder() {}
 
 StealOrder::StealOrder()
 {
-	type = O_STEAL;
+    type = O_STEAL;
+    target = nullptr;
 }
 
 StealOrder::~StealOrder()
 {
-	if (target) delete target;
+    if (target) delete target;
 }
 
-AssassinateOrder::AssassinateOrder()
-{
-	type = O_ASSASSINATE;
-}
+AssassinateOrder::AssassinateOrder() { type = O_ASSASSINATE; }
 
 AssassinateOrder::~AssassinateOrder()
 {
-	if (target) delete target;
+    if (target) delete target;
 }
 
-CastOrder::CastOrder()
-{
-	type = O_CAST;
-}
+CastOrder::CastOrder() { type = O_CAST; }
 
-CastOrder::~CastOrder()
-{
-}
+CastOrder::~CastOrder() {}
 
-CastMindOrder::CastMindOrder()
-{
-	id = 0;
-}
+CastMindOrder::CastMindOrder() { id = 0; }
 
-CastMindOrder::~CastMindOrder()
-{
-	delete id;
-}
+CastMindOrder::~CastMindOrder() { delete id; }
 
-TeleportOrder::TeleportOrder()
-{
-}
+TeleportOrder::TeleportOrder() {}
 
-TeleportOrder::~TeleportOrder()
-{
-}
+TeleportOrder::~TeleportOrder() {}
 
-CastRegionOrder::CastRegionOrder()
-{
-}
+CastRegionOrder::CastRegionOrder() {}
 
-CastRegionOrder::~CastRegionOrder()
-{
-}
+CastRegionOrder::~CastRegionOrder() {}
 
-CastIntOrder::CastIntOrder()
-{
-}
+CastIntOrder::CastIntOrder() {}
 
-CastIntOrder::~CastIntOrder()
-{
-}
+CastIntOrder::~CastIntOrder() {}
 
-CastUnitsOrder::CastUnitsOrder()
-{
-}
+CastUnitsOrder::CastUnitsOrder() {}
 
-CastUnitsOrder::~CastUnitsOrder()
-{
-}
+CastUnitsOrder::~CastUnitsOrder() {}
 
-EvictOrder::EvictOrder()
-{
-	type = O_EVICT;
-}
+EvictOrder::EvictOrder() { type = O_EVICT; }
 
-EvictOrder::~EvictOrder()
-{
-}
+EvictOrder::~EvictOrder() {}
 
-IdleOrder::IdleOrder()
-{
-	type = O_IDLE;
-}
+IdleOrder::IdleOrder() { type = O_IDLE; }
 
-IdleOrder::~IdleOrder()
-{
-}
+IdleOrder::~IdleOrder() {}
 
 TransportOrder::TransportOrder()
 {
-	type = O_TRANSPORT;
-	item = -1;
-	amount = 0;
-	except = 0;
-	target = NULL;
+    type = O_TRANSPORT;
+    item = -1;
+    amount = 0;
+    except = 0;
+    target = NULL;
 }
 
 TransportOrder::~TransportOrder()
 {
-	if (target) delete target;
+    if (target) delete target;
 }
 
-CastTransmuteOrder::CastTransmuteOrder()
-{
-}
+CastTransmuteOrder::CastTransmuteOrder() {}
 
-CastTransmuteOrder::~CastTransmuteOrder()
-{
-}
+CastTransmuteOrder::~CastTransmuteOrder() {}
 
-JoinOrder::JoinOrder()
-{
-	type = O_JOIN;
-}
+JoinOrder::JoinOrder() { type = O_JOIN; }
 
 JoinOrder::~JoinOrder()
 {
-	if (target) delete target;
+    if (target) delete target;
 }
 
-AnnihilateOrder::AnnihilateOrder()
-{
-	type = O_ANNIHILATE;
-}
+AnnihilateOrder::AnnihilateOrder() { type = O_ANNIHILATE; }
 
-AnnihilateOrder::~AnnihilateOrder()
-{
-}
+AnnihilateOrder::~AnnihilateOrder() {}
 
-SacrificeOrder::SacrificeOrder()
-{
-	type = O_SACRIFICE;
-}
+SacrificeOrder::SacrificeOrder() { type = O_SACRIFICE; }
 
-SacrificeOrder::~SacrificeOrder()
-{
-}
+SacrificeOrder::~SacrificeOrder() {}

--- a/orders.h
+++ b/orders.h
@@ -205,6 +205,7 @@ class BuyOrder : public Order {
 
 		int item;
 		int num;
+		bool repeating;
 };
 
 class SellOrder : public Order {
@@ -214,6 +215,7 @@ class SellOrder : public Order {
 
 		int item;
 		int num;
+		bool repeating;
 };
 
 class AttackOrder : public Order {
@@ -300,7 +302,7 @@ class TurnOrder : public Order {
 	public:
 		TurnOrder();
 		~TurnOrder();
-		int repeating;
+		bool repeating;
 		std::vector<std::string> turnOrders;
 };
 

--- a/orders.h
+++ b/orders.h
@@ -25,91 +25,91 @@
 #ifndef ORDERS_CLASS
 #define ORDERS_CLASS
 
-#include "gamedefs.h"
 #include "astring.h"
+#include "gamedefs.h"
 #include <list>
 
 class UnitId;
 
 enum {
-	O_ATLANTIS,
-	O_END,
-	O_UNIT,
-	O_ADDRESS,
-	O_ADVANCE,
-	O_ANNIHILATE,
-	O_ARMOR,
-	O_ASSASSINATE,
-	O_ATTACK,
-	O_AUTOTAX,
-	O_AVOID,
-	O_BEHIND,
-	O_BUILD,
-	O_BUY,
-	O_CAST,
-	O_CLAIM,
-	O_COMBAT,
-	O_CONSUME,
-	O_DECLARE,
-	O_DESCRIBE,
-	O_DESTROY,
-	O_DISTRIBUTE,
-	O_ENDFORM,
-	O_ENDTURN,
-	O_ENTER,
-	O_ENTERTAIN,
-	O_EVICT,
-	O_EXCHANGE,
-	O_FACTION,
-	O_FIND,
-	O_FORGET,
-	O_FORM,
-	O_GIVE,
-	O_GUARD,
-	O_HOLD,
-	O_IDLE,
-	O_JOIN,
-	O_LEAVE,
-	O_MOVE,
-	O_NAME,
-	O_NOAID,
-	O_NOCROSS,
-	O_NOSPOILS,
-	O_OPTION,
-	O_PASSWORD,
-	O_PILLAGE,
-	O_PREPARE,
-	O_PRODUCE,
-	O_PROMOTE,
-	O_QUIT,
-	O_RESTART,
-	O_REVEAL,
-	O_SACRIFICE,
-	O_SAIL,
-	O_SELL,
-	O_SHARE,
-	O_SHOW,
-	O_SPOILS,
-	O_STEAL,
-	O_STUDY,
-	O_TAKE,
-	O_TAX,
-	O_TEACH,
-	O_TRANSPORT,
-	O_TURN,
-	O_WEAPON,
-	O_WITHDRAW,
-	O_WORK,
-	NORDERS
+    O_ATLANTIS,
+    O_END,
+    O_UNIT,
+    O_ADDRESS,
+    O_ADVANCE,
+    O_ANNIHILATE,
+    O_ARMOR,
+    O_ASSASSINATE,
+    O_ATTACK,
+    O_AUTOTAX,
+    O_AVOID,
+    O_BEHIND,
+    O_BUILD,
+    O_BUY,
+    O_CAST,
+    O_CLAIM,
+    O_COMBAT,
+    O_CONSUME,
+    O_DECLARE,
+    O_DESCRIBE,
+    O_DESTROY,
+    O_DISTRIBUTE,
+    O_ENDFORM,
+    O_ENDTURN,
+    O_ENTER,
+    O_ENTERTAIN,
+    O_EVICT,
+    O_EXCHANGE,
+    O_FACTION,
+    O_FIND,
+    O_FORGET,
+    O_FORM,
+    O_GIVE,
+    O_GUARD,
+    O_HOLD,
+    O_IDLE,
+    O_JOIN,
+    O_LEAVE,
+    O_MOVE,
+    O_NAME,
+    O_NOAID,
+    O_NOCROSS,
+    O_NOSPOILS,
+    O_OPTION,
+    O_PASSWORD,
+    O_PILLAGE,
+    O_PREPARE,
+    O_PRODUCE,
+    O_PROMOTE,
+    O_QUIT,
+    O_RESTART,
+    O_REVEAL,
+    O_SACRIFICE,
+    O_SAIL,
+    O_SELL,
+    O_SHARE,
+    O_SHOW,
+    O_SPOILS,
+    O_STEAL,
+    O_STUDY,
+    O_TAKE,
+    O_TAX,
+    O_TEACH,
+    O_TRANSPORT,
+    O_TURN,
+    O_WEAPON,
+    O_WITHDRAW,
+    O_WORK,
+    NORDERS
 };
 
 enum {
-	M_NONE,
-	M_WALK,
-	M_RIDE,
-	M_FLY,
-	M_SWIM,
-	M_SAIL
+    M_NONE,
+    M_WALK,
+    M_RIDE,
+    M_FLY,
+    M_SWIM,
+    M_SAIL
 };
 
 #define MOVE_PAUSE 97
@@ -118,314 +118,315 @@ enum {
 /* Enter is MOVE_ENTER + num of object */
 #define MOVE_ENTER 100
 
-extern char const ** OrderStrs;
+extern char const **OrderStrs;
 
 int Parse1Order(AString *);
 
 class Order {
-	public:
-		Order();
-		virtual ~Order();
+  public:
+    Order();
+    virtual ~Order();
 
-		int type;
-		int quiet;
+    int type;
+    int quiet;
 };
 
 class MoveDir {
-	public:
-		int dir;
+  public:
+    int dir;
 };
 
 class MoveOrder : public Order {
-	public:
-		MoveOrder();
-		~MoveOrder();
+  public:
+    MoveOrder();
+    ~MoveOrder();
 
-		int advancing;
-		std::list<MoveDir *> dirs;
+    int advancing;
+    std::list<MoveDir *> dirs;
 };
 
 class WithdrawOrder : public Order {
-	public:
-		WithdrawOrder();
-		~WithdrawOrder();
+  public:
+    WithdrawOrder();
+    ~WithdrawOrder();
 
-		int item;
-		int amount;
+    int item;
+    int amount;
 };
 
 class GiveOrder : public Order {
-	public:
-		GiveOrder();
-		~GiveOrder();
+  public:
+    GiveOrder();
+    ~GiveOrder();
 
-		int item;
-		/* if amount == -1, transfer whole unit, -2 means all of item */
-		int amount;
-		int except;
-		int unfinished;
-		int merge;
+    int item;
+    /* if amount == -1, transfer whole unit, -2 means all of item */
+    int amount;
+    int except;
+    int unfinished;
+    int merge;
 
-		UnitId *target;
+    UnitId *target;
 };
 
 class StudyOrder : public Order {
-	public:
-		StudyOrder();
-		~StudyOrder();
+  public:
+    StudyOrder();
+    ~StudyOrder();
 
-		int skill;
-		int days;
-		int level;
+    int skill;
+    int days;
+    int level;
 };
 
 class TeachOrder : public Order {
-	public:
-		TeachOrder();
-		~TeachOrder();
+  public:
+    TeachOrder();
+    ~TeachOrder();
 
-		std::list<UnitId *> targets;
+    std::list<UnitId *> targets;
 };
 
 class ProduceOrder : public Order {
-	public:
-		ProduceOrder();
-		~ProduceOrder();
+  public:
+    ProduceOrder();
+    ~ProduceOrder();
 
-		int item;
-		int skill; /* -1 for none */
-		int productivity;
-		int target;
+    int item;
+    int skill; /* -1 for none */
+    int productivity;
+    int target;
 };
 
 class BuyOrder : public Order {
-	public:
-		BuyOrder();
-		~BuyOrder();
+  public:
+    BuyOrder();
+    ~BuyOrder();
 
-		int item;
-		int num;
-		bool repeating;
+    int item;
+    int num;
+    bool repeating;
 };
 
 class SellOrder : public Order {
-	public:
-		SellOrder();
-		~SellOrder();
+  public:
+    SellOrder();
+    ~SellOrder();
 
-		int item;
-		int num;
-		bool repeating;
+    int item;
+    int num;
+    bool repeating;
 };
 
 class AttackOrder : public Order {
-	public:
-		AttackOrder();
-		~AttackOrder();
+  public:
+    AttackOrder();
+    ~AttackOrder();
 
-		std::list<UnitId *> targets;
+    std::list<UnitId *> targets;
 };
 
 class BuildOrder : public Order {
-	public:
-		BuildOrder();
-		~BuildOrder();
+  public:
+    BuildOrder();
+    ~BuildOrder();
 
-		UnitId * target;
-		int new_building;
-		int needtocomplete;
+    UnitId *target;
+    int new_building;
+    int needtocomplete;
+    bool until_complete;
 };
 
 class SailOrder : public Order {
-	public:
-		SailOrder();
-		~SailOrder();
+  public:
+    SailOrder();
+    ~SailOrder();
 
-		std::list<MoveDir *> dirs;
+    std::list<MoveDir *> dirs;
 };
 
 class FindOrder : public Order {
-	public:
-		FindOrder();
-		~FindOrder();
+  public:
+    FindOrder();
+    ~FindOrder();
 
-		int find;
+    int find;
 };
 
 class StealthOrder : public Order {
-	public:
-		StealthOrder();
-		~StealthOrder();
+  public:
+    StealthOrder();
+    ~StealthOrder();
 
-		UnitId *target;
+    UnitId *target;
 };
 
 class StealOrder : public StealthOrder {
-	public:
-		StealOrder();
-		~StealOrder();
+  public:
+    StealOrder();
+    ~StealOrder();
 
-		int item;
+    int item;
 };
 
 class AssassinateOrder : public StealthOrder {
-	public:
-		AssassinateOrder();
-		~AssassinateOrder();
+  public:
+    AssassinateOrder();
+    ~AssassinateOrder();
 };
 
 class ForgetOrder : public Order {
-	public:
-		ForgetOrder();
-		~ForgetOrder();
+  public:
+    ForgetOrder();
+    ~ForgetOrder();
 
-		int skill;
+    int skill;
 };
 
 // Add class for exchange
 class ExchangeOrder : public Order {
-	public:
-		ExchangeOrder();
-		~ExchangeOrder();
+  public:
+    ExchangeOrder();
+    ~ExchangeOrder();
 
-		int giveItem;
-		int giveAmount;
-		int expectItem;
-		int expectAmount;
+    int giveItem;
+    int giveAmount;
+    int expectItem;
+    int expectAmount;
 
-		int exchangeStatus;
+    int exchangeStatus;
 
-		UnitId *target;
+    UnitId *target;
 };
 
 class TurnOrder : public Order {
-	public:
-		TurnOrder();
-		~TurnOrder();
-		bool repeating;
-		std::vector<std::string> turnOrders;
+  public:
+    TurnOrder();
+    ~TurnOrder();
+    bool repeating;
+    std::vector<std::string> turnOrders;
 };
 
 class CastOrder : public Order {
-	public:
-		CastOrder();
-		~CastOrder();
+  public:
+    CastOrder();
+    ~CastOrder();
 
-		int spell;
-		int level;
+    int spell;
+    int level;
 };
 
 class CastMindOrder : public CastOrder {
-	public:
-		CastMindOrder();
-		~CastMindOrder();
+  public:
+    CastMindOrder();
+    ~CastMindOrder();
 
-		UnitId *id;
+    UnitId *id;
 };
 
 class CastRegionOrder : public CastOrder {
-	public:
-		CastRegionOrder();
-		~CastRegionOrder();
+  public:
+    CastRegionOrder();
+    ~CastRegionOrder();
 
-		int xloc, yloc, zloc;
+    int xloc, yloc, zloc;
 };
 
 class TeleportOrder : public CastRegionOrder {
-	public:
-		TeleportOrder();
-		~TeleportOrder();
+  public:
+    TeleportOrder();
+    ~TeleportOrder();
 
-		int gate;
-		std::list<UnitId *> units;
+    int gate;
+    std::list<UnitId *> units;
 };
 
 class CastIntOrder : public CastOrder {
-	public:
-		CastIntOrder();
-		~CastIntOrder();
+  public:
+    CastIntOrder();
+    ~CastIntOrder();
 
-		int target;
+    int target;
 };
 
 class CastUnitsOrder : public CastOrder {
-	public:
-		CastUnitsOrder();
-		~CastUnitsOrder();
+  public:
+    CastUnitsOrder();
+    ~CastUnitsOrder();
 
-		std::list<UnitId *> units;
+    std::list<UnitId *> units;
 };
 
 class CastTransmuteOrder : public CastOrder {
-	public:
-		CastTransmuteOrder();
-		~CastTransmuteOrder();
+  public:
+    CastTransmuteOrder();
+    ~CastTransmuteOrder();
 
-		int item;
-		int number;
+    int item;
+    int number;
 };
 
 class EvictOrder : public Order {
-	public:
-		EvictOrder();
-		~EvictOrder();
+  public:
+    EvictOrder();
+    ~EvictOrder();
 
-		std::list<UnitId *> targets;
+    std::list<UnitId *> targets;
 };
 
 class IdleOrder : public Order {
-	public:
-		IdleOrder();
-		~IdleOrder();
+  public:
+    IdleOrder();
+    ~IdleOrder();
 };
 
 class TransportOrder : public Order {
-	public:
-		TransportOrder();
-		~TransportOrder();
+  public:
+    TransportOrder();
+    ~TransportOrder();
 
-		int item;
-		// amount == -1 means all available at transport time
-		// any other amount is also checked at transport time
-		int amount;
-		int except;
-		int distance;
+    int item;
+    // amount == -1 means all available at transport time
+    // any other amount is also checked at transport time
+    int amount;
+    int except;
+    int distance;
 
-		enum class TransportPhase {
-			SHIP_TO_QM,
-			INTER_QM_TRANSPORT,
-			DISTRIBUTE_FROM_QM
-		};
-		TransportPhase phase;
+    enum class TransportPhase {
+        SHIP_TO_QM,
+        INTER_QM_TRANSPORT,
+        DISTRIBUTE_FROM_QM
+    };
+    TransportPhase phase;
 
-		UnitId *target;
+    UnitId *target;
 };
 
 class JoinOrder : public Order {
-	public:
-		JoinOrder();
-		~JoinOrder();
+  public:
+    JoinOrder();
+    ~JoinOrder();
 
-		UnitId *target;
-		int overload;
-		int merge;
+    UnitId *target;
+    int overload;
+    int merge;
 };
 
 class AnnihilateOrder : public Order {
-	public:
-		AnnihilateOrder();
-		~AnnihilateOrder();
+  public:
+    AnnihilateOrder();
+    ~AnnihilateOrder();
 
-		int xloc, yloc, zloc;
+    int xloc, yloc, zloc;
 };
 
 class SacrificeOrder : public Order {
-	public:
-		SacrificeOrder();
-		~SacrificeOrder();
+  public:
+    SacrificeOrder();
+    ~SacrificeOrder();
 
-		int item;
-		int amount;
+    int item;
+    int amount;
 };
 
 #endif

--- a/snapshot-tests/rules/basic.html
+++ b/snapshot-tests/rules/basic.html
@@ -4728,6 +4728,15 @@ BEHIND 0
     <h4>
       BUILD HELP [unit]
     </h4>
+    <h4>
+      BUILD COMPLETE
+    </h4>
+    <h4>
+      BUILD [object type] COMPLETE
+    </h4>
+    <h4>
+      BUILD HELP [unit] COMPLETE
+    </h4>
     <p>
       BUILD given with no parameters causes the unit to perform work on an
       unfinished ship it possesses, or on the object that it is currently
@@ -4738,6 +4747,8 @@ BEHIND 0
       This help will be rejected if the unit you are trying to help does not
       consider you to be friendly.
     </p>
+    <p>
+      The variants with COMPLETE instruct the unit to continue with the same build order and repeat it the next month if the built object is not yet complete.  In the case of BUILD [object type] COMPLETE, the unit will remain in the current building if it is not complete, and it is the same type as the one specified, otherwise it will start a new object of the type specified.    </p>
     <p>
       Examples:
     </p>
@@ -4758,6 +4769,15 @@ BUILD Tower
     </p>
     <pre>
 BUILD HELP 5789
+    </pre>
+    <p>
+      To start a new castle and continue building until it is complete.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+BUILD Castle COMPLETE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/fracas.html
+++ b/snapshot-tests/rules/fracas.html
@@ -5105,6 +5105,15 @@ BEHIND 0
     <h4>
       BUILD HELP [unit]
     </h4>
+    <h4>
+      BUILD COMPLETE
+    </h4>
+    <h4>
+      BUILD [object type] COMPLETE
+    </h4>
+    <h4>
+      BUILD HELP [unit] COMPLETE
+    </h4>
     <p>
       BUILD given with no parameters causes the unit to perform work on an
       unfinished ship it possesses, or on the object that it is currently
@@ -5115,6 +5124,8 @@ BEHIND 0
       This help will be rejected if the unit you are trying to help does not
       consider you to be friendly.
     </p>
+    <p>
+      The variants with COMPLETE instruct the unit to continue with the same build order and repeat it the next month if the built object is not yet complete.  In the case of BUILD [object type] COMPLETE, the unit will remain in the current building if it is not complete, and it is the same type as the one specified, otherwise it will start a new object of the type specified.    </p>
     <p>
       Examples:
     </p>
@@ -5135,6 +5146,15 @@ BUILD Tower
     </p>
     <pre>
 BUILD HELP 5789
+    </pre>
+    <p>
+      To start a new castle and continue building until it is complete.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+BUILD Castle COMPLETE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/havilah.html
+++ b/snapshot-tests/rules/havilah.html
@@ -5369,6 +5369,15 @@ BEHIND 0
     <h4>
       BUILD HELP [unit]
     </h4>
+    <h4>
+      BUILD COMPLETE
+    </h4>
+    <h4>
+      BUILD [object type] COMPLETE
+    </h4>
+    <h4>
+      BUILD HELP [unit] COMPLETE
+    </h4>
     <p>
       BUILD given with no parameters causes the unit to perform work on an
       unfinished ship it possesses, or on the object that it is currently
@@ -5379,6 +5388,8 @@ BEHIND 0
       This help will be rejected if the unit you are trying to help does not
       consider you to be friendly.
     </p>
+    <p>
+      The variants with COMPLETE instruct the unit to continue with the same build order and repeat it the next month if the built object is not yet complete.  In the case of BUILD [object type] COMPLETE, the unit will remain in the current building if it is not complete, and it is the same type as the one specified, otherwise it will start a new object of the type specified.    </p>
     <p>
       Examples:
     </p>
@@ -5399,6 +5410,15 @@ BUILD Tower
     </p>
     <pre>
 BUILD HELP 5789
+    </pre>
+    <p>
+      To start a new castle and continue building until it is complete.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+BUILD Castle COMPLETE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/kingdoms.html
+++ b/snapshot-tests/rules/kingdoms.html
@@ -5511,6 +5511,15 @@ BEHIND 0
     <h4>
       BUILD HELP [unit]
     </h4>
+    <h4>
+      BUILD COMPLETE
+    </h4>
+    <h4>
+      BUILD [object type] COMPLETE
+    </h4>
+    <h4>
+      BUILD HELP [unit] COMPLETE
+    </h4>
     <p>
       BUILD given with no parameters causes the unit to perform work on an
       unfinished ship it possesses, or on the object that it is currently
@@ -5521,6 +5530,8 @@ BEHIND 0
       This help will be rejected if the unit you are trying to help does not
       consider you to be friendly.
     </p>
+    <p>
+      The variants with COMPLETE instruct the unit to continue with the same build order and repeat it the next month if the built object is not yet complete.  In the case of BUILD [object type] COMPLETE, the unit will remain in the current building if it is not complete, and it is the same type as the one specified, otherwise it will start a new object of the type specified.    </p>
     <p>
       Examples:
     </p>
@@ -5541,6 +5552,15 @@ BUILD Tower
     </p>
     <pre>
 BUILD HELP 5789
+    </pre>
+    <p>
+      To start a new castle and continue building until it is complete.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+BUILD Castle COMPLETE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/neworigins.html
+++ b/snapshot-tests/rules/neworigins.html
@@ -5542,6 +5542,15 @@ BEHIND 0
     <h4>
       BUILD HELP [unit]
     </h4>
+    <h4>
+      BUILD COMPLETE
+    </h4>
+    <h4>
+      BUILD [object type] COMPLETE
+    </h4>
+    <h4>
+      BUILD HELP [unit] COMPLETE
+    </h4>
     <p>
       BUILD given with no parameters causes the unit to perform work on an
       unfinished ship it possesses, or on the object that it is currently
@@ -5552,6 +5561,8 @@ BEHIND 0
       This help will be rejected if the unit you are trying to help does not
       consider you to be friendly.
     </p>
+    <p>
+      The variants with COMPLETE instruct the unit to continue with the same build order and repeat it the next month if the built object is not yet complete.  In the case of BUILD [object type] COMPLETE, the unit will remain in the current building if it is not complete, and it is the same type as the one specified, otherwise it will start a new object of the type specified.    </p>
     <p>
       Examples:
     </p>
@@ -5572,6 +5583,15 @@ BUILD Tower
     </p>
     <pre>
 BUILD HELP 5789
+    </pre>
+    <p>
+      To start a new castle and continue building until it is complete.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+BUILD Castle COMPLETE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/standard.html
+++ b/snapshot-tests/rules/standard.html
@@ -5410,6 +5410,15 @@ BEHIND 0
     <h4>
       BUILD HELP [unit]
     </h4>
+    <h4>
+      BUILD COMPLETE
+    </h4>
+    <h4>
+      BUILD [object type] COMPLETE
+    </h4>
+    <h4>
+      BUILD HELP [unit] COMPLETE
+    </h4>
     <p>
       BUILD given with no parameters causes the unit to perform work on an
       unfinished ship it possesses, or on the object that it is currently
@@ -5420,6 +5429,8 @@ BEHIND 0
       This help will be rejected if the unit you are trying to help does not
       consider you to be friendly.
     </p>
+    <p>
+      The variants with COMPLETE instruct the unit to continue with the same build order and repeat it the next month if the built object is not yet complete.  In the case of BUILD [object type] COMPLETE, the unit will remain in the current building if it is not complete, and it is the same type as the one specified, otherwise it will start a new object of the type specified.    </p>
     <p>
       Examples:
     </p>
@@ -5440,6 +5451,15 @@ BUILD Tower
     </p>
     <pre>
 BUILD HELP 5789
+    </pre>
+    <p>
+      To start a new castle and continue building until it is complete.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+BUILD Castle COMPLETE
     </pre>
     <div class="rule">
       

--- a/unit.cpp
+++ b/unit.cpp
@@ -86,7 +86,7 @@ Unit::Unit()
 	presentTaxing = 0;
 	presentMonthOrders = nullptr;
 	former = nullptr;
-	format = 0;
+	form_repeated = false;
 	free = 0;
 	practiced = 0;
 	moved = 0;
@@ -131,7 +131,7 @@ Unit::Unit(int seq, Faction *f, int a)
 	presentTaxing = 0;
 	presentMonthOrders = nullptr;
 	former = nullptr;
-	format = 0;
+	form_repeated = false;
 	free = 0;
 	practiced = 0;
 	moved = 0;

--- a/unit.h
+++ b/unit.h
@@ -306,7 +306,7 @@ class Unit {
 		std::list<TransportOrder *>transportorders;
 		JoinOrder *joinorders;
 		Unit *former;
-		int format;
+		bool form_repeated;
 
 		// Used for tracking VISIT quests
 		std::set<std::string> visited;

--- a/unittest/build_order_test.cpp
+++ b/unittest/build_order_test.cpp
@@ -1,0 +1,78 @@
+#include "external/boost/ut.hpp"
+#include "external/nlohmann/json.hpp"
+
+using json = nlohmann::json;
+
+#include "game.h"
+#include "gamedata.h"
+#include "testhelper.hpp"
+
+namespace ut = boost::ut;
+
+using namespace std;
+
+// This suite will test various aspects of the Build Order functionality.
+ut::suite<"Build Order"> build_order_suite = [] {
+    using namespace ut;
+
+    "Build order processes valid input correctly"_test = [] {
+        // validate that all variants of the build order parse correctly.
+        UnitTestHelper helper;
+        helper.initialize_game();
+        helper.setup_turn();
+        string name("Test Faction");
+        Faction *faction = helper.create_faction(name);
+        Unit *leader = helper.get_first_unit(faction);
+        Unit *unit = helper.create_unit(faction, leader->object->region);
+        Unit *unit2 = helper.create_unit(faction, leader->object->region);
+        Unit *unit3 = helper.create_unit(faction, leader->object->region);
+        Unit *unit4 = helper.create_unit(faction, leader->object->region);
+        leader->items.SetNum(I_STONE, 5);
+        unit->items.SetNum(I_STONE, 5);
+        unit2->items.SetNum(I_STONE, 5);
+        unit3->items.SetNum(I_STONE, 5);
+        unit4->items.SetNum(I_STONE, 5);
+        leader->Study(S_BUILDING, 30);
+        unit->Study(S_BUILDING, 30);
+        unit2->Study(S_BUILDING, 30);
+        unit3->Study(S_BUILDING, 30);
+        unit4->Study(S_BUILDING, 30);
+        helper.create_building(leader->object->region, unit4, O_TOWER);
+        unit4->object->incomplete = 10; // Set the tower to be incomplete for testin
+
+        // Test a simple build order
+        stringstream ss;
+        ss << "#atlantis 3 \"mypassword\"\n";
+        ss << "unit 2\n";
+        ss << "build tower\n"; // this should start a new tower and not carry over to the next month orders
+        ss << "unit 3\n";
+        ss << "build help 2\n"; // build help with 1 unit and not carry over.
+        ss << "unit 4\n";
+        ss << "build tower complete\n"; // build a different tower until completion and carry over to next month.
+        ss << "unit 5\n";
+        ss << "build help 4 complete\n"; // this should carry over.
+        ss << "unit 6\n";
+        ss << "build tower complete\n"; // this should continue to build the tower they are in and carry over.
+
+        helper.parse_orders(faction->num, ss, nullptr);
+
+        expect(leader->object->region->objects.size() == 3_ul); // dummy + shaft + tower
+
+        helper.run_month_orders();
+
+        expect(leader->oldorders.empty() == "true"_b);
+        expect(unit->oldorders.empty() == "true"_b);
+        expect(leader->object->incomplete == 8_i);
+        expect(unit2->oldorders.front() == "BUILD Tower COMPLETE");
+        expect(unit3->oldorders.front() == "BUILD HELP 4 COMPLETE");
+        expect(unit2->object->incomplete == 8_i);
+        expect(unit4->oldorders.front() == "BUILD Tower COMPLETE");
+        expect(unit4->object->incomplete == 9_i);
+
+        expect(leader->object->region->objects.size() == 5_ul); // dummy + shaft + 3 towers.
+
+        // Check the messages too
+        expect(faction->errors.size() == 0_ul); // No errors should be reported
+        expect(faction->events.size() == 5_ul); // 5 messages for the builds
+    };
+};

--- a/unittest/market_order_test.cpp
+++ b/unittest/market_order_test.cpp
@@ -1,0 +1,168 @@
+#include "external/boost/ut.hpp"
+
+#include "game.h"
+#include "gamedata.h"
+#include "testhelper.hpp"
+
+// Because boost::ut has it's own concept of events, as does Game, we cannot just use do
+// using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
+// closure to make the user defined literals and all the other niceness available.
+namespace ut = boost::ut;
+
+// This suite will test various aspects of the Faction class in isolation.
+ut::suite<"Market Orders"> market_order_suite = []
+{
+  using namespace ut;
+
+  "Multiple buy orders of same type are merged"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    std::string name = "Test Faction";
+    Faction *faction = helper.create_faction(name);
+    Unit *unit = helper.get_first_unit(faction);
+    unit->items.SetNum(I_SILVER, 8000);
+    ARegion *region = unit->object->region;
+    Unit *unit2 = helper.create_unit(faction, region);
+    unit2->items.SetNum(I_LEADERS, 1);
+    unit2->items.SetNum(I_SILVER, 8000);
+
+    int item_id;
+    int max_amount = 0;
+    int price = 0;
+    for(const auto market : region->markets) {
+      // M_SELL markets are what the region wants people to sell (ie, what it wants to buy).
+      if (market->type == Market::MarketType::M_SELL) continue;
+      // Don't buy men.
+      if (ItemDefs[market->item].type & IT_MAN) continue;
+      // Just for simplicity of testing, make the amount evenly divisible by 4.
+      market->amount = market->amount ? (market->amount / 4) * 4 : 0;
+      // Skip over things that don't have a quantity or price.
+      if (market->amount == 0 || market->price == 0) continue;
+      item_id = market->item;
+      max_amount = market->amount;
+      price = market->price;
+      break;
+    }
+
+    expect(max_amount > 0); // silly, just make sure we have a market item that we found.
+
+    std::stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    for (int i = 0; i < max_amount; i++) {
+      ss << "buy 1 " << ItemDefs[item_id].abr << std::endl;
+      ss << "@buy 1 " << ItemDefs[item_id].abr << std::endl;
+    }
+    ss << "unit 3\n";
+    ss << "buy " << std::to_string(max_amount) << ' ' << ItemDefs[item_id].abr << std::endl;
+    ss << "@buy " << std::to_string(max_amount) << ' ' << ItemDefs[item_id].abr << std::endl;
+
+    // each unit should end up with about 25% for each buy order.
+    helper.parse_orders(faction->num, ss);
+    helper.run_buy_orders();
+
+    expect(unit->items.GetNum(item_id) == (max_amount / 2));
+    expect(unit2->items.GetNum(item_id) == (max_amount / 2));
+
+    expect(faction->errors.size() == 0_ul);
+    expect(faction->events.size() == 4_ul);
+    std::string amt_string = ItemString(item_id, max_amount / 4);
+    expect(faction->events[0].message == "Buys " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[0].unit == unit);
+    expect(faction->events[1].message == "Buys " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[1].unit == unit);
+    expect(faction->events[2].message == "Buys " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[2].unit == unit2);
+    expect(faction->events[3].message == "Buys " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[3].unit == unit2);
+
+    // Check the unit recurring orders.  There should be max_amount/2 recurring buy orders for each.
+    expect(unit->oldorders.size() == static_cast<size_t>(max_amount));
+    expect(unit2->oldorders.size() == 1_ul);
+    // And make sure the orders are buy orders.
+    expect(unit->oldorders.front() == "@buy 1 " + std::string(ItemDefs[item_id].abr));
+    expect(unit->oldorders.back() == "@buy 1 " + std::string(ItemDefs[item_id].abr));
+    expect(unit2->oldorders.front() == "@buy " + std::to_string(max_amount) + ' ' + std::string(ItemDefs[item_id].abr));
+  };
+
+  "Multiple sell orders of same type are merged"_test = []
+  {
+    UnitTestHelper helper;
+    helper.initialize_game();
+    helper.setup_turn();
+
+    std::string name = "Test Faction";
+    Faction *faction = helper.create_faction(name);
+    Unit *unit = helper.get_first_unit(faction);
+    ARegion *region = unit->object->region;
+    Unit *unit2 = helper.create_unit(faction, region);
+    unit2->items.SetNum(I_LEADERS, 1);
+
+    int item_id;
+    int max_amount = 0;
+    int price = 0;
+    for(const auto market : region->markets) {
+      // M_BUY markets are what the region wants people to buy (ie, what it wants to sell).
+      if (market->type == Market::MarketType::M_BUY) continue;
+      // Don't sell men, we don't do slavery.
+      if (ItemDefs[market->item].type & IT_MAN) continue;
+      // Just for simplicity of testing, make the amount evenly divisible by 4.
+      market->amount = market->amount ? (market->amount / 4) * 4 : 0;
+      // Skip over things that don't have a quantity or price.
+      if (market->amount == 0 || market->price == 0) continue;
+      item_id = market->item;
+      max_amount = market->amount;
+      price = market->price;
+      break;
+    }
+
+    // Make sure they have enough to sell the items.
+    unit->items.SetNum(item_id, max_amount * 4);
+    unit2->items.SetNum(item_id, max_amount * 4);
+
+    expect(max_amount > 0); // silly, just make sure we have a market item that we found.
+
+    std::stringstream ss;
+    ss << "#atlantis 3\n";
+    ss << "unit 2\n";
+    for (int i = 0; i < max_amount; i++) {
+      ss << "sell 1 " << ItemDefs[item_id].abr << std::endl;
+      ss << "@sell 1 " << ItemDefs[item_id].abr << std::endl;
+    }
+    ss << "unit 3\n";
+    ss << "sell " << std::to_string(max_amount) << ' ' << ItemDefs[item_id].abr << std::endl;
+    ss << "@sell " << std::to_string(max_amount) << ' ' << ItemDefs[item_id].abr << std::endl;
+
+    // each unit should end up with about 25% for each buy order.
+    helper.parse_orders(faction->num, ss);
+    helper.run_sell_orders();
+
+    expect(unit->items.GetNum(item_id) == (max_amount * 4 - (max_amount / 2)));
+    expect(unit->items.GetNum(I_SILVER) == (max_amount / 2) * price);
+    expect(unit2->items.GetNum(item_id) == (max_amount * 4 - (max_amount / 2)));
+    expect(unit2->items.GetNum(I_SILVER) == (max_amount / 2) * price);
+
+    expect(faction->errors.size() == 0_ul);
+    expect(faction->events.size() == 4_ul);
+    std::string amt_string = ItemString(item_id, max_amount / 4);
+    expect(faction->events[0].message == "Sells " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[0].unit == unit);
+    expect(faction->events[1].message == "Sells " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[1].unit == unit);
+    expect(faction->events[2].message == "Sells " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[2].unit == unit2);
+    expect(faction->events[3].message == "Sells " + amt_string + " at $" + std::to_string(price) + " each.");
+    expect(faction->events[3].unit == unit2);
+
+    // Check the unit recurring orders.  There should be max_amount/2 recurring buy orders for each.
+    expect(unit->oldorders.size() == static_cast<size_t>(max_amount));
+    expect(unit2->oldorders.size() == 1_ul);
+    // And make sure the orders are buy orders.
+    expect(unit->oldorders.front() == "@sell 1 " + std::string(ItemDefs[item_id].abr));
+    expect(unit->oldorders.back() == "@sell 1 " + std::string(ItemDefs[item_id].abr));
+    expect(unit2->oldorders.front() == "@sell " + std::to_string(max_amount) + ' ' + std::string(ItemDefs[item_id].abr));
+  };
+};

--- a/unittest/order_checker_test.cpp
+++ b/unittest/order_checker_test.cpp
@@ -15,55 +15,51 @@ namespace ut = boost::ut;
 using namespace std;
 
 // This suite will test various aspects of the Faction class in isolation.
-ut::suite<"Order Checker"> order_checker_suite = []
-{
-  using namespace ut;
+ut::suite<"Order Checker"> order_checker_suite = [] {
+    using namespace ut;
 
-  "Order checker reports no errors with correct password"_test = []
-  {
-    UnitTestHelper helper;
-    helper.initialize_game();
-    helper.setup_turn();
+    "Order checker reports no errors with correct password"_test = [] {
+        UnitTestHelper helper;
+        helper.initialize_game();
+        helper.setup_turn();
 
-    string name("Test Faction");
-    Faction *faction = helper.create_faction(name);
-    faction->password = new AString("mypassword");
+        string name("Test Faction");
+        Faction *faction = helper.create_faction(name);
+        faction->password = new AString("mypassword");
 
-    stringstream ss;
-    ss << "#atlantis 3 \"mypassword\"\n";
-    ss << "unit 2\n";
-    ss << "work\n";
+        stringstream ss;
+        ss << "#atlantis 3 \"mypassword\"\n";
+        ss << "unit 2\n";
+        ss << "work\n";
 
-    stringstream ss2;
-    OrdersCheck checker(ss2);
+        stringstream ss2;
+        OrdersCheck checker(ss2);
 
-    helper.parse_orders(faction->num, ss, &checker);
-    expect(checker.numerrors == 0_i);
-    expect(ss2.str().find("No errors found.\n") != string::npos);
-  };
+        helper.parse_orders(faction->num, ss, &checker);
+        expect(checker.numerrors == 0_i);
+        expect(ss2.str().find("No errors found.\n") != string::npos);
+    };
 
-  "Order checker reports an error for incorrect password"_test = []
-  {
-    UnitTestHelper helper;
-    helper.initialize_game();
-    helper.setup_turn();
+    "Order checker reports an error for incorrect password"_test = [] {
+        UnitTestHelper helper;
+        helper.initialize_game();
+        helper.setup_turn();
 
-    string name("Test Faction");
-    Faction *faction = helper.create_faction(name);
-    faction->password = new AString("mypassword");
+        string name("Test Faction");
+        Faction *faction = helper.create_faction(name);
+        faction->password = new AString("mypassword");
 
-    stringstream ss;
-    ss << "#atlantis 3 \"wrongpassword\"\n";
-    ss << "unit 2\n";
-    ss << "work\n";
+        stringstream ss;
+        ss << "#atlantis 3 \"wrongpassword\"\n";
+        ss << "unit 2\n";
+        ss << "work\n";
 
-    stringstream ss2;
-    OrdersCheck checker(ss2);
+        stringstream ss2;
+        OrdersCheck checker(ss2);
 
-    helper.parse_orders(faction->num, ss, &checker);
-    expect(checker.numerrors == 1_i);
-    expect(ss2.str().find("No errors found.") == string::npos);
-    expect(ss2.str().find("*** Error: Incorrect password on #atlantis line. ***\n") != string::npos);
-  };
-
+        helper.parse_orders(faction->num, ss, &checker);
+        expect(checker.numerrors == 1_i);
+        expect(ss2.str().find("No errors found.") == string::npos);
+        expect(ss2.str().find("*** Error: Incorrect password on #atlantis line. ***\n") != string::npos);
+    };
 };

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -142,6 +142,14 @@ void UnitTestHelper::run_month_orders() {
     game.RunMonthOrders();
 }
 
+void UnitTestHelper::run_buy_orders() {
+    game.RunBuyOrders();
+}
+
+void UnitTestHelper::run_sell_orders() {
+    game.RunSellOrders();
+}
+
 void UnitTestHelper::run_productions() {
     // This will run the production phase for all regions in the game.
     for (auto &region : game.regions) {

--- a/unittest/testhelper.hpp
+++ b/unittest/testhelper.hpp
@@ -90,6 +90,10 @@ public:
     void run_productions();
     // Run all month orders for all factions.
     void run_month_orders();
+    // Run all buy orders.
+    void run_buy_orders();
+    // Run all sell orders.
+    void run_sell_orders();
 
     // dummy
     int get_seed() { return rng::get_random(10000); };


### PR DESCRIPTION
The BUY/SELL order is a fix to avoid having multiple BUY (or SELL) 1 <ITEM> be more beneficial than issuing a single larger buy order.  Due to how these orders were processed, if a unit issued multiple more than the hex could sell, that unit would have a very strong advantage in whether they won the random selection of if their order was processed.   By merging these orders into single orders for each type of item during turn processing we can a) cap the entire order at the hex limit and b) allocate fairly among multiple buyers.

The BUILD COMPLETE syntax is a QoL improvement requested on the discord.   If a unit issues the order as BUILD <Object> it will always start a new object.  If they issue it as BUILD <Object> COMPLETE they will a) start a new object if they are not in an existing incomplete object of the specified type and b) requeue the order for consecutive turns until the building is complete.   The BUILD HELP <unit> COMPLETE works similarly and just requeues the instruction to assist that unit until the building is complete.  That form is less generally useful imho, but was no additional overhead to include.

Additionally I was trying out a new code-formatting setup and so there are some large changes to a couple of files solely based on that.  Please just ignore whitespace during the diffs as most of the changes will be that.

Lastly, I updated the versions of the ut and json external libraries and provided Makefile targets to help keep them up to date in the future as well as updated the dependencies on the js mapviewer.