### PR TITLE
GCC 11 doesn't support ranges properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ map_viewer/.pnp.*
 map_viewer/.parcel-cache
 map_viewer/dist
 !*.[ch]
-.gdb_history
 !*.[ch]pp
 .gdb_history
 /out

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include "skills.h"
 #include "gamedata.h"
 #include "strings_util.hpp"
+#include "string_filters.hpp"
 
 void usage()
 {

--- a/skillshows.cpp
+++ b/skillshows.cpp
@@ -2,6 +2,7 @@
 #include "items.h"
 #include "object.h"
 #include "gamedata.h"
+#include "string_filters.hpp"
 
 static const std::string describe_escape_parameters(int item)
 {

--- a/string_filters.hpp
+++ b/string_filters.hpp
@@ -128,15 +128,14 @@ inline constexpr lowercase_t lowercase{};
  */
 struct canonicalize_t {
     std::string process(const std::string& str) const {
+        std::vector<std::string> processed_words;
 #ifdef CPP20_RANGES_ARE_BROKEN
         /** gcc 11 doesn't like the range solution, ergo this hack */
-        std::vector<std::string> words;
         std::istringstream f(str);
         std::string s;
         while (std::getline(f, s, ' ')) {
-            words.push_back(s | capitalize);
+            processed_words.push_back(s | capitalize);
         }
-        return strings::join(words, "_");
 #else
         auto parts_view = str
             | std::views::split(std::string_view{" "}) // Split by space
@@ -145,12 +144,11 @@ struct canonicalize_t {
                 return str | capitalize;
             });
 
-        std::vector<std::string> processed_words;
         // Efficiently copy the view elements into the vector
         std::ranges::copy(parts_view, std::back_inserter(processed_words));
+#endif
         // Join the processed words with an underscore
         return strings::join(processed_words, "_");
-#endif
     }
 
     std::string operator()(const std::string& str) const { return process(str); }

--- a/string_filters.hpp
+++ b/string_filters.hpp
@@ -149,11 +149,9 @@ struct canonicalize_t {
             if (!s.empty()) {
                 s.append(1, '_');
             }
-            // s += w | capitalize;
-            s.append(1, (char) std::toupper(w[0]));
-            s.append(w.begin() + 1, w.end());
+            s += w | capitalize;
         }
-        return str; // WRONG!
+        return str;
 #else
         auto parts_view = str
             | std::views::split(std::string_view{" "}) // Split by space

--- a/string_filters.hpp
+++ b/string_filters.hpp
@@ -1,7 +1,14 @@
 #pragma once
 #ifndef STRING_FILTERS_HPP
 #define STRING_FILTERS_HPP
-
+#ifndef WITHOUT_VIEWS
+#ifdef __GNUC__
+#if __GNUC_PREREQ(12,0)
+#else
+#define WITHOUT_VIEWS
+#endif
+#endif
+#endif
 #include "strings_util.hpp"
 
 #include <algorithm>

--- a/string_filters.hpp
+++ b/string_filters.hpp
@@ -12,6 +12,8 @@
 #include <ranges>
 #include <string_view>
 #include "strings_util.hpp"
+#include <sstream>
+#include <iostream>
 
 namespace filter {
 
@@ -124,6 +126,7 @@ inline constexpr lowercase_t lowercase{};
  */
 struct canonicalize_t {
     std::string process(const std::string& str) const {
+#ifdef _MSC_VER
         auto parts_view = str
             | std::views::split(std::string_view{" "}) // Split by space
             | std::views::transform([](auto&& subrange) {
@@ -136,6 +139,25 @@ struct canonicalize_t {
         std::ranges::copy(parts_view, std::back_inserter(processed_words));
         // Join the processed words with an underscore
         return strings::join(processed_words, "_");
+#else
+        /** FIXME: gcc doesn't like the range solution, ergo this hack */
+        std::vector<std::string> words;
+        std::istringstream f(str);
+        std::string s;
+        while (std::getline(f, s, ' ')) {
+            words.push_back(s);
+        }
+        s.clear();
+        for(const std::string& w : words) {
+            if (!s.empty()) {
+                s.append(1, '_');
+            }
+            // s += w | capitalize;
+            s.append(1, (char) std::toupper(w[0]));
+            s.append(w.begin() + 1, w.end());
+        }
+        return str; // WRONG!
+#endif
     }
 
     std::string operator()(const std::string& str) const { return process(str); }

--- a/string_filters.hpp
+++ b/string_filters.hpp
@@ -2,11 +2,8 @@
 #ifndef STRING_FILTERS_HPP
 #define STRING_FILTERS_HPP
 #ifndef WITHOUT_VIEWS
-#ifdef __GNUC__
-#if __GNUC_PREREQ(12,0)
-#else
+#if !((defined __GNUC__ && __GNUC__ >= 12) || defined __clang__)
 #define WITHOUT_VIEWS
-#endif
 #endif
 #endif
 #include "strings_util.hpp"

--- a/string_parser.hpp
+++ b/string_parser.hpp
@@ -12,7 +12,6 @@
 #include <iostream>
 
 #include "strings_util.hpp"
-#include "string_filters.hpp"
 
 namespace parser {
 
@@ -55,7 +54,7 @@ std::istream& operator>>(std::istream& is, string_parser& parser);
 
 class string_parser {
 public:
-    constexpr string_parser() noexcept : data_{}, pos_{0} {}
+    string_parser() noexcept : data_{}, pos_{0} {}
     explicit string_parser(const std::string& input) noexcept : data_{input}, pos_{0} {}
     explicit string_parser(std::string&& input) noexcept : data_{std::move(input)}, pos_{0} {}
     explicit string_parser(const char* input) noexcept : data_{input ? input : ""}, pos_{0} {}
@@ -71,11 +70,11 @@ public:
 
     // Utility methods
     void strip_white() noexcept;
-    constexpr void reset() noexcept { pos_ = 0; }
+    void reset() noexcept { pos_ = 0; }
     [[nodiscard]] std::string str() const noexcept { return data_.substr(pos_); }
     [[nodiscard]] const std::string& original() const noexcept { return data_; }
-    [[nodiscard]] constexpr bool empty() const noexcept { return pos_ >= data_.length(); }
-    [[nodiscard]] constexpr size_t length() const noexcept { return pos_ < data_.length() ? data_.length() - pos_ : 0; }
+    [[nodiscard]] bool empty() const noexcept { return pos_ >= data_.length(); }
+    [[nodiscard]] size_t length() const noexcept { return pos_ < data_.length() ? data_.length() - pos_ : 0; }
 
     void set_data(const std::string& input) noexcept { data_ = input; pos_ = 0; }
 

--- a/unittest/string_filters_test.cpp
+++ b/unittest/string_filters_test.cpp
@@ -1,3 +1,5 @@
+#include "string_filters.hpp"
+
 #include "external/boost/ut.hpp"
 #include "external/nlohmann/json.hpp"
 
@@ -5,7 +7,6 @@ using json = nlohmann::json;
 
 #include <string>
 #include "testhelper.hpp"
-#include "string_filters.hpp"
 
 // Because boost::ut has it's own concept of events, as does Game, we cannot just use
 // using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
@@ -18,6 +19,22 @@ using namespace std;
 ut::suite<"StringFilters"> string_filters_suite = []
 {
   using namespace ut;
+
+  "canonicalize adds underscores"_test = []
+  {
+    string input = "Hello Beautiful World";
+    string expected = "Hello_Beautiful_World";
+    string actual = filter::canonicalize(input);
+    expect(actual == expected);
+  };
+
+  "canonicalize adds capitals"_test = []
+  {
+    string input = "hello world";
+    string expected = "Hello_World";
+    string actual = filter::canonicalize(input);
+    expect(actual == expected);
+  };
 
   "legal_characters removes illegal characters"_test = []
   {

--- a/unittest/string_filters_without_ranges_test.cpp
+++ b/unittest/string_filters_without_ranges_test.cpp
@@ -1,0 +1,41 @@
+#ifndef CPP20_RANGES_ARE_BROKEN
+#define CPP20_RANGES_ARE_BROKEN
+#endif
+#include "string_filters.hpp"
+
+#include "external/boost/ut.hpp"
+#include "external/nlohmann/json.hpp"
+
+using json = nlohmann::json;
+
+#include <string>
+#include "testhelper.hpp"
+
+// Because boost::ut has it's own concept of events, as does Game, we cannot just use
+// using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
+// closure to make the user defined literals and all the other niceness available.
+namespace ut = boost::ut;
+
+using namespace std;
+
+// This suite tests the string_filters.hpp utility functions for string manipulation
+ut::suite<"StringFiltersWithoutRanges"> string_filters_without_ranges_suite = []
+{
+  using namespace ut;
+
+  "canonicalize adds underscores"_test = []
+  {
+    string input = "Hello Beautiful World";
+    string expected = "Hello_Beautiful_World";
+    string actual = filter::canonicalize(input);
+    expect(actual == expected);
+  };
+
+  "canonicalize adds capitals"_test = []
+  {
+    string input = "hello world";
+    string expected = "Hello_World";
+    string actual = filter::canonicalize(input);
+    expect(actual == expected);
+  };
+};


### PR DESCRIPTION
On Ubuntu 22.04, the default GNU C compiler version is gcc-11. It doesn't understand the code in string_filters.cpp, because the ranges library wasn't fully implemented at the time.

It's possible to achieve the same result with a slightly less efficient implementation, which I'm only enabling if required.

It would of course be nicer to detect the compiler and set -DWITHOUT_VIEWS in the Makefile, not in string_filters.hpp, but I don't know how to do that.
