### PR TITLE
Add CMake project definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ map_viewer/.pnp.*
 map_viewer/.parcel-cache
 map_viewer/dist
 !*.[ch]
+.gdb_history
 !*.[ch]pp
-/out/
 /out/
 /.vs

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ map_viewer/.parcel-cache
 map_viewer/dist
 !*.[ch]
 !*.[ch]pp
+/out/
+/out/
+/.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.31)
+project(atlantis CXX)
+set(CMAKE_CXX_STANDARD 20)
+
+add_library(engine
+    aregion.cpp
+    army.cpp
+    astring.cpp
+    battle.cpp
+    economy.cpp
+    edit.cpp
+    faction.cpp
+    game.cpp
+    gamedata.cpp
+    gamedefs.cpp
+    genrules.cpp
+    items.cpp
+    main.cpp
+    market.cpp
+    modify.cpp
+    monthorders.cpp
+    npc.cpp
+    object.cpp
+    orders.cpp
+    parseorders.cpp
+    production.cpp
+    quests.cpp
+    runorders.cpp
+    skills.cpp
+    skillshows.cpp
+    specials.cpp
+    spells.cpp
+    unit.cpp
+    events.cpp
+    events-battle.cpp
+    events-assassination.cpp
+    mapgen.cpp
+    simplex.cpp
+    namegen.cpp
+    indenter.cpp
+    text_report_generator.cpp
+)
+add_executable(basic
+    basic/extra.cpp
+    basic/map.cpp
+    basic/monsters.cpp
+    basic/rules.cpp
+    basic/world.cpp
+)
+target_link_libraries(basic engine)
+target_include_directories(basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,20 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.22)
 project(atlantis CXX)
 set(CMAKE_CXX_STANDARD 20)
+
+if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+    # add_compile_options(-Wsign-compare -Wall -Werror -Wno-switch -Wno-unknown-pragmas -Wstrict-prototypes -Wpointer-arith -Wno-char-subscripts -Wno-long-long)
+    add_compile_options(-Wall -Werror -pedantic)
+elseif(MSVC)
+    add_compile_options(/WX /MP /FC)
+    set(CMAKE_EXE_LINKER_FLAGS_DEBUG
+        "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:libc.lib /NODEFAULTLIB:libcmt.lib /NODEFAULTLIB:libcd.lib /NODEFAULTLIB:libcmtd.lib /NODEFAULTLIB:msvcrt.lib")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE
+        "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libc.lib /NODEFAULTLIB:libcmt.lib /NODEFAULTLIB:libcd.lib /NODEFAULTLIB:libcmtd.lib /NODEFAULTLIB:msvcrtd.lib")
+else()
+    message(STATUS "unknown compiler ${CMAKE_C_COMPILER_ID}")
+endif()
+
 
 add_library(engine
     aregion.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,23 @@ add_library(engine
     indenter.cpp
     text_report_generator.cpp
 )
-add_executable(basic
-    basic/extra.cpp
-    basic/map.cpp
-    basic/monsters.cpp
-    basic/rules.cpp
-    basic/world.cpp
+
+macro(add_game GAME)
+add_executable(${GAME}
+    ${GAME}/extra.cpp
+    ${GAME}/map.cpp
+    ${GAME}/monsters.cpp
+    ${GAME}/rules.cpp
+    ${GAME}/world.cpp
 )
-target_link_libraries(basic engine)
-target_include_directories(basic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(${GAME} engine)
+target_include_directories(${GAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+endmacro()
+
+add_game(basic)
+add_game(fracas)
+add_game(havilah)
+add_game(kingdoms)
+add_game(neworigins)
+add_game(standard)
+add_game(unittest)

--- a/build
+++ b/build
@@ -1,0 +1,2 @@
+cd out ; make "$@"
+

--- a/configure
+++ b/configure
@@ -1,0 +1,1 @@
+cmake -DCMAKE_BUILD_TYPE=Debug -B out .


### PR DESCRIPTION
[CMake](https://cmake.org) is much easier to maintain than hand-crafted Makefiles, and has IDE support in Visual Studio and VS Code. This change doesn't replace the existing Makefile builds, but adds CMake as an option.

Accepting this PR would make life a lot easier for me!