### PR TITLE
Fix code so that non-ring maps work

### DIFF
--- a/runorders.cpp
+++ b/runorders.cpp
@@ -3157,6 +3157,7 @@ void Game::RunAnnihilateOrders() {
     // Annihilate will destroy the target hex and all surrounding hexes.  Already annihilated regions cannot be
     // annihilated again.
     int max_annihilates = rulesetSpecificData.value("allowed_annihilates", 1);
+    bool random_annihilates = rulesetSpecificData.value("random_annihilates", false);
 
     for(const auto r : regions) {
         for(const auto obj : r->objects) {
@@ -3217,7 +3218,7 @@ void Game::RunAnnihilateOrders() {
                 }
 
                 // If the unit didn't use all their annihilates, and we should do random ones, do them.
-                while(allowed_annihilates > 0) {
+                while(random_annihilates && allowed_annihilates > 0) {
                     // pick a random region region to annihilate
                     ARegionArray *level = nullptr;
 


### PR DESCRIPTION
This fixes the setup code slightly so that if you (as someone did in testing) created a non-ring level, with no altars then they don't get blocked out of the center.

Really the ring level creation should also be NO7 specific and such, but for now this makes it so we don't break things for NO8, etc when we turn off annihilation.