### PR TITLE
Document the IDLE order

### DIFF
--- a/game.h
+++ b/game.h
@@ -93,7 +93,7 @@ public:
 	int ViewMap(const AString &, const AString &);
 	// LLS
 	void UnitFactionMap();
-	int GenRules(const AString &, const AString &, const AString &);
+	int generate_rules(const std::string& rules, const std::string& css, const std::string& intro);
 	std::string FactionTypeDescription(Faction &fac);
 	int Doorders_check(const AString &strOrders, const AString &strCheck);
 

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -355,16 +355,16 @@ string Game::FactionTypeDescription(Faction &fac) {
 }
 
 // LLS - converted HTML tags to lowercase
-int Game::GenRules(const AString &rules, const AString &css, const AString &intro)
+int Game::generate_rules(const std::string& rules, const std::string& css, const std::string& intro)
 {
 	Faction fac;
 	bool found;
 	SkillType *pS;
 
-	ofstream f(rules.const_str(), ios::out|ios::trunc);
+	ofstream f(rules, ios::out|ios::trunc);
 	if (!f.is_open()) return 0;
 
-	ifstream introf(intro.const_str(), ios::in);
+	ifstream introf(intro, ios::in);
 	if (!introf.is_open()) return 0;
 
 	// Perform a number of ruleset sanity checks to make sure we don't output rules for something which is not truly
@@ -634,6 +634,7 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << enclose("li", true) << url("#give", "give") << '\n' << enclose("li", false);
 	f << enclose("li", true) << url("#guard", "guard") << '\n' << enclose("li", false);
 	f << enclose("li", true) << url("#hold", "hold") << '\n' << enclose("li", false);
+	f << enclose("li", true) << url("#idle", "idle") << '\n' << enclose("li", false);
 	f << enclose("li", true) << url("#join", "join") << '\n' << enclose("li", false);
 	f << enclose("li", true) << url("#leave", "leave") << '\n' << enclose("li", false);
 	f << enclose("li", true) << url("#move", "move") << '\n' << enclose("li", false);
@@ -4285,6 +4286,17 @@ int Game::GenRules(const AString &rules, const AString &css, const AString &intr
 	f << example_start("Instruct the unit to avoid combat in other regions.")
 	  << "HOLD 1\n"
 	  << example_end();
+
+	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
+	f << anchor("idle") << '\n';
+	f << enclose("h4", true) << "IDLE\n" << enclose("h4", false);
+	f << enclose("p", true) << "IDLE instructs the issuing unit to do nothing for the entire month.\n"
+	  << enclose("p", false);
+	f << enclose("p", true) << "Example:\n" << enclose("p", false);
+	f << example_start("Instruct the unit to admire the scenery.")
+	  << "IDLE\n"
+	  << example_end();
+
 
 	f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
 	f << anchor("join") << '\n';

--- a/main.cpp
+++ b/main.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 				usage();
 				break;
 			}
-			if (!game.GenRules(argv[4], argv[3], argv[2])) {
+			if (!game.generate_rules(argv[4], argv[3], argv[2])) {
 				Awrite("Unable to generate rules!");
 				break;
 			}

--- a/snapshot-tests/rules/basic.html
+++ b/snapshot-tests/rules/basic.html
@@ -310,6 +310,9 @@
             <a href="#hold">hold</a>
           </li>
           <li>
+            <a href="#idle">idle</a>
+          </li>
+          <li>
             <a href="#join">join</a>
           </li>
           <li>
@@ -5524,6 +5527,28 @@ GUARD 1
     </p>
     <pre>
 HOLD 1
+    </pre>
+    <div class="rule">
+      
+    </div>
+    <a name="idle"></a>
+    <h4>
+      IDLE
+    </h4>
+    <p>
+      IDLE instructs the issuing unit to do nothing for the entire month.
+    </p>
+    <p>
+      Example:
+    </p>
+    <p>
+      Instruct the unit to admire the scenery.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+IDLE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/fracas.html
+++ b/snapshot-tests/rules/fracas.html
@@ -316,6 +316,9 @@
             <a href="#hold">hold</a>
           </li>
           <li>
+            <a href="#idle">idle</a>
+          </li>
+          <li>
             <a href="#join">join</a>
           </li>
           <li>
@@ -5879,6 +5882,28 @@ GUARD 1
     </p>
     <pre>
 HOLD 1
+    </pre>
+    <div class="rule">
+      
+    </div>
+    <a name="idle"></a>
+    <h4>
+      IDLE
+    </h4>
+    <p>
+      IDLE instructs the issuing unit to do nothing for the entire month.
+    </p>
+    <p>
+      Example:
+    </p>
+    <p>
+      Instruct the unit to admire the scenery.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+IDLE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/havilah.html
+++ b/snapshot-tests/rules/havilah.html
@@ -319,6 +319,9 @@
             <a href="#hold">hold</a>
           </li>
           <li>
+            <a href="#idle">idle</a>
+          </li>
+          <li>
             <a href="#join">join</a>
           </li>
           <li>
@@ -6168,6 +6171,28 @@ GUARD 1
     </p>
     <pre>
 HOLD 1
+    </pre>
+    <div class="rule">
+      
+    </div>
+    <a name="idle"></a>
+    <h4>
+      IDLE
+    </h4>
+    <p>
+      IDLE instructs the issuing unit to do nothing for the entire month.
+    </p>
+    <p>
+      Example:
+    </p>
+    <p>
+      Instruct the unit to admire the scenery.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+IDLE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/kingdoms.html
+++ b/snapshot-tests/rules/kingdoms.html
@@ -316,6 +316,9 @@
             <a href="#hold">hold</a>
           </li>
           <li>
+            <a href="#idle">idle</a>
+          </li>
+          <li>
             <a href="#join">join</a>
           </li>
           <li>
@@ -6307,6 +6310,28 @@ GUARD 1
     </p>
     <pre>
 HOLD 1
+    </pre>
+    <div class="rule">
+      
+    </div>
+    <a name="idle"></a>
+    <h4>
+      IDLE
+    </h4>
+    <p>
+      IDLE instructs the issuing unit to do nothing for the entire month.
+    </p>
+    <p>
+      Example:
+    </p>
+    <p>
+      Instruct the unit to admire the scenery.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+IDLE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/neworigins.html
+++ b/snapshot-tests/rules/neworigins.html
@@ -325,6 +325,9 @@
             <a href="#hold">hold</a>
           </li>
           <li>
+            <a href="#idle">idle</a>
+          </li>
+          <li>
             <a href="#join">join</a>
           </li>
           <li>
@@ -6315,6 +6318,28 @@ GUARD 1
     </p>
     <pre>
 HOLD 1
+    </pre>
+    <div class="rule">
+      
+    </div>
+    <a name="idle"></a>
+    <h4>
+      IDLE
+    </h4>
+    <p>
+      IDLE instructs the issuing unit to do nothing for the entire month.
+    </p>
+    <p>
+      Example:
+    </p>
+    <p>
+      Instruct the unit to admire the scenery.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+IDLE
     </pre>
     <div class="rule">
       

--- a/snapshot-tests/rules/standard.html
+++ b/snapshot-tests/rules/standard.html
@@ -316,6 +316,9 @@
             <a href="#hold">hold</a>
           </li>
           <li>
+            <a href="#idle">idle</a>
+          </li>
+          <li>
             <a href="#join">join</a>
           </li>
           <li>
@@ -6206,6 +6209,28 @@ GUARD 1
     </p>
     <pre>
 HOLD 1
+    </pre>
+    <div class="rule">
+      
+    </div>
+    <a name="idle"></a>
+    <h4>
+      IDLE
+    </h4>
+    <p>
+      IDLE instructs the issuing unit to do nothing for the entire month.
+    </p>
+    <p>
+      Example:
+    </p>
+    <p>
+      Instruct the unit to admire the scenery.
+    </p>
+    <p>
+      
+    </p>
+    <pre>
+IDLE
     </pre>
     <div class="rule">
       


### PR DESCRIPTION
This order was added to the game 20+ years ago (at the same time that the quartermaster code was originally added) but was never documented.

It's a very simple order, it just tells the unit to do nothing (not even work) for the entire month.