### PR TITLE
Fix a few small fleet bugs

### DIFF
--- a/basic/rules.cpp
+++ b/basic/rules.cpp
@@ -253,6 +253,7 @@ static GameDefs g = {
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT,	// REPORT_FORMAT
 	5, // BATTLE_STOP_MOVE_PERCENT
+	GameDefs::NewShipJoinsFleetBehavior::NO_CROSS_JOIN, // NEW_SHIP_JOINS_FLEET_BEHAVIOR
 };
 
 GameDefs *Globals = &g;

--- a/fracas/rules.cpp
+++ b/fracas/rules.cpp
@@ -256,6 +256,7 @@ static GameDefs g = {
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT,	// REPORT_FORMAT
 	5, // BATTLE_STOP_MOVE_PERCENT
+	GameDefs::NewShipJoinsFleetBehavior::NO_CROSS_JOIN, // NEW_SHIP_JOINS_FLEET_BEHAVIOR
 };
 
 GameDefs *Globals = &g;

--- a/gamedefs.h
+++ b/gamedefs.h
@@ -150,7 +150,7 @@ public:
 	int TAX_BONUS_ARMOR;
 	// bonus for manning a fortification
 	int TAX_BONUS_FORT;
-	
+
 	// Options to control who is able to tax
 	enum {
 		TAX_ANYONE = 0x00001,
@@ -376,18 +376,18 @@ public:
 	// Higher values decrease likeliness of settlements
 	// suggested: 0-5
 	int LESS_ARCTIC_TOWNS;
-	
+
 	// Percent of surface level covered with ocean.
 	int OCEAN;
-	
+
 	// Size factor for continent creation.
 	int CONTINENT_SIZE;
-	
+
 	// Granularity of terrain - default setting is 0.
 	// A value of 1 means maximum variability,
 	// higher values = more regular terrain spread
 	int TERRAIN_GRANULARITY;
-	
+
 	// Relative frequency of LAKE terrain
 	int LAKES;
 
@@ -398,7 +398,7 @@ public:
 	//  land mass will be much lower than this percentage)
 	// suggested value: 10, 25, 50+ it's really a matter of taste
 	int ARCHIPELAGO;
-	
+
 	// Reduce/Sever Land Bridges: this is the base chance
 	// that thin strips of land will be 'cut'. This chance is
 	// doubled when a region has exactly four adjacent sea
@@ -585,7 +585,7 @@ public:
 
 	int ARMY_ROUT;
 	int ONLY_ROUT_ONCE;
-	
+
 	// How are fortification bonuses handled?
 	// Setting this flag will enable fort bonuses to be treated as a
 	// modifier to the attack chance rather than a flat bonus to the
@@ -615,7 +615,7 @@ public:
 
 	// Amount of skill improvement when a skill is used
 	int SKILL_PRACTICE_AMOUNT;
-	
+
 	// Experience mandatory: use lower rates of study per
 	// this amount of experience less than current days of
 	// study. Zero disables experience system. (50 is a
@@ -640,7 +640,7 @@ public:
 	// If we are preventing sail through, should we also prevent the 'easy
 	// portage' that the above allows by default?
 	int ALLOW_TRIVIAL_PORTAGE;
-	
+
 	// Non-Perennial Gates: setting this between 1 and 11 will cause gates
 	// to open and close. Gates will be open this number of months per year.
 	// Each gate will have a different period of opening (although they are
@@ -649,7 +649,7 @@ public:
 	// a random jump (stranding the jumper until the gate opens). Nexus
 	// gates (and optionally, starting city gates) are open all the time.
 	int GATES_NOT_PERENNIAL;
-	
+
 	// Are gates in starting cities open all year round? Need only be set
 	// if GATES_NOT_PERENNIAL is selected.
 	int START_GATES_OPEN;
@@ -662,7 +662,7 @@ public:
 	// Transport and related settings
 	enum {
 		ALLOW_TRANSPORT = 0x01, // Do we allow transport/distribute?
-		// actual cost will be * (4 - (level+1)/2), which means that 
+		// actual cost will be * (4 - (level+1)/2), which means that
 		// the cost will be from *1 (at level 5) to *3 (at level 1)
 		QM_AFFECT_COST = 0x02, // QM level affect shipping cost?
 		// actual distance will be NONLOCAL_TRANSPORT + ((level + 1)/3)
@@ -707,10 +707,10 @@ public:
 	// How developed pre-existing towns are at the start of the game
 	// (100 = standard).
 	int TOWN_DEVELOPMENT;
-	
+
 	// Whether you need to be a war faction to have tact-5 leaders
 	int TACTICS_NEEDS_WAR;
-	
+
 	// Whether allies will be affected by the noaid flag
 	int ALLIES_NOAID;
 
@@ -746,7 +746,7 @@ public:
 	// in OVERWHELMING varaible. Setting 0 effectively turns this featur off, but settining it to 2
 	// will mean that one army front line must be 2X larger than other army front line to achieve
 	// overwhelming.
-	// 
+	//
 	// This feature uses ARMY_ROUT setting to determine how size of the army is determined, by hits
 	// or by figure count.
 	int OVERWHELMING;
@@ -771,7 +771,7 @@ public:
 	// Use 0 - when you don't want any world events in the times
 	// Use 1 - when you want them
 	int WORLD_EVENTS;
-	
+
 	// Include faction statistics and ranking on items faction own into the report.
 	// THIS IS BOOL, NOT INT
 	// Use 0 - no stats included
@@ -817,6 +817,16 @@ public:
 	// BATTLE_STOP_MOVE_PERCENT is the percent of losses a unit can take and still move and attack.
 	// 0 means any losses will stop you from moving and attacking.
 	int BATTLE_STOP_MOVE_PERCENT;
+
+	enum class NewShipJoinsFleetBehavior {
+		// The current V7 behavior, no auto join of ships if they have differnet flight types
+		NO_CROSS_JOIN = 0,
+		// Flying ships will always auto join, but non-flying won't auto join flying fleets.
+		ONLY_FLYING_CROSS_JOIN = 1,
+		// All ships will auto join, regardless of flight status
+		ALL_CROSS_JOIN = 2,
+	};
+	NewShipJoinsFleetBehavior NEW_SHIP_JOINS_FLEET_BEHAVIOR;
 };
 
 extern GameDefs *Globals;

--- a/havilah/rules.cpp
+++ b/havilah/rules.cpp
@@ -181,7 +181,7 @@ static GameDefs g = {
 	1,	// LAKES
 	16,	// ARCHIPELAGO
 	30,	// SEVER_LAND_BRIDGES
-	6,	// SEA_LIMIT	
+	6,	// SEA_LIMIT
 	GameDefs::NO_EFFECT,	// LAKE_WAGE_EFFECT
 	0,	// LAKESIDE_IS_COASTAL
 	0,	// ODD_TERRAIN
@@ -261,6 +261,7 @@ static GameDefs g = {
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT, // REPORT_FORMAT
 	5, // BATTLE_STOP_MOVE_PERCENT
+	GameDefs::NewShipJoinsFleetBehavior::NO_CROSS_JOIN, // NEW_SHIP_JOINS_FLEET_BEHAVIOR
 };
 
 GameDefs *Globals = &g;

--- a/kingdoms/rules.cpp
+++ b/kingdoms/rules.cpp
@@ -254,6 +254,7 @@ static GameDefs g = {
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT, // REPORT_FORMAT
 	5, // BATTLE_STOP_MOVE_PERCENT
+	GameDefs::NewShipJoinsFleetBehavior::NO_CROSS_JOIN, // NEW_SHIP_JOINS_FLEET_BEHAVIOR
 };
 
 GameDefs *Globals = &g;

--- a/map_viewer/yarn.lock
+++ b/map_viewer/yarn.lock
@@ -1557,13 +1557,13 @@ __metadata:
   linkType: hard
 
 "cross-spawn@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
+  version: 7.0.5
+  resolution: "cross-spawn@npm:7.0.5"
   dependencies:
     path-key: "npm:^3.1.0"
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
-  checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
+  checksum: 10c0/aa82ce7ac0814a27e6f2b738c5a7cf1fa21a3558a1e42df449fc96541ba3ba731e4d3ecffa4435348808a86212f287c6f20a1ee551ef1ff95d01cfec5f434944
   languageName: node
   linkType: hard
 

--- a/neworigins/rules.cpp
+++ b/neworigins/rules.cpp
@@ -261,6 +261,7 @@ static GameDefs g = {
 	1, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT | GameDefs::REPORT_FORMAT_JSON, // REPORT_FORMAT
 	5, // BATTLE_STOP_MOVE_PERCENT
+	GameDefs::NewShipJoinsFleetBehavior::NO_CROSS_JOIN, // NEW_SHIP_JOINS_FLEET_BEHAVIOR
 };
 
 GameDefs *Globals = &g;

--- a/object.cpp
+++ b/object.cpp
@@ -594,51 +594,24 @@ int Object::SailThroughCheck(int dir)
 			return 1;
 		}
 
+		// Per the rules, you can only exit a region in the direction you came from or an adjacent direction.
 		// fleet can always sail backward
 		if (prevdir == dir) {
 			return 1;
 		}
 
-		// Now we have to check that fleet is not sailing through land
-		{
-			// Fleet is on land, it is not flying and comes from another region
-			// so check that the fleet goes not through land
-			int blocked1 = 0;
-			int blocked2 = 0;
-			int d1 = prevdir;
-			int d2 = dir;
+		// Check the adjacent directions as well. (Note: this code has been broken prior to NewOrigins post-V7 code)
+		// Prior to V7, the code allowed you to sail through land as long as there was a connected stretch of water
+		// between the entry direction and the exit direction.
+		int d1 = (prevdir + 1) % NDIRS;
+		int d2 = (prevdir - 1 + NDIRS) % NDIRS;
 
-			if (d1 > d2) {
-				int tmp = d1;
-				d1 = d2;
-				d2 = tmp;
-			}
-
-			for (int k = d1+1; k < d2; k++) {
-				ARegion *land1 = region->neighbors[k];
-				if ((!land1) ||
-						(TerrainDefs[land1->type].similar_type !=
-						 R_OCEAN))
-					blocked1 = 1;
-			}
-
-			int sides = NDIRS - 2 - (d2 - d1 - 1);
-			for (int l = d2+1; l <= d2 + sides; l++) {
-				int dl = l;
-				if (dl >= NDIRS) dl -= NDIRS;
-				ARegion *land2 = region->neighbors[dl];
-				if ((!land2) ||
-						(TerrainDefs[land2->type].similar_type !=
-						 R_OCEAN))
-					blocked2 = 1;
-			}
-
-			if ((blocked1) && (blocked2)) {
-				return 0;
-			}
-			else {
-				return 1;
-			}
+		// Check those directions and make sure they exist and are water.
+		if (dir == d1 && region->neighbors[d1] && TerrainDefs[region->neighbors[d1]->type].similar_type == R_OCEAN) {
+			return 1;
+		}
+		if (dir == d2 && region->neighbors[d2] && TerrainDefs[region->neighbors[d2]->type].similar_type == R_OCEAN) {
+			return 1;
 		}
 	}
 	return 0;

--- a/standard/rules.cpp
+++ b/standard/rules.cpp
@@ -178,7 +178,7 @@ static GameDefs g = {
 	1, // LAKES
 	16,	// ARCHIPELAGO
 	30, // SEVER_LAND_BRIDGES
-	6, // SEA_LIMIT	
+	6, // SEA_LIMIT
 	GameDefs::NO_EFFECT, // LAKE_WAGE_EFFECT
 	0,	// LAKESIDE_IS_COASTAL
 	0,	// ODD_TERRAIN
@@ -253,6 +253,7 @@ static GameDefs g = {
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT, // REPORT_FORMAT
 	5, // BATTLE_STOP_MOVE_PERCENT
+	GameDefs::NewShipJoinsFleetBehavior::NO_CROSS_JOIN, // NEW_SHIP_JOINS_FLEET_BEHAVIOR
 };
 
 GameDefs *Globals = &g;

--- a/unittest/fleet_build_test.cpp
+++ b/unittest/fleet_build_test.cpp
@@ -1,0 +1,171 @@
+#include "external/boost/ut.hpp"
+#include "external/nlohmann/json.hpp"
+
+using json = nlohmann::json;
+
+#include "game.h"
+#include "gamedata.h"
+#include "testhelper.hpp"
+
+namespace ut = boost::ut;
+
+using namespace std;
+
+// This suite will test various aspects of the Build Order functionality.
+ut::suite<"Fleet Builds"> fleet_build_suite = [] {
+    using namespace ut;
+
+    "No Cross Join behavior"_test = [] {
+        UnitTestHelper helper;
+        helper.initialize_game();
+        helper.setup_turn();
+        string name("Test Faction");
+        Faction *faction = helper.create_faction(name);
+        Unit *leader = helper.get_first_unit(faction);
+        Unit *unit = helper.create_unit(faction, leader->object->region);
+        // Make an adjacent region into water for this test.
+        leader->object->region->neighbors[2]->type = R_OCEAN;
+        leader->items.SetNum(I_LEADERS, 10);
+        leader->items.SetNum(I_WOOD, 20);
+        unit->items.SetNum(I_LEADERS, 10);
+        unit->items.SetNum(I_FLOATER, 20);
+        leader->Study(S_SHIPBUILDING, 4500);
+        unit->Study(S_SHIPBUILDING, 4500);
+
+        // Put the leader in a flying ship.
+        helper.create_fleet(leader->object->region, leader, I_BALLOON, 1);
+        leader->object->flying = true;
+        // Put the unit in a non-flying ship
+        helper.create_fleet(unit->object->region, unit, I_LONGBOAT, 1);
+        unit->object->flying = false;
+
+        // Now set up some build orders
+        stringstream ss;
+        ss << "#atlantis 3 \"mypassword\"\n";
+        ss << "unit 2\n";
+        ss << "build raft\n"; // this should create a new fleet with a raft and move the unit into it.
+        ss << "unit 3\n";
+        ss << "build balloon\n"; // this should create a new fleet with a balloon and move the unit into it.
+        helper.parse_orders(faction->num, ss, nullptr);
+
+        expect(leader->object->region->objects.size() == 4_ul); // dummy + shaft + 2 fleets
+
+        helper.run_month_orders();
+
+        expect(leader->object->region->objects.size() == 6_ul); // dummy + shaft + 4 fleets.
+
+        // Check the messages too
+        expect(faction->errors.size() == 0_ul); // No errors should be reported
+        expect(faction->events.size() == 2_ul); // 2 messages for the builds
+        expect(leader->object->num == 102_i); // leader should be in the new fleet
+        expect(leader->object->ships.front()->type == I_RAFT); // leader should be in a raft
+        expect(unit->object->num == 103_i); // unit should be in the new fleet
+        expect(unit->object->ships.front()->type == I_BALLOON); // unit should be in a balloon
+    };
+
+    "Only Flying Cross Join behavior"_test = [] {
+        UnitTestHelper helper;
+        helper.initialize_game();
+        helper.setup_turn();
+        Globals->NEW_SHIP_JOINS_FLEET_BEHAVIOR  = GameDefs::NewShipJoinsFleetBehavior::ONLY_FLYING_CROSS_JOIN;
+        string name("Test Faction");
+        Faction *faction = helper.create_faction(name);
+        Unit *leader = helper.get_first_unit(faction);
+        Unit *unit = helper.create_unit(faction, leader->object->region);
+        // Make an adjacent region into water for this test.
+        leader->object->region->neighbors[2]->type = R_OCEAN;
+        leader->items.SetNum(I_LEADERS, 10);
+        leader->items.SetNum(I_WOOD, 20);
+        unit->items.SetNum(I_LEADERS, 10);
+        unit->items.SetNum(I_FLOATER, 20);
+        leader->Study(S_SHIPBUILDING, 4500);
+        unit->Study(S_SHIPBUILDING, 4500);
+
+        // Put the leader in a flying ship.
+        helper.create_fleet(leader->object->region, leader, I_BALLOON, 1);
+        leader->object->flying = true;
+        // Put the unit in a non-flying ship
+        helper.create_fleet(unit->object->region, unit, I_LONGBOAT, 1);
+        unit->object->flying = false;
+
+        // Now set up some build orders
+        stringstream ss;
+        ss << "#atlantis 3 \"mypassword\"\n";
+        ss << "unit 2\n";
+        ss << "build raft\n"; // this should create a new fleet with a raft and move the unit into it.
+        ss << "unit 3\n";
+        ss << "build balloon\n"; // this should create join the existing fleet with a balloon.
+        helper.parse_orders(faction->num, ss, nullptr);
+
+        expect(leader->object->region->objects.size() == 4_ul); // dummy + shaft + 2 fleets
+
+        helper.run_month_orders();
+
+        expect(leader->object->region->objects.size() == 5_ul); // dummy + shaft + 3 fleets.
+
+        // Check the messages too
+        expect(faction->errors.size() == 0_ul); // No errors should be reported
+        expect(faction->events.size() == 2_ul); // 2 messages for the builds
+        expect(leader->object->num == 102_i); // leader should be in the new fleet
+        expect(leader->object->ships.front()->type == I_RAFT); // leader should be in a raft
+        expect(unit->object->num == 101_i); // unit should be in the same fleet.
+        expect(unit->object->ships.front()->type == I_LONGBOAT); // fleet should still have a longboat.
+        expect(unit->object->ships.size() == 2_ul); // fleet should have 2 ships.
+        expect(unit->object->ships.GetNum(I_BALLOON) == 1_i); // fleet should have a balloon.
+    };
+
+    "All Cross Join behavior"_test = [] {
+        UnitTestHelper helper;
+        helper.initialize_game();
+        helper.setup_turn();
+        Globals->NEW_SHIP_JOINS_FLEET_BEHAVIOR  = GameDefs::NewShipJoinsFleetBehavior::ALL_CROSS_JOIN;
+        string name("Test Faction");
+        Faction *faction = helper.create_faction(name);
+        Unit *leader = helper.get_first_unit(faction);
+        Unit *unit = helper.create_unit(faction, leader->object->region);
+        // Make an adjacent region into water for this test.
+        leader->object->region->neighbors[2]->type = R_OCEAN;
+        leader->items.SetNum(I_LEADERS, 10);
+        leader->items.SetNum(I_WOOD, 20);
+        unit->items.SetNum(I_LEADERS, 10);
+        unit->items.SetNum(I_FLOATER, 20);
+        leader->Study(S_SHIPBUILDING, 4500);
+        unit->Study(S_SHIPBUILDING, 4500);
+
+        // Put the leader in a flying ship.
+        helper.create_fleet(leader->object->region, leader, I_BALLOON, 1);
+        leader->object->flying = true;
+        // Put the unit in a non-flying ship
+        helper.create_fleet(unit->object->region, unit, I_LONGBOAT, 1);
+        unit->object->flying = false;
+
+        // Now set up some build orders
+        stringstream ss;
+        ss << "#atlantis 3 \"mypassword\"\n";
+        ss << "unit 2\n";
+        ss << "build raft\n"; // this should join the raft to the flying fleet and make it non-flying
+        ss << "unit 3\n";
+        ss << "build balloon\n"; // this should join a balloon to the non-flying fleet.
+        helper.parse_orders(faction->num, ss, nullptr);
+
+        expect(leader->object->region->objects.size() == 4_ul); // dummy + shaft + 2 fleets
+
+        helper.run_month_orders();
+
+        expect(leader->object->region->objects.size() == 4_ul); // dummy + shaft + 2 fleets.
+
+        // Check the messages too
+        expect(faction->errors.size() == 0_ul); // No errors should be reported
+        expect(faction->events.size() == 2_ul); // 2 messages for the builds
+        expect(leader->object->num == 100_i); // leader should be in the new fleet
+        expect(leader->object->ships.front()->type == I_BALLOON); // leaders fleet should have a balloon.
+        expect(leader->object->ships.size() == 2_ul); // leaders fleet should have 2 ships.
+        expect(leader->object->ships.GetNum(I_RAFT) == 1_i); // leaders fleet should have a raft.
+        expect(leader->object->flying == 0_i); // leaders fleet should be non-flying.
+
+        expect(unit->object->num == 101_i); // unit should be in the same fleet.
+        expect(unit->object->ships.front()->type == I_LONGBOAT); // fleet should still have a longboat.
+        expect(unit->object->ships.size() == 2_ul); // fleet should have 2 ships.
+        expect(unit->object->ships.GetNum(I_BALLOON) == 1_i); // fleet should also have a balloon.
+    };
+};

--- a/unittest/rules.cpp
+++ b/unittest/rules.cpp
@@ -253,6 +253,7 @@ static GameDefs g = {
 	0, // HALF_RIDING_BONUS
 	GameDefs::REPORT_FORMAT_TEXT | GameDefs::REPORT_FORMAT_JSON, // REPORT_FORMAT
 	5, // BATTLE_STOP_MOVE_PERCENT
+	GameDefs::NewShipJoinsFleetBehavior::NO_CROSS_JOIN, // NEW_SHIP_JOINS_FLEET_BEHAVIOR
 };
 
 GameDefs *Globals = &g;


### PR DESCRIPTION
This fixes the following bugs
1) a small bug in creation of ships due to my recent build orders change
2) made the behavior for new ships on creation in whether they automatically join the fleet if created by a unit in the fleet
   configurable.
3) Fixed the way that defense in ships was allocated.  Now the best defensive values always go to the first units in the fleet.
4) Fixed a bug in sailing where the rules stated that when PREVENT_SAIL_THROUGH was set, a ship could, during the same turn,
   only sail out of a land hex in the direction it entered, or an adjacent direction.  The previous code allowed sail out in any
   direction that was connected via contiguous water.  This specifically meant that a single hex island would never stop a sailing ship.
5) Another package dependency in the map_viewer needed an upgrade, so I folded that into this PR.