### PR TITLE
Two small changes

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -2570,11 +2570,11 @@ void makeRivers(
     logger::write("Distances from water body to water body");
 
     size_t sz = waterBodies.size();
-    int distances[sz][sz];
-    for (size_t i = 0; i < sz; i++) {
-        for (size_t j = 0; j < sz; j++) {
-            distances[i][j] = INT32_MAX;
-        }
+    std::vector<std::vector<int>> distances;
+    distances.resize(sz);
+    for (auto &row : distances) {
+        row.resize(sz);
+        std::fill(row.begin(), row.end(), INT32_MAX);
     }
 
     for (const auto& water : waterBodies) {
@@ -3521,7 +3521,11 @@ void ARegionList::AddHistoricalBuildings(ARegionArray* arr, const int w, const i
     });
 
     size_t sz = cities.size();
-    int distances[sz][sz];
+
+    std::vector<std::vector<int>> distances;
+    distances.resize(sz);
+    for (auto &row : distances) { row.resize(sz); }
+
     for (size_t i = 0; i < sz; i++) {
         for (size_t j = i + 1; j < sz; j++) {
             if (i == j) {

--- a/game.h
+++ b/game.h
@@ -292,7 +292,7 @@ private:
 
     // control the random number seed used for new game generation (by default it uses the existing
     // seedrandomrandom function) which uses the current time.
-    std::function<void()> init_random_seed; // = static_cast<void(*)()>(&rng::seed_random);
+    std::function<void()> init_random_seed = static_cast<void(*)()>(&rng::seed_random);
 
     enum
     {


### PR DESCRIPTION
1) Fix a function that I had commented during testing of the new rng
   code and never uncommented.  Having it commented meant that new
   world generation failed as it's the default random seed function.
   This fix has already been applied to the v8 stable branch.
2) Reimplement the changes Enno provided in PR #273 to remove a
   dynamically sized array.  While this works in C98 and is defined,
   it's not part of the c++ standard, and thus it's compiler dependant.
   Replaced with using std::vectors which is my preference over C-style
   arrays anyway.