### PR TITLE
Fix unit test small bugs.

### DIFF
--- a/unittest/n07_victory_test.cpp
+++ b/unittest/n07_victory_test.cpp
@@ -710,7 +710,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     expect(event["category"] == "annihilate");
     expect(event["unit"]["number"] == 3_i);
     event = events[5];
-    expect(event["message"] == "desert (1,3) in Testing Wilds has been utterly annihilated.");
+    expect(event["message"] == "cavern (0,0,underworld) in Testing Wilds has been utterly annihilated.");
     expect(event["category"] == "annihilate");
 
 

--- a/unittest/testhelper.cpp
+++ b/unittest/testhelper.cpp
@@ -5,13 +5,6 @@
 #include "testhelper.hpp"
 
 UnitTestHelper::UnitTestHelper() {
-    rng::seed_random(0xdeadbeef); // Seed the random number generator with a fixed value for reproducibility.
-
-    // std::cerr << "Seeding random number generator with 0xdeadbeef" << std::endl;
-    // for (int i = 0; i < 10; i++) {
-    //     std::cerr << "rng::generator() = " << rng::generator()() << std::endl;
-    // }
-
     game.init_random_seed = []() { rng::seed_random(0xdeadbeef); };
 
     // Set up the output streams to capture the output.

--- a/unittest/unit_test_helper_test.cpp
+++ b/unittest/unit_test_helper_test.cpp
@@ -45,7 +45,7 @@ ut::suite<"UnitTestHelper"> unit_test_helper_suite = []
     // initialize the game which will generate a small bit of output
     helper.initialize_game();
     auto seed = helper.get_seed();
-    expect(seed == 3901_i);
+    expect(seed == 108_i);
   };
 
   "UnitTestHelper can set basic skills"_test = []

--- a/unittest/world.cpp
+++ b/unittest/world.cpp
@@ -9,7 +9,7 @@ const std::string& AGetNameString(int name) {
 
 void Game::CreateWorld() {
     logger::write("Creating world");
-    regions.create_levels(1);
+    regions.create_levels(2);
     // because of the way regions are numbered, if you want 4 hexes you need a height of 4 and a width of 2.
     regions.create_surface_level(0, 2, 4, "");
     // Make an underworld level


### PR DESCRIPTION
This subsumes and includes Enno's changes from PR #279 and on top of that fixes some other small nits.

1) it removes some unneeded debug code that had been left around.
2) it fixes the 2 unit tests which changed due to fixing the actual level count to be correct.