### PR TITLE
Remove some unneeded std::string calls

### DIFF
--- a/army.cpp
+++ b/army.cpp
@@ -1276,19 +1276,19 @@ const WeaponBonusMalus* GetWeaponBonusMalus(const WeaponType& attacker, const We
         const WeaponBonusMalus *bm = &attacker.bonusMalus[i];
         if (!bm->weaponAbbr) continue;
 
-        if (std::string(bm->weaponAbbr) == target.abbr) {
+        if (target.abbr == bm->weaponAbbr) {
             return bm;
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 int Army::DoAnAttack(Battle * b, char const *special, int numAttacks, int attackType,
         int attackLevel, int flags, int weaponClass, char const *effect,
         int mountBonus, Soldier *attacker, Army *attackers, bool attackbehind, int attackDamage)
 {
-    auto sp = special != NULL ? find_special(special) : std::nullopt;
+    auto sp = special != nullptr ? find_special(special) : std::nullopt;
 
     // if special is defined then it is magical attack and not attack by the physical weapon soldier has
     int weaponIndex = !sp ? attacker->weapon : -1;
@@ -1328,7 +1328,7 @@ int Army::DoAnAttack(Battle * b, char const *special, int numAttacks, int attack
                 return -1;
             }
 
-            if (effect != NULL && !combat) {
+            if (effect != nullptr && !combat) {
                 /* We got through shield... if killing spell, destroy shield */
                 std::erase(shields, hi);
             }

--- a/battle.cpp
+++ b/battle.cpp
@@ -7,8 +7,6 @@
 #include "items.h"
 #include "strings_util.hpp"
 
-using namespace std;
-
 enum class StatsCategory {
     ROUND,
     BATTLE
@@ -78,12 +76,15 @@ void WriteStats(Battle &battle, Army &army, StatsCategory category) {
             int succeeded = att.attacks - att.failed;
             int reachedTarget = succeeded - att.missed;
 
-            s += ", attacked " + to_string(succeeded) + " of " + to_string(att.attacks) + " " + strings::plural(att.attacks, "time", "times");
-            s += ", " + to_string(reachedTarget) + " successful " + strings::plural(reachedTarget, "attack", "attacks");
-            s += ", " + to_string(att.blocked) + " blocked by armor";
-            s += ", " + to_string(att.hit) + " " + strings::plural(att.killed, "hit", "hits");
-            s += ", " + to_string(att.damage) + " total damage";
-            s += ", and killed " + to_string(att.killed)  + " " + strings::plural(att.killed, "enemy", "enemies") + ".";
+            s += ", attacked " + std::to_string(succeeded) + " of " + std::to_string(att.attacks) + " " +
+                strings::plural(att.attacks, "time", "times");
+            s += ", " + std::to_string(reachedTarget) + " successful " +
+                strings::plural(reachedTarget, "attack", "attacks");
+            s += ", " + std::to_string(att.blocked) + " blocked by armor";
+            s += ", " + std::to_string(att.hit) + " " + strings::plural(att.killed, "hit", "hits");
+            s += ", " + std::to_string(att.damage) + " total damage";
+            s += ", and killed " + std::to_string(att.killed)  + " " +
+                strings::plural(att.killed, "enemy", "enemies") + ".";
 
             battle.AddLine(s);
         }
@@ -239,7 +240,7 @@ void Battle::DoAttack(int round, Soldier *a, Army *attackers, Army *def,
 void Battle::NormalRound(int round,Army * a,Army * b)
 {
     /* Write round header */
-    AddLine("Round " + to_string(round) + ":");
+    AddLine("Round " + std::to_string(round) + ":");
 
     if (a->tactics_bonus > b->tactics_bonus) {
         AddLine(a->leader->name + " tactics bonus " + std::to_string(a->tactics_bonus) + ".");
@@ -322,7 +323,7 @@ void Battle::NormalRound(int round,Army * a,Army * b)
 
 void Battle::GetSpoils(std::list<Location *>& losers, ItemList& spoils, int ass)
 {
-    string quest_rewards;
+    std::string quest_rewards;
 
     for(const auto l : losers) {
         Unit *u = l->unit;

--- a/events-assassination.cpp
+++ b/events-assassination.cpp
@@ -7,8 +7,6 @@
 #include "rng.hpp"
 #include "string_filters.hpp"
 
-using namespace std;
-
 AssassinationFact::AssassinationFact() {
     this->location = EventLocation();
 }
@@ -17,7 +15,7 @@ AssassinationFact::~AssassinationFact() {
 
 }
 
-const vector<string> SENTIMENT = {
+const std::vector<std::string> SENTIMENT = {
     "fearsome",
     "alarming",
     "horrifying",
@@ -25,14 +23,14 @@ const vector<string> SENTIMENT = {
     "worrisome"
 };
 
-const vector<string> LOCALS = {
+const std::vector<std::string> LOCALS = {
     "citizens",
     "inhabitants",
     "locals",
     "commoners"
 };
 
-const vector<string> FEELING = {
+const std::vector<std::string> FEELING = {
     "shocked",
     "stunned",
     "horrified",

--- a/events-battle.cpp
+++ b/events-battle.cpp
@@ -6,7 +6,6 @@
 #include <stdexcept>
 #include <sstream>
 #include "strings_util.hpp"
-using namespace std;
 
 BattleFact::BattleFact() {
     this->attacker = BattleSide();
@@ -19,7 +18,7 @@ BattleFact::~BattleFact() {
 
 }
 
-const vector<string> ADJECTIVE = {
+const std::vector<std::string> ADJECTIVE = {
     "A few",
     "Handful",
     "Some",
@@ -30,7 +29,7 @@ const vector<string> ADJECTIVE = {
     "Dozen"
 };
 
-const vector<string> REPORTING = {
+const std::vector<std::string> REPORTING = {
     "traders",
     "merchants",
     "pilgrims",
@@ -47,7 +46,7 @@ const vector<string> REPORTING = {
     "commoners"
 };
 
-const vector<string> CHANNEL = {
+const std::vector<std::string> CHANNEL = {
     "are talking",
     "are rumoring",
     "are worried",
@@ -56,7 +55,7 @@ const vector<string> CHANNEL = {
     "are discussing"
 };
 
-const vector<string> BATTLE = {
+const std::vector<std::string> BATTLE = {
     "an encounter",
     "a fight",
     "a conflict",
@@ -65,7 +64,7 @@ const vector<string> BATTLE = {
     "the battle"
 };
 
-const vector<string> ONE_SIDE = {
+const std::vector<std::string> ONE_SIDE = {
     "a faction",
     "a rebels",
     "a villans",
@@ -73,14 +72,14 @@ const vector<string> ONE_SIDE = {
     "a partisans"
 };
 
-const vector<string> TWO_SIDES = {
+const std::vector<std::string> TWO_SIDES = {
     "hostile forces",
     "enemies",
     "two armies",
     "combatants"
 };
 
-const vector<string> HUNTERS = {
+const std::vector<std::string> HUNTERS = {
     "adventurers",
     "hunters",
     "daredevils",
@@ -88,14 +87,14 @@ const vector<string> HUNTERS = {
     "rangers"
 };
 
-const vector<string> SIZES = {
+const std::vector<std::string> SIZES = {
     "couple",
     "few",
     "several",
     "many"
 };
 
-const vector<string> ACTION_SUCCESS = {
+const std::vector<std::string> ACTION_SUCCESS = {
     "slew",
     "murdered",
     "killed",
@@ -108,14 +107,14 @@ const vector<string> ACTION_SUCCESS = {
     "expelled"
 };
 
-const vector<string> ACTION_ATTEMPT = {
+const std::vector<std::string> ACTION_ATTEMPT = {
     "attacked",
     "ambushed",
     "tried to cast out",
     "tried to expel"
 };
 
-const vector<string> FEAR_NOUN = {
+const std::vector<std::string> FEAR_NOUN = {
     "terror",
     "fear",
     "anxiety",
@@ -123,7 +122,7 @@ const vector<string> FEAR_NOUN = {
     "dread"
 };
 
-string relativeSize(int size) {
+std::string relativeSize(int size) {
     if (size < 3) return SIZES[0];
     if (size < 12) return SIZES[1];
     if (size < 24) return SIZES[2];

--- a/game.cpp
+++ b/game.cpp
@@ -22,8 +22,6 @@
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
 
-using namespace std;
-
 Game::Game()
 {
     gameStatus = GAME_STATUS_UNINIT;
@@ -106,7 +104,7 @@ std::string Game::GetXtraMap(ARegion *reg, int type)
     return " ";
 }
 
-void Game::WriteSurfaceMap(ostream& f, ARegionArray *pArr, int type)
+void Game::WriteSurfaceMap(std::ostream& f, ARegionArray *pArr, int type)
 {
     ARegion *reg;
     int yy = 0;
@@ -135,7 +133,7 @@ void Game::WriteSurfaceMap(ostream& f, ARegionArray *pArr, int type)
     f << "\n";
 }
 
-void Game::WriteUnderworldMap(ostream& f, ARegionArray *pArr, int type)
+void Game::WriteUnderworldMap(std::ostream& f, ARegionArray *pArr, int type)
 {
     ARegion *reg, *reg2;
     int xx = 0;
@@ -252,7 +250,7 @@ int Game::view_map(const std::string& typestr,const std::string& mapfile)
                 }
                 continue;
             };
-            string label = (pArr->strName.empty() ? "surface" : (pArr->strName + to_string(i-1)));
+            std::string label = (pArr->strName.empty() ? "surface" : (pArr->strName + std::to_string(i-1)));
             worldmap[label] = json::array();
 
             for (int y = 0; y < pArr->y; y++) {
@@ -364,7 +362,7 @@ int Game::OpenGame()
     //
     // The order here must match the order in SaveGame
     //
-    ifstream f("game.in", ios::in);
+    std::ifstream f("game.in", std::ios::in);
     if (!f.is_open()) return(0);
     //
     // Read in Globals
@@ -474,7 +472,7 @@ int Game::OpenGame()
 
 int Game::SaveGame()
 {
-    ofstream f("game.out", ios::out|ios::ate);
+    std::ofstream f("game.out", std::ios::out|std::ios::ate);
     if (!f.is_open()) return(0);
 
     //
@@ -523,7 +521,7 @@ void Game::DummyGame()
 
 int Game::WritePlayers()
 {
-    ofstream f("players.out", ios::out|ios::ate);
+    std::ofstream f("players.out", std::ios::out|std::ios::ate);
     if (!f.is_open()) return(0);
 
     f << PLAYERS_FIRST_LINE << "\n";
@@ -548,7 +546,7 @@ int Game::WritePlayers()
 
 bool Game::ReadPlayers()
 {
-    ifstream f("players.in", ios::in);
+    std::ifstream f("players.in", std::ios::in);
     if (!f.is_open()) return(0);
 
     parser::string_parser parser;
@@ -715,7 +713,7 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
     if (token == "Name:") {
         std::string name = parser.str();
         if (!name.empty()) {
-            if (new_player) name += " (" + to_string(fac->num) + ")";
+            if (new_player) name += " (" + std::to_string(fac->num) + ")";
             fac->set_name(name, false);
         }
         return true;
@@ -755,7 +753,7 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
 
     if (token == "Reward:") {
         int amt = parser.get_token().get_number().value_or(0);
-        fac->event("Reward of " + to_string(amt) + " silver.", "reward");
+        fac->event("Reward of " + std::to_string(amt) + " silver.", "reward");
         fac->unclaimed += amt;
         return true;
     }
@@ -790,10 +788,10 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
         }
         if (!reg) {
             std::string str = "Invalid Loc: ";
-            str += x ? to_string(x.value()) + ", " : "missing x-coord, ";
-            str += y ? to_string(y.value()) + ", " : "missing y-coord, ";
-            str += z ? to_string(z.value()) : "missing z-coord";
-            str += " in faction " + to_string(fac->num);
+            str += x ? std::to_string(x.value()) + ", " : "missing x-coord, ";
+            str += y ? std::to_string(y.value()) + ", " : "missing y-coord, ";
+            str += z ? std::to_string(z.value()) : "missing z-coord";
+            str += " in faction " + std::to_string(fac->num);
             logger::write(str);
         }
         fac->pReg = reg;
@@ -804,12 +802,12 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
         // Creates a new unit in the location specified by a Loc: line
         // with a gm_alias of whatever is after the NewUnit: tag.
         if (!fac->pReg) {
-            logger::write("NewUnit is not valid without a Loc: for faction "+ to_string(fac->num));
+            logger::write("NewUnit is not valid without a Loc: for faction "+ std::to_string(fac->num));
             return true;
         }
         int val = parser.get_token().get_number().value_or(0);
         if (!val) {
-            logger::write("NewUnit: must be followed by an alias in faction " + to_string(fac->num));
+            logger::write("NewUnit: must be followed by an alias in faction " + std::to_string(fac->num));
             return true;
         }
         Unit *u = GetNewUnit(fac);
@@ -822,29 +820,30 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
     if (token == "Item:") {
         std::string alias = parser.get_token().get_string();
         if (alias.empty()) {
-            logger::write("Item: needs to specify a unit in faction " + to_string(fac->num));
+            logger::write("Item: needs to specify a unit in faction " + std::to_string(fac->num));
             return true;
         }
         Unit *u = parse_gm_unit(alias, fac);
         if (!u) {
-            logger::write("Item: needs to specify a unit in faction " + to_string(fac->num));
+            logger::write("Item: needs to specify a unit in faction " + std::to_string(fac->num));
             return true;
         }
         if (u->faction->num != fac->num) {
-            logger::write("Item: unit "+ to_string(u->num) + " doesn't belong to faction " + to_string(fac->num));
+            logger::write("Item: unit "+ std::to_string(u->num) + " doesn't belong to faction " +
+                std::to_string(fac->num));
             return true;
         }
 
         auto val = parser.get_token().get_number();
         if (!val) {
-            logger::write("Must specify a number of items to give for Item: in faction " + to_string(fac->num));
+            logger::write("Must specify a number of items to give for Item: in faction " + std::to_string(fac->num));
             return true;
         }
 
         token = parser.get_token();
         int it = parse_all_items(token);
         if (it == -1) {
-            logger::write("Must specify a valid item to give for Item: in faction " + to_string(fac->num));
+            logger::write("Must specify a valid item to give for Item: in faction " + std::to_string(fac->num));
             return true;
         }
 
@@ -860,29 +859,30 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
     if (token == "Skill:") {
         std::string alias = parser.get_token().get_string();
         if (alias.empty()) {
-            logger::write("Skill: needs to specify a unit in faction " + to_string(fac->num));
+            logger::write("Skill: needs to specify a unit in faction " + std::to_string(fac->num));
             return true;
         }
         Unit *u = parse_gm_unit(alias, fac);
         if (!u) {
-            logger::write("Skill: needs to specify a unit in faction " + to_string(fac->num));
+            logger::write("Skill: needs to specify a unit in faction " + std::to_string(fac->num));
             return true;
         }
         if (u->faction->num != fac->num) {
-            logger::write("Item: unit "+ to_string(u->num) + " doesn't belong to faction " + to_string(fac->num));
+            logger::write("Item: unit "+ std::to_string(u->num) + " doesn't belong to faction " +
+                std::to_string(fac->num));
             return true;
         }
 
         token = parser.get_token();
         int sk = parse_skill(token);
         if (sk == -1) {
-            logger::write("Must specify a valid skill for Skill: in faction " + to_string(fac->num));
+            logger::write("Must specify a valid skill for Skill: in faction " + std::to_string(fac->num));
             return true;
         }
 
         int days = parser.get_token().get_number().value_or(0) * u->GetMen();
         if (!days) {
-            logger::write("Must specify a days for Skill: in faction " + to_string(fac->num));
+            logger::write("Must specify a days for Skill: in faction " + std::to_string(fac->num));
             return true;
         }
 
@@ -895,7 +895,7 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
             fac->shows.push_back({ .skill = sk, .level = lvl });
         }
         if (!u->gm_alias) {
-            u->event("Is taught " + to_string(days) + " days of " + SkillStrs(sk) + " by the gods.", "gm_gift");
+            u->event("Is taught " + std::to_string(days) + " days of " + SkillStrs(sk) + " by the gods.", "gm_gift");
         }
         /* This is NOT quite the same, but the gods are more powerful than mere mortals */
         int mage = (SkillDefs[sk].flags & SkillType::MAGIC);
@@ -914,11 +914,12 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
         //Not quit so, handle it as a unit order
         Unit *u = parse_gm_unit(alias, fac);
         if (!u) {
-            logger::write("Order: needs to specify a unit in faction " + to_string(fac->num));
+            logger::write("Order: needs to specify a unit in faction " + std::to_string(fac->num));
             return true;
         }
         if (u->faction->num != fac->num) {
-            logger::write("Order: unit "+ to_string(u->num) + " doesn't belong to faction " + to_string(fac->num));
+            logger::write("Order: unit "+ std::to_string(u->num) + " doesn't belong to faction " +
+                std::to_string(fac->num));
             return true;
         }
 
@@ -926,12 +927,12 @@ bool Game::ReadPlayersLine(parser::token& token, parser::string_parser& parser, 
         bool repeating = parser.get_at();
         token = parser.get_token();
         if (!token) {
-            logger::write("Order: must provide unit order for faction "+ to_string(fac->num));
+            logger::write("Order: must provide unit order for faction "+ std::to_string(fac->num));
             return true;
         }
         int o = Parse1Order(token);
         if (o == -1 || o == O_ATLANTIS || o == O_END || o == O_UNIT || o == O_FORM || o == O_ENDFORM) {
-            logger::write("Order: invalid order given for faction "+ to_string(fac->num));
+            logger::write("Order: invalid order given for faction "+ std::to_string(fac->num));
             return true;
         }
         if (repeating) {
@@ -1067,7 +1068,7 @@ void Game::ReadOrders()
             std::string str = "orders.";
             str += std::to_string(fac->num);
 
-            ifstream file(str, ios::in);
+            std::ifstream file(str, std::ios::in);
             if(file.is_open()) {
                 ParseOrders(fac->num, file, nullptr);
                 file.close();
@@ -1124,8 +1125,8 @@ void Game::WriteReport()
     }
 
     for(const auto fac : factions) {
-        string report_file = "report." + to_string(fac->num);
-        string template_file = "template." + to_string(fac->num);
+        std::string report_file = "report." + std::to_string(fac->num);
+        std::string template_file = "template." + std::to_string(fac->num);
 
         if (!fac->is_npc || fac->gets_gm_report(this)) {
             // Generate the report in JSON format and then write it to whatever formats we want
@@ -1135,7 +1136,7 @@ void Game::WriteReport()
             fac->build_json_report(json_report, this, citems);
 
             if (Globals->REPORT_FORMAT & GameDefs::REPORT_FORMAT_JSON) {
-                ofstream jsonf(report_file + ".json", ios::out | ios::ate);
+                std::ofstream jsonf(report_file + ".json", std::ios::out | std::ios::ate);
                 if (jsonf.is_open()) {
                     jsonf << json_report.dump(2);
                 }
@@ -1143,13 +1144,13 @@ void Game::WriteReport()
 
             if (Globals->REPORT_FORMAT & GameDefs::REPORT_FORMAT_TEXT) {
                 TextReportGenerator text_report;
-                ofstream f(report_file, ios::out | ios::ate);
+                std::ofstream f(report_file, std::ios::out | std::ios::ate);
                 if (f.is_open()) {
                     text_report.output(f, json_report, show_region_depth);
                 }
                 if (!fac->is_npc && fac->temformat != TEMPLATE_OFF) {
                     // even factions which get a gm report do not get a template.
-                    ofstream f(template_file, ios::out | ios::ate);
+                    std::ofstream f(template_file, std::ios::out | std::ios::ate);
                     if (f.is_open()) {
                         text_report.output_template(f, json_report, fac->temformat, show_region_depth);
                     }
@@ -1318,7 +1319,7 @@ void Game::UnitFactionMap()
     Unit *u;
 
     logger::write("Opening units.txt");
-    ofstream f("units.txt", ios::out|ios::ate);
+    std::ofstream f("units.txt", std::ios::out|std::ios::ate);
     if (!f.is_open()) {
         logger::write("Couldn't open file!");
         return;
@@ -1330,7 +1331,7 @@ void Game::UnitFactionMap()
             logger::write("doesn't exist");
         } else {
             logger::write(std::to_string(i) + ":" + std::to_string(u->faction->num));
-            f << i << ":" << u->faction->num << endl;
+            f << i << ":" << u->faction->num << std::endl;
         }
     }
 }
@@ -1504,7 +1505,7 @@ void Game::MonsterCheck(ARegion *r, Unit *u)
     std::string tmp;
     int skill;
     int linked = 0;
-    map< int, int > chances;
+    std::map< int, int > chances;
 
     if (u->type != U_WMON) {
 
@@ -1528,7 +1529,7 @@ void Game::MonsterCheck(ARegion *r, Unit *u)
                     if (u->GetSkill(skill) >= ItemDefs[i->type].esc_val) losses = 0;
                 }
                 if (losses) {
-                    string temp = item_string(i->type, losses) + strings::plural(losses, " decay", " decays") +
+                    std::string temp = item_string(i->type, losses) + strings::plural(losses, " decay", " decays") +
                         " into nothingness.";
                     u->event(temp, "decay");
                     u->items.SetNum(i->type,i->num - losses);
@@ -1922,7 +1923,7 @@ void Game::write_times_article(std::string article)
 {
     std::string fname;
 
-    do { fname = "times." + std::to_string(rng::get_random(10000)); } while (filesystem::exists(fname));
+    do { fname = "times." + std::to_string(rng::get_random(10000)); } while (std::filesystem::exists(fname));
     std::ofstream f(fname, std::ios::out | std::ios::trunc);
     if (f.is_open()) {
         f << indent::wrap(78,70,0) << article << '\n';

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -11,13 +11,11 @@
 #include <ranges>
 #include <vector>
 
-using namespace std;
-
-struct tag_data { string tag; bool open;};
-static inline tag_data enclose(string tag, bool open) { return { tag, open }; }
+struct tag_data { std::string tag; bool open;};
+static inline tag_data enclose(std::string tag, bool open) { return { tag, open }; }
 
 template<typename _CharT, typename _Traits>
-static inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& os, tag_data data) {
+static inline std::basic_ostream<_CharT, _Traits>& operator<<(std::basic_ostream<_CharT, _Traits>& os, tag_data data) {
     if (!data.open) os << indent::decr;
     os << "<" << (data.open ? "" : "/") << data.tag << ">" << '\n';
     if (data.open) os << indent::incr;
@@ -28,7 +26,7 @@ struct pre_data { bool open;};
 static inline pre_data pre(bool open) { return { open }; }
 
 template<typename _CharT, typename _Traits>
-static inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& os, pre_data data) {
+static inline std::basic_ostream<_CharT, _Traits>& operator<<(std::basic_ostream<_CharT, _Traits>& os, pre_data data) {
     if (!data.open) {
         os << indent::pop_indent();
         os << indent::wrap(78, 70, 0);
@@ -41,16 +39,16 @@ static inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _
     return os;
 }
 
-static inline string class_tag(string tag, string css_class) { return tag + " class=\"" + css_class + "\""; }
-static inline string anchor(string name) { return "<a name=\"" + name + "\"></a>"; }
-static inline string url(string href, string text) { return "<a href=\"" + href + "\">" + text + "</a>"; }
+static inline std::string class_tag(std::string tag, std::string css_class) { return tag + " class=\"" + css_class + "\""; }
+static inline std::string anchor(std::string name) { return "<a name=\"" + name + "\"></a>"; }
+static inline std::string url(std::string href, std::string text) { return "<a href=\"" + href + "\">" + text + "</a>"; }
 
-struct example_data { string header; bool start; };
-static inline example_data example_start(string header) { return { header, true }; }
+struct example_data { std::string header; bool start; };
+static inline example_data example_start(std::string header) { return { header, true }; }
 static inline example_data example_end() { return { "", false }; }
 
 template<typename _CharT, typename _Traits>
-static inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& os, example_data data) {
+static inline std::basic_ostream<_CharT, _Traits>& operator<<(std::basic_ostream<_CharT, _Traits>& os, example_data data) {
     if (data.start) {
         os << enclose("p", true) << data.header << '\n' << enclose("p", false);
         os << enclose("p", true) << '\n' << enclose("p", false);
@@ -63,13 +61,13 @@ static inline basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _
     return os;
 }
 
-static string inline num_to_word(int n) {
-    static string vals [] = {
+static std::string inline num_to_word(int n) {
+    static std::string vals [] = {
         "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
         "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen",
         "seventeen", "eighteen", "nineteen", "twenty"
     };
-    if (n > 20 || n < 0) return to_string(n);
+    if (n > 20 || n < 0) return std::to_string(n);
     return vals[n];
 }
 
@@ -80,15 +78,15 @@ static int study_rate(int days, int exp) {
     return sl.GetStudyRate(1, 1);
 }
 
-inline string faction_point_usage(Faction& fac, bool verbose=true) {
-    string seperator;
-    stringstream ss;
+inline std::string faction_point_usage(Faction& fac, bool verbose=true) {
+    std::string seperator;
+    std::stringstream ss;
     for (const auto& [key, value] : fac.type) {
         if (value <= 0) continue;
         if (verbose) {
-            ss << seperator << to_string(value) << " " << strings::plural(value, "point", "points") << " on " << key;
+            ss << seperator << std::to_string(value) << " " << strings::plural(value, "point", "points") << " on " << key;
         } else {
-            ss << seperator << key << " " << to_string(value);
+            ss << seperator << key << " " << std::to_string(value);
         }
         seperator = (verbose ? ", " : " ");
     }
@@ -97,8 +95,8 @@ inline string faction_point_usage(Faction& fac, bool verbose=true) {
 
 // This function is an utter abomination capable of summoning eldritch horrors from beyond.   This needs to
 // be cleaned up, but that can wait until after this pass.  It's just too messy to fix right now.
-inline string unit_tax_description() {
-    string temp, temp2, temp3;
+inline std::string unit_tax_description() {
+    std::string temp, temp2, temp3;
     int prev = 0, hold = 0;
 
     if (Globals->WHO_CAN_TAX &
@@ -166,7 +164,7 @@ inline string unit_tax_description() {
         else if (Globals->WHO_CAN_TAX &
                 (GameDefs::TAX_MELEE_WEAPON_AND_MATCHING_SKILL |
                     GameDefs::TAX_BOW_SKILL_AND_MATCHING_WEAPON)) {
-            string temp3;
+            std::string temp3;
             int prev2 = 0, hold2 = 0;
             if (Globals->WHO_CAN_TAX &
                     GameDefs::TAX_MELEE_WEAPON_AND_MATCHING_SKILL) {
@@ -225,7 +223,7 @@ inline string unit_tax_description() {
                 temp2 += "who knows a combat spell";
         } else {
             int hold2 = 0, prev2 = 0;
-            string temp3;
+            std::string temp3;
             if (Globals->WHO_CAN_TAX & GameDefs::TAX_MAGE_COMBAT_SPELL)
                 temp2 += "whose combat spell ";
             else
@@ -277,8 +275,8 @@ inline string unit_tax_description() {
     return temp;
 }
 
-string Game::FactionTypeDescription(Faction &fac) {
-    stringstream buffer;
+std::string Game::FactionTypeDescription(Faction &fac) {
+    std::stringstream buffer;
     std::vector<std::string> missingTypes;
     std::vector<std::string> types;
 
@@ -338,10 +336,10 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
     Faction fac;
     bool found;
 
-    ofstream f(rules, ios::out|ios::trunc);
+    std::ofstream f(rules, std::ios::out|std::ios::trunc);
     if (!f.is_open()) return 0;
 
-    ifstream introf(intro, ios::in);
+    std::ifstream introf(intro, std::ios::in);
     if (!introf.is_open()) return 0;
 
     // Perform a number of ruleset sanity checks to make sure we don't output rules for something which is not truly
@@ -400,7 +398,7 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
     f << indent::wrap(78, 70, 0);
 
     f << "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
-      << endl;
+      << std::endl;
     f << enclose("html", true);
 
     f << enclose("head", true);
@@ -421,7 +419,7 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
     f << enclose("h2", true) << "Copyright 1993 by Russell Wallace\n" << enclose("h2", false);
     auto t = time(nullptr);
     auto tm = *localtime(&t);
-    f << enclose("h3", true) << "Last Change: " << put_time(&tm, "%B %d, %Y") << '\n' << enclose("h3", false);
+    f << enclose("h3", true) << "Last Change: " << std::put_time(&tm, "%B %d, %Y") << '\n' << enclose("h3", false);
     f << enclose("center", false);
 
     f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
@@ -540,9 +538,9 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
     f << enclose("li", true) << url("#magic_usingmagic", "Using Magic") << '\n' << enclose("li", false);
     f << enclose("li", true) << url("#magic_incombat", "Mages In Combat") << '\n' << enclose("li", false);
     if (app_exist) {
-        string ref = "#magic_" + Globals->APPRENTICE_NAME + "s";
-        string text = Globals->APPRENTICE_NAME + "s";
-        text[0] = toupper(text[0]);
+        std::string ref = "#magic_" + Globals->APPRENTICE_NAME + "s";
+        std::string text = Globals->APPRENTICE_NAME + "s";
+        text[0] = std::toupper(text[0]);
         f << enclose("li", true) << url(ref, text) << '\n' << enclose("li", false);
     }
     f << enclose("ul", false);
@@ -708,8 +706,8 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
     f << enclose(class_tag("div", "rule"), true) << '\n' << enclose("div", false);
     f << enclose("h2", true) << "Introduction\n" << enclose("h2", false);
     while (!introf.eof()) {
-        string in;
-        getline(introf >> ws, in);
+        std::string in;
+        std::getline(introf >> std::ws, in);
         f << in << '\n';
     }
 
@@ -846,27 +844,27 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
 
             for (auto &fp : *FactionTypes) {
                 if (fp == F_WAR) {
-                    f << enclose("td align=\"center\" nowrap", true) << to_string(AllowedTaxes(&fac))
-                      << (Globals->TACTICS_NEEDS_WAR ? " / " + to_string(AllowedTacticians(&fac)) : "")
+                    f << enclose("td align=\"center\" nowrap", true) << std::to_string(AllowedTaxes(&fac))
+                      << (Globals->TACTICS_NEEDS_WAR ? " / " + std::to_string(AllowedTacticians(&fac)) : "")
                       << '\n' << enclose("td", false);
                 }
 
                 if (fp == F_TRADE) {
-                    f << enclose("td align=\"center\" nowrap", true) << to_string(AllowedTrades(&fac))
-                      << (qm_exist ? " / " + to_string(AllowedQuarterMasters(&fac)) : "")
+                    f << enclose("td align=\"center\" nowrap", true) << std::to_string(AllowedTrades(&fac))
+                      << (qm_exist ? " / " + std::to_string(AllowedQuarterMasters(&fac)) : "")
                       << '\n' << enclose("td", false);
                 }
 
                 if (fp == F_MARTIAL) {
-                    f << enclose("td align=\"center\" nowrap", true) << to_string(AllowedMartial(&fac))
-                      << (qm_exist ? " / " + to_string(AllowedQuarterMasters(&fac)) : "")
-                      << (Globals->TACTICS_NEEDS_WAR ? " / " + to_string(AllowedTacticians(&fac)) : "")
+                    f << enclose("td align=\"center\" nowrap", true) << std::to_string(AllowedMartial(&fac))
+                      << (qm_exist ? " / " + std::to_string(AllowedQuarterMasters(&fac)) : "")
+                      << (Globals->TACTICS_NEEDS_WAR ? " / " + std::to_string(AllowedTacticians(&fac)) : "")
                       << '\n' << enclose("td", false);
                 }
 
                 if (fp == F_MAGIC) {
-                    f << enclose("td align=\"center\" nowrap", true) << to_string(AllowedMages(&fac))
-                      << (app_exist ? " / " + to_string(AllowedApprentices(&fac)) : "")
+                    f << enclose("td align=\"center\" nowrap", true) << std::to_string(AllowedMages(&fac))
+                      << (app_exist ? " / " + std::to_string(AllowedApprentices(&fac)) : "")
                       << '\n' << enclose("td", false);
                 }
             }
@@ -1295,7 +1293,7 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
               << '\n' << enclose("p", false);
 
             int num_methods = 1 + (Globals->GATES_EXIST ? 1 : 0) + (may_sail ? 1 : 0);
-            string methods[] = {"You must go ", "The first is ", "The second is "};
+            std::string methods[] = {"You must go ", "The first is ", "The second is "};
             int method = 1;
             if (num_methods == 1) method = 0;
             f << enclose("p", true);
@@ -1628,7 +1626,7 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
     f << enclose("table border=\"1\"", true);
     f << enclose("tr", true);
     f << enclose("td colspan=\"2\" rowspan=\"2\"", true) << enclose("td", false);
-    f << enclose("td colspan=\"" + to_string(Globals->MAX_SPEED) + "\"", true) << "Movement Phase\n"
+    f << enclose("td colspan=\"" + std::to_string(Globals->MAX_SPEED) + "\"", true) << "Movement Phase\n"
       << enclose("td", false);
     f << enclose("tr", false);
     f << enclose("tr", true);
@@ -1639,7 +1637,7 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
     for (int i = 0; i < Globals->MAX_SPEED; i++) {
         f << enclose("tr", true);
         if (!i) {
-            f << enclose("td rowspan=\"" + to_string(Globals->MAX_SPEED) + "\"", true) << "Speed\n"
+            f << enclose("td rowspan=\"" + std::to_string(Globals->MAX_SPEED) + "\"", true) << "Speed\n"
               << enclose("td", false);
         }
         f << enclose("th", true) << i + 1 << '\n' << enclose("th", false);
@@ -1759,7 +1757,7 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
             }
             f << (spec ? "" : "None.") << "\n";
             f << enclose("td", false);
-            f << enclose("td align=\"left\" nowrap", true) << (spec ? to_string(mt.speciallevel) : "--") << '\n'
+            f << enclose("td align=\"left\" nowrap", true) << (spec ? std::to_string(mt.speciallevel) : "--") << '\n'
               << enclose("td", false);
             f << enclose("td align=\"left\" nowrap", true) << mt.defaultlevel << '\n' << enclose("td", false);
             f << enclose("tr", false);
@@ -3442,10 +3440,10 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
         << enclose("p", false);
 
     if (app_exist) {
-        string app_name(Globals->APPRENTICE_NAME);
+        std::string app_name(Globals->APPRENTICE_NAME);
         app_name.append("s");
         f << anchor("magic_"+app_name) << '\n';
-        app_name[0] = toupper(app_name[0]);
+        app_name[0] = std::toupper(app_name[0]);
         f << enclose("h3", true) << app_name << ":\n" << enclose("h3", false);
         f << enclose("p", true) << app_name << " may be created by having a unit study ";
         comma = 0;
@@ -4556,7 +4554,7 @@ int Game::generate_rules(const std::string& rules, const std::string& css, const
         f << enclose("p", true) << "Example:\n" << enclose("p", false);
         f << example_start(
             "Select a staff of fire as the "
-            + string(!(Globals->USE_PREPARE_COMMAND == GameDefs::PREPARE_STRICT) ? "preferred " : "")
+            + std::string(Globals->USE_PREPARE_COMMAND != GameDefs::PREPARE_STRICT ? "preferred " : "")
             + "battle item.")
           << "PREPARE STAF\n"
           << example_end();

--- a/havilah/extra.cpp
+++ b/havilah/extra.cpp
@@ -8,8 +8,6 @@
 #include <iterator>
 #include <memory>
 
-using namespace std;
-
 #define RELICS_REQUIRED_FOR_VICTORY 7
 #define MINIMUM_ACTIVE_QUESTS       3
 #define MAXIMUM_ACTIVE_QUESTS       10
@@ -85,13 +83,13 @@ static void CreateQuest(ARegionList& regions, int monfaction)
     int d, count, temple, i, j, clash;
     ARegion *r;
     std::string rname;
-    map <string, int> temples;
-    map <string, int>::iterator it;
-    string stlstr;
+    std::map <std::string, int> temples;
+    std::map <std::string, int>::iterator it;
+    std::string stlstr;
     int destprobs[MAX_DESTINATIONS] = { 0, 0, 80, 20, 0 };
     int destinations[MAX_DESTINATIONS];
-    string destnames[MAX_DESTINATIONS];
-    set<string> intersection;
+    std::string destnames[MAX_DESTINATIONS];
+    std::set<std::string> intersection;
 
     std::shared_ptr<Quest> q = std::make_shared<Quest>();
     q->type = -1;
@@ -261,13 +259,13 @@ static void CreateQuest(ARegionList& regions, int monfaction)
             for(const auto& q2: quests) {
                 if (q2->type == Quest::VISIT && q->building == q2->building) {
                     intersection.clear();
-                    set_intersection(
+                    std::set_intersection(
                         q->destinations.begin(),
                         q->destinations.end(),
                         q2->destinations.begin(),
                         q2->destinations.end(),
-                        inserter(intersection, intersection.begin()),
-                        less<string>()
+                        std::inserter(intersection, intersection.begin()),
+                        std::less<std::string>()
                     );
                     if (intersection.size() > 0)
                         q->type = -1;
@@ -291,11 +289,11 @@ Faction *Game::CheckVictory()
     Object *o;
     Location *l;
     std::string message, times, temp;
-    map <string, int> vRegions, uvRegions;
-    map <string, int>::iterator it;
-    string stlstr;
-    set<string> intersection, un;
-    set<string>::iterator it2;
+    std::map <std::string, int> vRegions, uvRegions;
+    std::map <std::string, int>::iterator it;
+    std::string stlstr;
+    std::set<std::string> intersection, un;
+    std::set<std::string>::iterator it2;
 
     for(const auto& q: quests) {
         if (q->type != Quest::VISIT) continue;
@@ -319,11 +317,11 @@ Faction *Game::CheckVictory()
         for(const auto o : r->objects) {
             for(const auto u : o->units) {
                 intersection.clear();
-                set_intersection(
+                std::set_intersection(
                     u->visited.begin(), u->visited.end(),
                     un.begin(), un.end(),
-                    inserter(intersection, intersection.begin()),
-                    less<string>()
+                    std::inserter(intersection, intersection.begin()),
+                    std::less<std::string>()
                 );
                 u->visited = intersection;
             }
@@ -637,8 +635,8 @@ Faction *Game::CheckVictory()
             f->event(message, "gameover");
             write_times_article(times);
 
-            string filename = "winner." + to_string(f->num);
-            ofstream wf(filename, ios::out | ios::ate);
+            std::string filename = "winner." + std::to_string(f->num);
+            std::ofstream wf(filename, std::ios::out | std::ios::ate);
 
             if (wf.is_open()) {
                 message = TurnNumber();
@@ -711,7 +709,7 @@ Faction *Game::CheckVictory()
         }
     }
 
-    std::vector<shared_ptr<Quest>> questsWithProblems;
+    std::vector<std::shared_ptr<Quest>> questsWithProblems;
     for(const auto& q: quests) {
         switch(q->type) {
             case Quest::SLAY:

--- a/havilah/world.cpp
+++ b/havilah/world.cpp
@@ -4,8 +4,6 @@
 #include <iostream>
 #include <fstream>
 
-using namespace std;
-
 typedef struct
 {
     const std::string word;
@@ -203,7 +201,7 @@ void CountNames()
     // Dump all the names we created to a file so the GM can scan
     // them easily (to check for randomly generated rude words,
     // for example)
-    ofstream names("names.out", ios::out|ios::ate);
+    std::ofstream names("names.out", std::ios::out|std::ios::ate);
     for(const auto& name: regionnames) {
         names << name << '\n';
     }

--- a/items.cpp
+++ b/items.cpp
@@ -8,8 +8,6 @@
 #include <ranges>
 #include <cmath>
 
-using namespace std;
-
 const int MonType::getAggression() {
     int aggression = this->hostile;
     aggression *= Globals->MONSTER_ADVANCE_HOSTILE_PERCENT;
@@ -186,9 +184,9 @@ int parse_transportable_item(const parser::token& token, int flags)
     return item;
 }
 
-string item_string(int type, int num, int flags)
+std::string item_string(int type, int num, int flags)
 {
-    string temp;
+    std::string temp;
     if (num == 1) {
         if (flags & FULLNUM)
             temp += std::to_string(num) + " ";
@@ -1351,7 +1349,7 @@ std::string Item::report(bool see_illusions)
     return ret;
 }
 
-void Item::Writeout(ostream& f)
+void Item::Writeout(std::ostream& f)
 {
     if (type != -1) {
         f << num << " ";
@@ -1361,20 +1359,20 @@ void Item::Writeout(ostream& f)
         f << "-1 NO_ITEM\n";
 }
 
-void Item::Readin(istream &f)
+void Item::Readin(std::istream &f)
 {
     std::string temp;
-    f >> ws >> num >> temp;
+    f >> std::ws >> num >> temp;
     type = lookup_item(temp);
 }
 
-void ItemList::Writeout(ostream& f)
+void ItemList::Writeout(std::ostream& f)
 {
     f << size() << "\n";
     for(auto i : items) i->Writeout(f);
 }
 
-void ItemList::Readin(istream &f)
+void ItemList::Readin(std::istream &f)
 {
     int i;
     f >> i;

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -6,8 +6,6 @@
 #include "quests.h"
 #include "rng.hpp"
 
-using namespace std;
-
 void Game::RunMovementOrders()
 {
     int phase, error;
@@ -107,8 +105,8 @@ void Game::RunMovementOrders()
                         u->savedmovedir = d->dir;
                     }
 
-                    string tOrder = (mo->advancing ? "ADVANCE" : "MOVE");
-                    string temp = tOrder + ": Unit has insufficient movement points; remaining moves queued.";
+                    std::string tOrder = (mo->advancing ? "ADVANCE" : "MOVE");
+                    std::string temp = tOrder + ": Unit has insufficient movement points; remaining moves queued.";
                     u->event(temp, "movement");
 
                     for (const auto d : mo->dirs) {
@@ -124,7 +122,7 @@ void Game::RunMovementOrders()
                         else if (d->dir == MOVE_PAUSE)
                             tOrder += "P";
                         else
-                            tOrder += to_string(d->dir - MOVE_ENTER);
+                            tOrder += std::to_string(d->dir - MOVE_ENTER);
                     }
                     u->oldorders.push_front(tOrder);
                 }
@@ -134,7 +132,7 @@ void Game::RunMovementOrders()
                 SailOrder *so = dynamic_cast<SailOrder *>(u->monthorders);
                 if (so->dirs.size() > 0) {
                     u->event("SAIL: Can't sail that far; remaining moves queued.", "movement");
-                    string tOrder = "SAIL";
+                    std::string tOrder = "SAIL";
                     for (const auto d : so->dirs) {
                         tOrder += " ";
                         if (d->dir == MOVE_PAUSE)
@@ -273,7 +271,7 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
             }
 
             for (const auto f : facs) {
-                string temp = fleet->name;
+                std::string temp = fleet->name;
                 temp += (x->dir == MOVE_PAUSE ? " performs maneuvers in " : " sails from ") + reg->short_print();
                 if (x->dir != MOVE_PAUSE) temp += " to " + newreg->short_print();
                 f->event(temp, "sail");
@@ -300,7 +298,7 @@ Location *Game::Do1SailOrder(ARegion *reg, Object *fleet, Unit *cap)
             }
             reg = newreg;
             if (newreg->ForbiddenShip(fleet)) {
-                string temp = fleet->name + " is stopped by guards in " + newreg->short_print() + ".";
+                std::string temp = fleet->name + " is stopped by guards in " + newreg->short_print() + ".";
                 cap->faction->event(temp, "sail");
                 stop = 1;
             }
@@ -432,7 +430,7 @@ void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
 {
     Object *buildobj;
     int questcomplete = 0;
-    string quest_rewards;
+    std::string quest_rewards;
 
     if (!Globals->BUILD_NO_TRADE && !ActivityCheck(r, u->faction, FactionActivity::TRADE)) {
         u->error("BUILD: Faction can't produce in that many regions.");
@@ -504,7 +502,7 @@ void Game::Run1BuildOrder(ARegion *r, Object *obj, Unit *u)
     int num = u->GetMen() * usk;
 
     // AS
-    string job;
+    std::string job;
     if (needed < 1) {
         // This looks wrong, but isn't.
         // If a building has a maxMaintenance of 75 and the road is at
@@ -615,7 +613,7 @@ void Game::RunBuildShipOrder(ARegion *r, Object *obj, Unit *u)
     } else {
         percent = 100 * output / ItemDefs[ship].pMonths;
         u->event(
-            "Performs construction work on a " + ItemDefs[ship].name + " (" + to_string(percent) + "%) in " +
+            "Performs construction work on a " + ItemDefs[ship].name + " (" + std::to_string(percent) + "%) in " +
                 r->short_print() + ".",
             "build", r
         );
@@ -1041,7 +1039,7 @@ void Game::RunUnitProduce(ARegion *r, Unit *u)
     if (o->target > 0) {
         TurnOrder *tOrder = new TurnOrder;
         tOrder->repeating = 0;
-        std::string order = "PRODUCE " + to_string(o->target) + " " + ItemDefs[o->item].abr;
+        std::string order = "PRODUCE " + std::to_string(o->target) + " " + ItemDefs[o->item].abr;
         tOrder->turnOrders.push_back(order);
         u->turnorders.push_front(tOrder);
     }
@@ -1073,12 +1071,12 @@ void Game::RunProduceOrders(ARegion *r)
                 BuildOrder *o = dynamic_cast<BuildOrder *>(u->monthorders);
                 if (o->until_complete) {
                     if ((u->build > 0 || o->target) && u->object->incomplete > 0) {
-                        string order = "BUILD ";
+                        std::string order = "BUILD ";
                         if (o->target) {
                             Unit *t = r->GetUnitId(o->target, u->faction->num);
-                            order += "HELP " + to_string(t->num);
+                            order += "HELP " + std::to_string(t->num);
                         } else {
-                            string name = ObjectDefs[u->object->type].name;
+                            std::string name = ObjectDefs[u->object->type].name;
                             if (name.find(" ") != std::string::npos) {
                                 // If the name has spaces, we need to quote it
                                 order += "\"" + name + "\"";
@@ -1089,7 +1087,7 @@ void Game::RunProduceOrders(ARegion *r)
                         order += " COMPLETE";
                         u->oldorders.push_front(order);
                     } else if (u->build < 0 || o->target) {
-                        string order = "BUILD ";
+                        std::string order = "BUILD ";
                         BuildOrder *border = nullptr;
                         Unit *t;
                         if (o->target) {
@@ -1102,7 +1100,7 @@ void Game::RunProduceOrders(ARegion *r)
                         }
                         if (border && border->needtocomplete > 0) {
                             if (o->target) {
-                                order += "HELP " + to_string(t->num);
+                                order += "HELP " + std::to_string(t->num);
                             } else {
                                 order += ItemDefs[-(u->build)].abr;
                             }
@@ -1174,7 +1172,7 @@ int Game::FindAttemptedProd(ARegion *r, Production *p)
 void Game::RunAProduction(ARegion *r, Production *p)
 {
     int questcomplete;
-    string quest_rewards;
+    std::string quest_rewards;
 
     p->activity = 0;
     if (p->amount == 0) return;
@@ -1212,7 +1210,7 @@ void Game::RunAProduction(ARegion *r, Production *p)
             if (po->target > 0) {
                 TurnOrder *tOrder = new TurnOrder;
                 tOrder->repeating = 0;
-                std::string order = "PRODUCE " + to_string(po->target) + " " + ItemDefs[po->item].abr;
+                std::string order = "PRODUCE " + std::to_string(po->target) + " " + ItemDefs[po->item].abr;
                 tOrder->turnOrders.push_back(order);
                 u->turnorders.push_front(tOrder);
             }
@@ -1224,7 +1222,7 @@ void Game::RunAProduction(ARegion *r, Production *p)
                 //
                 if (po->skill == -1) {
                     u->event(
-                        "Earns " + to_string(ubucks) + " silver working in " + r->short_print() + ".",
+                        "Earns " + std::to_string(ubucks) + " silver working in " + r->short_print() + ".",
                         "work", r
                     );
                 } else {
@@ -1310,12 +1308,12 @@ void Game::Do1StudyOrder(Unit *u, Object *obj)
         if (skmax < o->level) {
             o->level = skmax;
             if (u->GetRealSkill(sk) >= o->level) {
-                u->error("STUDY: Cannot study " + SkillDefs[sk].name + " beyond level " + to_string(o->level) + ".");
+                u->error("STUDY: Cannot study " + SkillDefs[sk].name + " beyond level " + std::to_string(o->level) + ".");
                 return;
             } else {
                 u->error(
                     "STUDY: set study goal for " + SkillDefs[sk].name + " to the maximum achievable level (" +
-                    to_string(o->level) + ")."
+                    std::to_string(o->level) + ")."
                 );
             }
         }
@@ -1333,7 +1331,7 @@ void Game::Do1StudyOrder(Unit *u, Object *obj)
 
     if ((SkillDefs[sk].flags & SkillType::MAGIC) && u->type != U_MAGE) {
         if (u->type == U_APPRENTICE) {
-            u->error(string("STUDY: An ") + Globals->APPRENTICE_NAME + " cannot be made into a mage.");
+            u->error(std::string("STUDY: An ") + Globals->APPRENTICE_NAME + " cannot be made into a mage.");
             return;
         }
         if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
@@ -1358,23 +1356,23 @@ void Game::Do1StudyOrder(Unit *u, Object *obj)
 
     if ((SkillDefs[sk].flags & SkillType::APPRENTICE) && u->type != U_APPRENTICE) {
         if (u->type == U_MAGE) {
-            u->error(string("STUDY: A mage cannot be made into an ") + Globals->APPRENTICE_NAME + ".");
+            u->error(std::string("STUDY: A mage cannot be made into an ") + Globals->APPRENTICE_NAME + ".");
             return;
         }
 
         if (Globals->FACTION_LIMIT_TYPE != GameDefs::FACLIM_UNLIMITED) {
             if (CountApprentices(u->faction) >= AllowedApprentices(u->faction)) {
-                u->error(string("STUDY: Can't have another ") + Globals->APPRENTICE_NAME + ".");
+                u->error(std::string("STUDY: Can't have another ") + Globals->APPRENTICE_NAME + ".");
                 return;
             }
         }
         if (u->GetMen() != 1) {
-            u->error(string("STUDY: Only 1-man units can be ") + Globals->APPRENTICE_NAME + "s.");
+            u->error(std::string("STUDY: Only 1-man units can be ") + Globals->APPRENTICE_NAME + "s.");
             return;
         }
         if (!(Globals->MAGE_NONLEADERS)) {
             if (u->GetLeaders() != 1) {
-                u->error(string("STUDY: Only leaders may be ") + Globals->APPRENTICE_NAME + "s.");
+                u->error(std::string("STUDY: Only leaders may be ") + Globals->APPRENTICE_NAME + "s.");
                 return;
             }
         }
@@ -1436,9 +1434,9 @@ void Game::Do1StudyOrder(Unit *u, Object *obj)
 
     if (u->Study(sk, days)) {
         u->ConsumeSharedMoney(cost);
-        string str = "Studies " + SkillDefs[sk].name;
+        std::string str = "Studies " + SkillDefs[sk].name;
         taughtdays = taughtdays / u->GetMen();
-        if (taughtdays) { str += " and was taught for " + to_string(taughtdays) + " days"; }
+        if (taughtdays) { str += " and was taught for " + std::to_string(taughtdays) + " days"; }
         str += " at a cost of " + item_string(I_SILVER, cost) + ".";
         u->event(str, "study");
         // study to level order
@@ -1446,11 +1444,12 @@ void Game::Do1StudyOrder(Unit *u, Object *obj)
             if (u->GetRealSkill(sk) < o->level) {
                 TurnOrder *tOrder = new TurnOrder;
                 tOrder->repeating = 0;
-                std::string order = "STUDY " + string(SkillDefs[sk].abbr) + " " + to_string(o->level);
+                std::string order = "STUDY " + std::string(SkillDefs[sk].abbr) + " " + std::to_string(o->level);
                 tOrder->turnOrders.push_back(order);
                 u->turnorders.push_front(tOrder);
             } else {
-                string msg = "Completes study to level " + to_string(o->level) + " in " + SkillDefs[sk].name + ".";
+                std::string msg = "Completes study to level " + std::to_string(o->level) + " in " +
+                    SkillDefs[sk].name + ".";
                 u->event(msg, "study");
             }
         }
@@ -1537,7 +1536,7 @@ Location *Game::DoAMoveOrder(Unit *unit, ARegion *region, Object *obj)
 {
     MoveOrder *o = dynamic_cast<MoveOrder *>(unit->monthorders);
     ARegion *newreg;
-    string road, temp;
+    std::string road, temp;
 
     int movetype, cost, startmove, weight;
     Unit *ally, *forbid;

--- a/neworigins/extra.cpp
+++ b/neworigins/extra.cpp
@@ -6,8 +6,6 @@
 #include <iterator>
 #include <memory>
 
-using namespace std;
-
 #define MINIMUM_ACTIVE_QUESTS 5
 #define MAXIMUM_ACTIVE_QUESTS 20
 #define QUEST_EXPLORATION_PERCENT 30
@@ -114,13 +112,13 @@ static void CreateQuest(ARegionList& regions, int monfaction)
     int d, count, temple, i, j, clash, reward_count;
     ARegion *r;
     std::string rname;
-    map <string, int> temples;
-    map <string, int>::iterator it;
-    string stlstr;
+    std::map <std::string, int> temples;
+    std::map <std::string, int>::iterator it;
+    std::string stlstr;
     int destprobs[MAX_DESTINATIONS] = { 0, 0, 80, 20, 0 };
     int destinations[MAX_DESTINATIONS];
-    string destnames[MAX_DESTINATIONS];
-    set<string> intersection;
+    std::string destnames[MAX_DESTINATIONS];
+    std::set<std::string> intersection;
 
     std::shared_ptr<Quest> q = std::make_shared<Quest>();
     q->type = -1;
@@ -342,14 +340,13 @@ static void CreateQuest(ARegionList& regions, int monfaction)
             for(const auto& q2: quests) {
                 if (q2->type == Quest::VISIT && q->building == q2->building) {
                     intersection.clear();
-                    set_intersection(
+                    std::set_intersection(
                         q->destinations.begin(),
                         q->destinations.end(),
                         q2->destinations.begin(),
                         q2->destinations.end(),
-                        inserter(intersection,
-                            intersection.begin()),
-                        less<string>()
+                        std::inserter(intersection, intersection.begin()),
+                        std::less<std::string>()
                     );
                     if (intersection.size() > 0)
                         q->type = -1;
@@ -521,11 +518,11 @@ Faction *Game::CheckVictory()
     Object *o;
     Location *l;
     std::string message, times, temp;
-    map <string, int> vRegions, uvRegions;
-    map <string, int>::iterator it;
-    string stlstr;
-    set<string> intersection, un;
-    set<string>::iterator it2;
+    std::map <std::string, int> vRegions, uvRegions;
+    std::map <std::string, int>::iterator it;
+    std::string stlstr;
+    std::set<std::string> intersection, un;
+    std::set<std::string>::iterator it2;
     Faction *winner = nullptr;
 
     for(const auto& q: quests) {
@@ -551,11 +548,11 @@ Faction *Game::CheckVictory()
         for(const auto o : r->objects) {
             for(const auto u : o->units) {
                 intersection.clear();
-                set_intersection(
+                std::set_intersection(
                     u->visited.begin(), u->visited.end(),
                     un.begin(), un.end(),
-                    inserter(intersection, intersection.begin()),
-                    less<string>()
+                    std::inserter(intersection, intersection.begin()),
+                    std::less<std::string>()
                 );
                 u->visited = intersection;
             }
@@ -816,16 +813,16 @@ Faction *Game::CheckVictory()
 
             total_cities++;
 
-            string name = r->town->name;
-            string possible_faction = name.substr(0, name.find_first_of(" \t\n"));
+            std::string name = r->town->name;
+            std::string possible_faction = name.substr(0, name.find_first_of(" \t\n"));
             // The first word of the name was not all numeric, don't count for anyone
-            if (!all_of(
+            if (!std::all_of(
                 possible_faction.begin(),
                 possible_faction.end(),
                 [](unsigned char ch){ return std::isdigit(ch); }
             )) continue;
             // Now that we know it's all numeric, convert it to an int
-            int faction_id = stoi(possible_faction);
+            int faction_id = std::stoi(possible_faction);
 
             // Make sure it's a valid faction
             Faction *f = GetFaction(factions, faction_id);
@@ -840,7 +837,7 @@ Faction *Game::CheckVictory()
         }
 
         // Set up the voting result to be reported if we are far enough in
-        string message = "Voting results: \n";
+        std::string message = "Voting results: \n";
 
         int max_vote = -1;
         bool tie = false;
@@ -855,7 +852,7 @@ Faction *Game::CheckVictory()
                 tie = true;
                 maxFaction = nullptr;
             }
-            message += "Faction " + f->name + " has " + to_string(vote.second) + " votes.\n";
+            message += "Faction " + f->name + " has " + std::to_string(vote.second) + " votes.\n";
         }
 
         // See if we have enough votes to even report the info.  Since a win requires 50% + 1, we can start reporting
@@ -866,13 +863,14 @@ Faction *Game::CheckVictory()
                 winner = maxFaction;
                 message += "\n" + winner->name + " has enough votes and has won the game!";
             } else {
-                int percent = floor((max_vote * 100) / total_cities);
+                int percent = std::floor((max_vote * 100) / total_cities);
                 if (tie) {
                     message += "\nThere is a tie for the most votes with multiple factions having ";
                 } else {
                     message += "\nThe current leader is " + maxFaction->name + " with ";
                 }
-                message += to_string(max_vote) + "/" + to_string(total_cities) + " votes (" + to_string(percent) + "%).";
+                message += std::to_string(max_vote) + "/" + std::to_string(total_cities) +
+                    " votes (" + std::to_string(percent) + "%).";
             }
             write_times_article(message);
         }

--- a/neworigins/world.cpp
+++ b/neworigins/world.cpp
@@ -5,8 +5,6 @@
 #include <iostream>
 #include <fstream>
 
-using namespace std;
-
 typedef struct
 {
     const std::string word;
@@ -204,7 +202,7 @@ void CountNames()
     // Dump all the names we created to a file so the GM can scan
     // them easily (to check for randomly generated rude words,
     // for example)
-    ofstream names("names.out", ios::out|ios::ate);
+    std::ofstream names("names.out", std::ios::out|std::ios::ate);
     for(const auto& name: regionnames) {
         names << name << '\n';
     }

--- a/object.cpp
+++ b/object.cpp
@@ -455,9 +455,9 @@ std::string Object::FleetDefinition()
             num = GetNumShips(item);
             if (num > 0) {
                 if (num > 1) {
-                    fleet += std::string(", ") + std::to_string(num) + " " + ItemDefs[item].names;
+                    fleet += ", " + std::to_string(num) + " " + ItemDefs[item].names;
                 } else {
-                    fleet += std::string(", ") + std::to_string(num) + " " +ItemDefs[item].name;
+                    fleet += ", " + std::to_string(num) + " " +ItemDefs[item].name;
                 }
             }
         }

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -12,8 +12,6 @@
 
 #include <string>
 
-using namespace std;
-
 void orders_check::error(const std::string& err)
 {
     check_file << indent::push_indent(0) <<  "\n\n*** Error: " << err << " ***\n" << indent::pop_indent();
@@ -136,7 +134,8 @@ void Game::parse_error(orders_check *checker, Unit *unit, Faction *faction, cons
 }
 
 void Game::overwrite_month_warning(std::string type, Unit *u, orders_check * checker) {
-    string err = type + ": Overwriting previous " + string(u->inTurnBlock ? "DELAYED " : "") + "month-long order.";
+    std::string err = type + ": Overwriting previous " + std::string(u->inTurnBlock ? "DELAYED " : "") +
+        "month-long order.";
     parse_error(checker, u, 0, err);
 }
 
@@ -1062,7 +1061,7 @@ void Game::ProcessClaimOrder(Unit *u, parser::string_parser& parser, orders_chec
     u->faction->unclaimed -= value;
     u->SetMoney(u->GetMoney() + value);
     u->faction->DiscoverItem(I_SILVER, 0, 1);
-    u->event("Claims $" + to_string(value) + ".", "claim");
+    u->event("Claims $" + std::to_string(value) + ".", "claim");
 }
 
 void Game::ProcessFactionOrder(Unit *u, parser::string_parser& parser, orders_check *checker)
@@ -1100,7 +1099,7 @@ void Game::ProcessFactionOrder(Unit *u, parser::string_parser& parser, orders_ch
     }
 
     if (a > AllowedApprentices(u->faction)) {
-        u->error(string("FACTION: Too many ") + Globals->APPRENTICE_NAME + "s to change to that faction type.");
+        u->error(std::string("FACTION: Too many ") + Globals->APPRENTICE_NAME + "s to change to that faction type.");
         u->faction->type = oldfactype;
         return;
     }
@@ -1213,7 +1212,7 @@ void Game::ProcessRestartOrder(Unit *u, parser::string_parser& parser, orders_ch
         Faction *pFac = AddFaction(0, NULL);
         pFac->set_address(u->faction->address);
         pFac->password = u->faction->password;
-        string facstr = "Restarting " + pFac->address + ".";
+        std::string facstr = "Restarting " + pFac->address + ".";
     }
 }
 
@@ -1866,7 +1865,7 @@ void Game::ProcessWithdrawOrder(Unit *unit, parser::string_parser& parser, order
     unit->withdraworders.push_back(order);
 }
 
-std::string Game::ProcessTurnOrder(Unit *unit, istream& f, orders_check *checker, bool repeat)
+std::string Game::ProcessTurnOrder(Unit *unit, std::istream& f, orders_check *checker, bool repeat)
 {
     int turnDepth = 1;
     int turnLast = 1;
@@ -2264,7 +2263,7 @@ void Game::ProcessNameOrder(Unit *unit, parser::string_parser& parser, orders_ch
     }
 
     int towntype = unit->object->region->town->TownType();
-    string tstring = (towntype == TOWN_VILLAGE) ? "village" : (towntype == TOWN_TOWN) ? "town" : "city";
+    std::string tstring = (towntype == TOWN_VILLAGE) ? "village" : (towntype == TOWN_TOWN) ? "town" : "city";
 
     // Calculate rename cost if applicable
     int cost = 0;

--- a/production.cpp
+++ b/production.cpp
@@ -5,8 +5,6 @@
 #include "gamedata.h"
 #include "rng.hpp"
 
-using namespace std;
-
 Production::Production()
 {
     itemtype = -1;
@@ -27,7 +25,7 @@ Production::Production(int it, int maxamt)
     skill = lookup_skill(ItemDefs[it].pSkill);
 }
 
-void Production::write_out(ostream& f)
+void Production::write_out(std::ostream& f)
 {
     f << (itemtype == -1 ? "NO_ITEM" : ItemDefs[itemtype].abr) << '\n';
     f << amount << '\n';
@@ -38,18 +36,18 @@ void Production::write_out(ostream& f)
     f << productivity << '\n';
 }
 
-void Production::read_in(istream& f)
+void Production::read_in(std::istream& f)
 {
     std::string temp;
 
-    f >> ws >> temp;
+    f >> std::ws >> temp;
     itemtype = lookup_item(temp);
 
     f >> amount;
     f >> baseamount;
 
     if (itemtype == I_SILVER)
-        f >> ws >> temp;
+        f >> std::ws >> temp;
     else
         temp = ItemDefs[itemtype].pSkill;
 
@@ -58,6 +56,6 @@ void Production::read_in(istream& f)
     f >> productivity;
 }
 
-string Production::write_report() {
+std::string Production::write_report() {
     return item_string(itemtype, amount);
 }

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -2,8 +2,6 @@
 #include "gamedata.h"
 #include "quests.h"
 
-using namespace std;
-
 void Game::RunOrders()
 {
     //
@@ -243,7 +241,8 @@ void Game::Do1Assassinate(ARegion *r, Object *o, Unit *u)
         }
     }
     if (!succ) {
-        string temp = u->name + " is caught attempting to assassinate " + tar->name + " in " + r->short_print() + ".";
+        std::string temp = u->name + " is caught attempting to assassinate " + tar->name +
+            " in " + r->short_print() + ".";
         for(const auto f : seers) {
             f->event(temp, "combat", r, u);
         }
@@ -311,7 +310,8 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
     }
 
     if (!succ) {
-        string temp = u->name + " is caught attempting to steal from " + tar->name + " in " + r->short_print() + ".";
+        std::string temp = u->name + " is caught attempting to steal from " + tar->name +
+            " in " + r->short_print() + ".";
         for(const auto f : seers) {
             f->event(temp, "theft", r, u);
         }
@@ -345,7 +345,7 @@ void Game::Do1Steal(ARegion *r, Object *o, Unit *u)
     u->items.SetNum(so->item, u->items.GetNum(so->item) + amt);
     tar->items.SetNum(so->item, tar->items.GetNum(so->item) - amt);
 
-    string temp = u->name + " steals " + item_string(so->item, amt) + " from " + tar->name + ".";
+    std::string temp = u->name + " steals " + item_string(so->item, amt) + " from " + tar->name + ".";
     for(const auto f : seers) {
         f->event(temp, "theft", r, u);
     }
@@ -448,7 +448,7 @@ void Game::RunDestroyOrders()
 }
 
 void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
-    string quest_rewards;
+    std::string quest_rewards;
 
     if (TerrainDefs[r->type].similar_type == R_OCEAN) {
         u->error("DESTROY: Can't destroy a ship while at sea.");
@@ -490,7 +490,7 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
 
         willDestroy = std::min(destroyablePoints, destroyPower);
         if (willDestroy == 0) {
-            u->error(string("DESTROY: Can't destroy ") + o->name + " more.");
+            u->error(std::string("DESTROY: Can't destroy ") + o->name + " more.");
             for (const auto u2 : o->units) u2->destroy = 0;
             return;
         }
@@ -500,7 +500,7 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
             o->destroyed += willDestroy;
             o->incomplete += willDestroy;
 
-            u->event("Destroys " + to_string(willDestroy) + " structure points from the " + o->name + ".", "destroy");
+            u->event("Destroys " + std::to_string(willDestroy) + " structure points from the " + o->name + ".", "destroy");
         } else {
             u->event("Destroys " + o->name + ".", "destroy");
 
@@ -520,7 +520,7 @@ void Game::Do1Destroy(ARegion *r, Object *o, Unit *u) {
         if (o->type == O_DUMMY) {
             u->error("DESTROY: Not inside a structure.");
         } else {
-            u->error(string("DESTROY: Can't destroy ") + o->name + ".");
+            u->error(std::string("DESTROY: Can't destroy ") + o->name + ".");
         }
         for (const auto u2 : o->units) u2->destroy = 0;
         return;
@@ -545,14 +545,14 @@ void Game::RunFindUnit(Unit *u)
         if (!all) {
             fac = GetFaction(factions, f->find);
             if (fac) {
-                string temp = "The address of " + fac->name + " is " + fac->address + ".";
+                std::string temp = "The address of " + fac->name + " is " + fac->address + ".";
                 u->faction->event(temp, "find");
             } else {
-                u->error(string("FIND: ") + to_string(f->find) + " is not a valid faction number.");
+                u->error(std::string("FIND: ") + std::to_string(f->find) + " is not a valid faction number.");
             }
         } else {
             for(const auto fac : factions) {
-                string temp = "The address of " + fac->name + " is " + fac->address + ".";
+                std::string temp = "The address of " + fac->name + " is " + fac->address + ".";
                 u->faction->event(temp, "find");
             }
         }
@@ -1028,7 +1028,7 @@ void Game::EndGame(Faction *victor)
             fac->quit = QUIT_GAME_OVER;
 
         if (victor) {
-            string temp(victor->name);
+            std::string temp(victor->name);
             fac->event(temp + " has won the game!", "gameover");
         } else
             fac->event("The game has ended with no winner.", "gameover");
@@ -1372,7 +1372,8 @@ void Game::DoSell(ARegion *r, Market *m)
                     u->ConsumeShared(o->item, temp);
                     u->SetMoney(u->GetMoney() + temp * m->price);
                     oit = u->sellorders.erase(oit);
-                    u->event("Sells " + item_string(o->item, temp) + " at $" + to_string(m->price) + " each.", "sell");
+                    u->event("Sells " + item_string(o->item, temp) + " at $" +
+                        std::to_string(m->price) + " each.", "sell");
                     delete o;
                     continue;
                 }
@@ -1415,9 +1416,9 @@ int Game::GetBuyAmount(ARegion *r, Market *m)
                             o->num = 0;
                         }
                         if (u->type == U_APPRENTICE) {
-                            string name = Globals->APPRENTICE_NAME;
+                            std::string name = Globals->APPRENTICE_NAME;
                             name[0] = toupper(name[0]);
-                            string temp = "BUY: " + name + "s can't recruit more men.";
+                            std::string temp = "BUY: " + name + "s can't recruit more men.";
                             u->error(temp);
                             o->num = 0;
                         }
@@ -1520,7 +1521,8 @@ void Game::DoBuy(ARegion *r, Market *m)
                     u->faction->DiscoverItem(o->item, 0, 1);
                     u->ConsumeSharedMoney(temp * m->price);
                     oit = u->buyorders.erase(oit);
-                    u->event("Buys " + item_string(o->item, temp) + " at $" + to_string(m->price) + " each.", "buy");
+                    u->event("Buys " + item_string(o->item, temp) + " at $" +
+                        std::to_string(m->price) + " each.", "buy");
                     delete o;
                     continue;
                 }
@@ -1770,7 +1772,7 @@ void Game::CheckAllyHungerItem(int item, int value)
 
 void Game::AssessMaintenance()
 {
-    string quest_rewards;
+    std::string quest_rewards;
 
     /* First pass: set needed */
     for(const auto r : regions) {
@@ -1879,11 +1881,11 @@ void Game::AssessMaintenance()
                 if (u->needed > 0 && u->faction->unclaimed) {
                     /* Now see if faction has money */
                     if (u->faction->unclaimed >= u->needed) {
-                        u->event("Claims " + to_string(u->needed) + " silver for maintenance.", "maintenance");
+                        u->event("Claims " + std::to_string(u->needed) + " silver for maintenance.", "maintenance");
                         u->faction->unclaimed -= u->needed;
                         u->needed = 0;
                     } else {
-                        u->event("Claims " + to_string(u->faction->unclaimed) + " silver for maintenance.",
+                        u->event("Claims " + std::to_string(u->faction->unclaimed) + " silver for maintenance.",
                             "maintenance");
                         u->needed -= u->faction->unclaimed;
                         u->faction->unclaimed = 0;
@@ -1945,14 +1947,14 @@ int Game::DoWithdrawOrder(ARegion *r, Unit *u, WithdrawOrder *o)
     }
 
     if (cost > u->faction->unclaimed) {
-        u->error(string("WITHDRAW: Too little unclaimed silver to withdraw ") + item_string(itm, amt) + ".");
+        u->error(std::string("WITHDRAW: Too little unclaimed silver to withdraw ") + item_string(itm, amt) + ".");
         return 0;
     }
 
     if (ItemDefs[itm].max_inventory) {
         int cur = u->items.GetNum(itm) + amt;
         if (cur > ItemDefs[itm].max_inventory) {
-            u->error(string("WITHDRAW: Unit cannot have more than ") + item_string(itm, ItemDefs[itm].max_inventory));
+            u->error(std::string("WITHDRAW: Unit cannot have more than ") + item_string(itm, ItemDefs[itm].max_inventory));
             return 0;
         }
     }
@@ -2084,12 +2086,12 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
 
     // Check each Item can be given
     if (ItemDefs[o->giveItem].flags & ItemType::CANTGIVE) {
-        u->error(string("EXCHANGE: Can't trade ") + ItemDefs[o->giveItem].names + ".");
+        u->error(std::string("EXCHANGE: Can't trade ") + ItemDefs[o->giveItem].names + ".");
         return;
     }
 
     if (ItemDefs[o->expectItem].flags & ItemType::CANTGIVE) {
-        u->error(string("EXCHANGE: Can't trade ") + ItemDefs[o->expectItem].names + ".");
+        u->error(std::string("EXCHANGE: Can't trade ") + ItemDefs[o->expectItem].names + ".");
         return;
     }
 
@@ -2111,8 +2113,8 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
     // Check other unit has enough to give
     int amtRecieve = o->expectAmount;
     if (amtRecieve > t->GetSharedNum(o->expectItem)) {
-        t->error(string("EXCHANGE: Not giving enough. Expecting ") + item_string(o->expectItem, o->expectAmount) + ".");
-        u->error(string("EXCHANGE: Exchange aborted.  Not enough recieved. Expecting ") +
+        t->error(std::string("EXCHANGE: Not giving enough. Expecting ") + item_string(o->expectItem, o->expectAmount) + ".");
+        u->error(std::string("EXCHANGE: Exchange aborted.  Not enough recieved. Expecting ") +
             item_string(o->expectItem, o->expectAmount) + ".");
         return;
     }
@@ -2124,18 +2126,18 @@ void Game::DoExchangeOrder(ARegion *r, Unit *u, ExchangeOrder *o)
         if (ptrUnitTemp == u && tOrder->expectItem == o->giveItem && tOrder->giveItem == o->expectItem) {
             exchangeOrderFound = true;
             if (tOrder->giveAmount < o->expectAmount) {
-                t->error(string("EXCHANGE: Not giving enough. Expecting ") +
+                t->error(std::string("EXCHANGE: Not giving enough. Expecting ") +
                     item_string(o->expectItem, o->expectAmount) + ".");
-                u->error(string("EXCHANGE: Exchange aborted. Not enough recieved. Expecting ") +
+                u->error(std::string("EXCHANGE: Exchange aborted. Not enough recieved. Expecting ") +
                     item_string(o->expectItem, o->expectAmount) + ".");
                 tOrder->exchangeStatus = 0;
                 o->exchangeStatus = 0;
                 return;
             }
             if (tOrder->giveAmount > o->expectAmount) {
-                t->error(string("EXCHANGE: Exchange aborted. Too much given. Expecting ") +
+                t->error(std::string("EXCHANGE: Exchange aborted. Too much given. Expecting ") +
                     item_string(o->expectItem, o->expectAmount) + ".");
-                u->error(string("EXCHANGE: Exchange aborted. Too much offered. Expecting ") +
+                u->error(std::string("EXCHANGE: Exchange aborted. Too much offered. Expecting ") +
                     item_string(o->expectItem, o->expectAmount) + ".");
                 tOrder->exchangeStatus = 0;
                 o->exchangeStatus = 0;
@@ -2177,8 +2179,8 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
     Object *fleet;
     SkillList *skills;
 
-    string ord = (o->type == O_TAKE) ? "TAKE" : "GIVE";
-    string event_type = (o->type == O_TAKE) ? "take" : "give";
+    std::string ord = (o->type == O_TAKE) ? "TAKE" : "GIVE";
+    std::string event_type = (o->type == O_TAKE) ? "take" : "give";
 
     /* Transfer/GIVE ship items: */
     if ((o->item >= 0) && (ItemDefs[o->item].type & IT_SHIP)) {
@@ -2432,7 +2434,7 @@ int Game::DoGiveOrder(ARegion *r, Unit *u, GiveOrder *o)
             return 0;
         }
 
-        string temp = "Discards ";
+        std::string temp = "Discards ";
         if (ItemDefs[o->item].type & IT_MAN) {
             u->SetMen(o->item, u->GetMen(o->item) - amt);
             r->DisbandInRegion(o->item, amt);
@@ -2791,7 +2793,7 @@ void Game::CheckTransportOrders()
                     } else { // sender isn't a valid QM
                         if (!target_is_valid_qm) { // Non-qms or invalid qms can only send to valid QMs
                             // Give a specific error message depending on why they aren't considered a quartermaster
-                            string temp = "TRANSPORT: Target " + tar->unit->name;
+                            std::string temp = "TRANSPORT: Target " + tar->unit->name;
                             temp += (
                                 target_owns_qm_building ?
                                 " does not own a transport structure." :
@@ -2967,7 +2969,7 @@ void Game::RunTransportPhase(TransportOrder::TransportPhase phase) {
 
                     u->ConsumeShared(t->item, amt);
                     u->event("Transports " + item_string(t->item, amt) + " to " + tar->unit->name +
-                        " for $" + to_string(cost) + ".", "transport");
+                        " for $" + std::to_string(cost) + ".", "transport");
                     if (u->faction != tar->unit->faction) {
                         tar->unit->event("Receives " + item_string(t->item, amt) + " from " + u->name + ".", "transport");
                     }
@@ -3032,7 +3034,7 @@ void Game::RunSacrificeOrders() {
                     }
 
                     int required = -sacrifice_object->incomplete;
-                    int used = min(required, o->amount);
+                    int used = std::min(required, o->amount);
 
                     // Okay we have a valid sacrifice.  Do it.
                     sacrifice_object->incomplete += used;
@@ -3099,7 +3101,7 @@ void Game::Do1Annihilate(ARegion *reg) {
     if (TerrainDefs[reg->type].flags & TerrainType::ANNIHILATED) return; // just a double check
 
     // put the annihilation in the news and tell every faction.
-    string message = reg->print() + " has been utterly annihilated.";
+    std::string message = reg->print() + " has been utterly annihilated.";
     AnnihilationFact *fact = new AnnihilationFact();
     fact->message = message;
     events->AddFact(fact);
@@ -3264,8 +3266,8 @@ void Game::RunAnnihilateOrders() {
                     u->annihilateorders.pop_front();
 
                     TurnOrder *tOrder = new TurnOrder;
-                    std::string order = "ANNIHILATE " + to_string(o->xloc) + " " + to_string(o->yloc) +
-                        " " + to_string(o->zloc);
+                    std::string order = "ANNIHILATE " + std::to_string(o->xloc) + " " + std::to_string(o->yloc) +
+                        " " + std::to_string(o->zloc);
                     tOrder->repeating = 0;
                     tOrder->turnOrders.push_back(order);
                     u->turnorders.push_front(tOrder);

--- a/skills.cpp
+++ b/skills.cpp
@@ -116,7 +116,7 @@ int SkillMax(char const *skill, int race)
     auto mt = man_def->get();
 
     std::string skname = pS->get().abbr;
-    std::string mani("MANI");
+    strings::ci_string mani = "MANI";
     for (unsigned int c=0; c < (sizeof(mt.skills)/sizeof(mt.skills[0])); c++) {
         if (skname == mt.skills[c])
             return mt.speciallevel;

--- a/spells.cpp
+++ b/spells.cpp
@@ -3,8 +3,6 @@
 
 #include "string_parser.hpp"
 
-using namespace std;
-
 static int RandomiseSummonAmount(int num)
 {
     int retval = 0;
@@ -580,7 +578,7 @@ void Game::RunACastOrder(ARegion * r,Object *o,Unit * u)
     }
 
     if (u->GetSkill(u->castorders->spell) < u->castorders->level || u->castorders->level == 0) {
-        u->error(string("CAST '") + SkillDefs[u->castorders->spell].name + "': Skill level isn't that high.");
+        u->error(std::string("CAST '") + SkillDefs[u->castorders->spell].name + "': Skill level isn't that high.");
         return;
     }
 
@@ -818,7 +816,7 @@ int Game::RunMindReading(ARegion *r,Unit *u)
         return 0;
     }
 
-    string temp = "Casts Mind Reading: " + tar->name + ", " + tar->faction->name + ".";
+    std::string temp = "Casts Mind Reading: " + tar->name + ", " + tar->faction->name + ".";
 
     if (level >= 3) {
         temp += tar->items.report(2,5,0) + ". Skills: ";
@@ -860,7 +858,7 @@ int Game::RunEnchant(ARegion *r,Unit *u, int skill, int item)
 
     // Add the created items
     u->items.SetNum(item, u->items.GetNum(item) + num);
-    u->event("Enchants " + to_string(num) + " " + ItemDefs[item].names + ".", "spell");
+    u->event("Enchants " + std::to_string(num) + " " + ItemDefs[item].names + ".", "spell");
     if (num == 0) return 0;
     return 1;
 }
@@ -1178,10 +1176,7 @@ int Game::RunBirdLore(ARegion *r,Unit *u)
     int type = regions.GetRegionArray(r->zloc)->levelType;
 
     if (type != ARegionArray::LEVEL_SURFACE) {
-        std::string error("CAST: Bird Lore may only be cast on the surface of ");
-        error += Globals->WORLD_NAME;
-        error += ".";
-        u->error(error);
+        u->error("CAST: Bird Lore may only be cast on the surface of " + Globals->WORLD_NAME + ".");
         return 0;
     }
 
@@ -1393,7 +1388,7 @@ int Game::RunEarthLore(ARegion *r,Unit *u)
     int amt = r->Wages() * level * 2 / 10;
 
     u->items.SetNum(I_SILVER,u->items.GetNum(I_SILVER) + amt);
-    u->event("Casts Earth Lore, raising " + to_string(amt) + " silver.", "spell");
+    u->event("Casts Earth Lore, raising " + std::to_string(amt) + " silver.", "spell");
     return 1;
 }
 
@@ -1416,14 +1411,14 @@ int Game::RunPhantasmalEntertainment(ARegion *r,Unit *u)
     }
 
     u->items.SetNum(I_SILVER, u->items.GetNum(I_SILVER) + amt);
-    u->event("Casts Phantasmal Entertainment, raising " + to_string(amt) + " silver.", "spell");
+    u->event("Casts Phantasmal Entertainment, raising " + std::to_string(amt) + " silver.", "spell");
     return 1;
 }
 
 int Game::RunClearSkies(ARegion *r, Unit *u)
 {
     ARegion *tar = r;
-    string temp = "Casts Clear Skies";
+    std::string temp = "Casts Clear Skies";
     int val;
 
     CastRegionOrder *order = dynamic_cast<CastRegionOrder *>(u->castorders);
@@ -1458,7 +1453,7 @@ int Game::RunWeatherLore(ARegion *r, Unit *u)
     if (level >= 5) months = 12;
     else if (level >= 3) months = 6;
 
-    string temp = "Casts Weather Lore on " + tar->short_print() + ". It will be ";
+    std::string temp = "Casts Weather Lore on " + tar->short_print() + ". It will be ";
     int weather, futuremonth;
     for (i = 0; i <= months; i++) {
         futuremonth = (month + i)%12;
@@ -1508,14 +1503,14 @@ int Game::RunDetectGates(ARegion *r,Object *o,Unit *u)
     u->event("Casts Gate Lore, detecting nearby Gates:", "spell");
     int found = 0;
     if ((r->gate) && (!r->gateopen)) {
-        u->event("Identified local gate number " + to_string(r->gate) + " in " + r->short_print() + ".", "spell");
+        u->event("Identified local gate number " + std::to_string(r->gate) + " in " + r->short_print() + ".", "spell");
     }
     for (int i=0; i<NDIRS; i++) {
         ARegion *tar = r->neighbors[i];
         if (tar) {
             if (tar->gate) {
                 if (Globals->DETECT_GATE_NUMBERS) {
-                    u->event(tar->print() + " contains Gate " + to_string(tar->gate) + ".", "spell");
+                    u->event(tar->print() + " contains Gate " + std::to_string(tar->gate) + ".", "spell");
                 } else {
                     u->event(tar->print() + " contains a Gate.", "spell");
                 }
@@ -1681,7 +1676,8 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
             if (!tar->gateopen) good = 0;
         } while (!good);
 
-        string jump_text = "Casts Random Gate Jump. Capacity: " + to_string(weight) + "/" + to_string(maxweight) + ".";
+        std::string jump_text = "Casts Random Gate Jump. Capacity: " +
+            std::to_string(weight) + "/" + std::to_string(maxweight) + ".";
         u->event(jump_text, "spell");
     } else {
         tar = regions.FindGate(order->gate);
@@ -1694,12 +1690,13 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
             return 0;
         }
 
-        string jump_text = "Casts Gate Jump. Capacity: " + to_string(weight) + "/" + to_string(maxweight) + ".";
+        std::string jump_text = "Casts Gate Jump. Capacity: " +
+            std::to_string(weight) + "/" + std::to_string(maxweight) + ".";
         u->event(jump_text, "spell");
     }
 
     int comma = 0;
-    string unitlist;
+    std::string unitlist;
     for(const auto id : order->units) {
         Location *loc = r->GetLocation(id, u->faction->num);
         if (loc) {
@@ -1712,7 +1709,7 @@ int Game::RunGateJump(ARegion *r,Object *o,Unit *u)
             if (loc->unit->GetAttitude(r,u) < AttitudeType::ALLY) {
                 u->error("CAST: Unit is not allied.");
             } else {
-                unitlist += (comma ? ", " : "") + to_string(loc->unit->num);
+                unitlist += (comma ? ", " : "") + std::to_string(loc->unit->num);
                 comma = 1;
                 loc->unit->DiscardUnfinishedShips();
                 loc->unit->event("Is teleported through a Gate to " + tar->print() + " by " + u->name + ".", "spell");

--- a/text_report_generator.cpp
+++ b/text_report_generator.cpp
@@ -9,8 +9,6 @@
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
 
-// using namespace std;
-
 const int TextReportGenerator::line_width = 70;
 const int TextReportGenerator::map_width = 23;
 const size_t TextReportGenerator::template_fill_size = 6;
@@ -346,7 +344,7 @@ void TextReportGenerator::output_unit_summary(std::ostream& f, const json& unit,
     }
 
     if (unit.contains("description")) f << "; " << to_s(unit["description"]);
-	f << ".\n";
+    f << ".\n";
 }
 
 void TextReportGenerator::output_unit(std::ostream& f, const json& unit, bool show_unit_attitudes) {
@@ -412,14 +410,14 @@ void TextReportGenerator::output_structure(std::ostream& f, const json& structur
         }
         f << ".\n";
     }
-	f << indent::incr;
+    f << indent::incr;
     if (structure.contains("units") && !structure["units"].empty()) {
         for(const auto& unit : structure["units"]) {
             output_unit(f, unit, show_unit_attitudes);
         }
     }
     f << indent::decr;
-	f << '\n';
+    f << '\n';
 }
 
 void TextReportGenerator::output_region(
@@ -536,7 +534,7 @@ void TextReportGenerator::output(std::ostream& f, const json& report, bool show_
         if (report.contains("type")) {
             f << " (";
             bool comma = false;
-            // std::right now there are 4 possible faction types.
+            // right now there are 4 possible faction types.
             // martial, war, trade, magic.
             // while it's not legal to have martial along with war and trade, for now we will just check and output
             // all of them.

--- a/unit.cpp
+++ b/unit.cpp
@@ -6,8 +6,6 @@
 #include "external/nlohmann/json.hpp"
 using json = nlohmann::json;
 
-using namespace std;
-
 UnitId::UnitId()
 {
 }
@@ -16,15 +14,15 @@ UnitId::~UnitId()
 {
 }
 
-string UnitId::Print()
+std::string UnitId::Print()
 {
     if (unitnum) {
-        return to_string(unitnum);
+        return std::to_string(unitnum);
     } else {
         if (faction) {
-            return string("faction ") + to_string(faction) + " new " + to_string(alias);
+            return std::string("faction ") + std::to_string(faction) + " new " + std::to_string(alias);
         } else {
-            return string("new ") + to_string(alias);
+            return std::string("new ") + std::to_string(alias);
         }
     }
 }
@@ -138,9 +136,9 @@ void Unit::MakeWMon(char const *monname, int mon, int num)
     SetMonFlags();
 }
 
-void Unit::Writeout(ostream& f)
+void Unit::Writeout(std::ostream& f)
 {
-    set<string>::iterator it;
+    std::set<std::string>::iterator it;
 
     f << name << '\n';
     f << (describe.empty() ? "none" : describe) << '\n';
@@ -169,13 +167,13 @@ void Unit::Writeout(ostream& f)
     }
 }
 
-void Unit::Readin(istream& f, std::list<Faction *>& facs)
+void Unit::Readin(std::istream& f, std::list<Faction *>& facs)
 {
     std::string str;
-    std::getline(f >> ws, str);
+    std::getline(f >> std::ws, str);
     name = str | filter::strip_number;
 
-    std::getline(f >> ws, str);
+    std::getline(f >> std::ws, str);
     describe = str | filter::legal_characters;
     if (describe == "none") describe.clear();
 
@@ -203,12 +201,12 @@ void Unit::Readin(istream& f, std::list<Faction *>& facs)
 
     f >> free;
 
-    f >> ws >> str;
+    f >> std::ws >> str;
     readyItem = lookup_item(str);
     for (i = 0; i < MAX_READY; i++) {
-        f >> ws >> str;
+        f >> std::ws >> str;
         readyWeapon[i] = lookup_item(str);
-        f >> ws >> str;
+        f >> std::ws >> str;
         readyArmor[i] = lookup_item(str);
     }
 
@@ -217,7 +215,7 @@ void Unit::Readin(istream& f, std::list<Faction *>& facs)
     items.Readin(f);
     skills.Readin(f);
 
-    f >> ws >> str;
+    f >> std::ws >> str;
     combat = lookup_skill(str);
 
     f >> savedmovement;
@@ -225,7 +223,7 @@ void Unit::Readin(istream& f, std::list<Faction *>& facs)
 
     f >> i;
     while (i-- > 0) {
-        std::getline(f >> ws, str);
+        std::getline(f >> std::ws, str);
         visited.insert(str);
     }
 }
@@ -235,7 +233,7 @@ std::string Unit::MageReport()
     std::string temp;
 
     if (combat != -1) {
-        temp = std::string(". Combat spell: ") + SkillStrs(combat);
+        temp = ". Combat spell: " + SkillStrs(combat);
     }
     return temp;
 }
@@ -254,11 +252,7 @@ std::string Unit::ReadyItem()
             ++item;
         }
     }
-    if (item > 0)
-    {
-        weaponstr = std::string("Ready weapon")
-            + (item == 1 ? "" : "s") + ": " + weaponstr;
-    }
+    if (item > 0) weaponstr = "Ready weapon" + strings::plural(item, "", "s") + ": " + weaponstr;
     weapon = item;
 
     item = 0;
@@ -270,12 +264,11 @@ std::string Unit::ReadyItem()
             ++item;
         }
     }
-    if (item > 0)
-        armorstr = std::string("Ready armor: ") + armorstr;
+    if (item > 0) armorstr = "Ready armor: " + armorstr;
     armor = item;
 
     if (readyItem != -1) {
-        battlestr = std::string("Ready item: ") + item_string(readyItem, 1);
+        battlestr = "Ready item: " + item_string(readyItem, 1);
         item = 1;
     } else
         item = 0;
@@ -396,14 +389,14 @@ std::string Unit::SpoilsReport() {
 }
 
 // TODO: Move this somewhere more global.  For now it's only used here.
-static inline void trim(string& s) {
-    s.erase(s.begin(), find_if_not(s.begin(), s.end(), [](char c){ return isspace(c); }));
-    s.erase(find_if_not(s.rbegin(), s.rend(), [](char c){ return isspace(c); }).base(), s.end());
+static inline void trim(std::string& s) {
+    s.erase(s.begin(), std::find_if_not(s.begin(), s.end(), [](char c){ return std::isspace(c); }));
+    s.erase(std::find_if_not(s.rbegin(), s.rend(), [](char c){ return std::isspace(c); }).base(), s.end());
 }
 
 json Unit::write_json_orders()
 {
-    stack<json> parent_stack;
+    std::stack<json> parent_stack;
     json container = json::array();
     parser::string_parser temp;
     parser::token token(std::nullopt);
@@ -416,7 +409,7 @@ json Unit::write_json_orders()
         token = temp.get_token();
         int order_val = token ? Parse1Order(token) : NORDERS;
 
-        set<int> month_orders = { O_MOVE, O_SAIL, O_TEACH, O_STUDY, O_BUILD, O_PRODUCE, O_ENTERTAIN, O_WORK };
+        std::set<int> month_orders = { O_MOVE, O_SAIL, O_TEACH, O_STUDY, O_BUILD, O_PRODUCE, O_ENTERTAIN, O_WORK };
         if (Globals->TAX_PILLAGE_MONTH_LONG) {
             month_orders.emplace(O_TAX);
             month_orders.emplace(O_PILLAGE);
@@ -551,8 +544,8 @@ void Unit::build_json_report(
     j = build_json_descriptor();
 
     if (!my_unit) {
-        string att = AttitudeStrs[static_cast<int>(attitude)];
-        transform(att.begin(), att.end(), att.begin(), ::tolower);
+        std::string att = AttitudeStrs[static_cast<int>(attitude)];
+        std::transform(att.begin(), att.end(), att.begin(), [](char c){ return std::tolower(c); });
         j["attitude"] = att;
     } else {
         j["own_unit"] = true;
@@ -945,7 +938,7 @@ void Unit::set_name(const std::string& newname)
     std::string temp = newname | filter::legal_characters;
     if (temp.empty()) return;
 
-    name = temp + " (" + to_string(num) + ")";
+    name = temp + " (" + std::to_string(num) + ")";
 }
 
 void Unit::set_description(const std::string& newdescription)
@@ -1058,7 +1051,7 @@ void Unit::ConsumeShared(int item, int needed)
 {
     // Use up items carried by the using unit first
     int amount = items.GetNum(item);
-    int used = min(amount, needed);
+    int used = std::min(amount, needed);
     needed -= used;
     items.SetNum(item, amount - used);
     // If we had enough, we are done
@@ -1070,10 +1063,10 @@ void Unit::ConsumeShared(int item, int needed)
             if (u->faction == faction && u->GetFlag(FLAG_SHARING)) {
                 amount = u->items.GetNum(item);
                 if (amount < 1) continue;
-                used = min(needed, amount);
+                used = std::min(needed, amount);
                 u->items.SetNum(item, amount - used);
                 needed -= used;
-                string temp = u->name + " shares " + item_string(item, used) + " with " + name + ".";
+                std::string temp = u->name + " shares " + item_string(item, used) + " with " + name + ".";
                 u->event(temp, "share");
                 // If the need has been filled, then we are done
                 if (needed == 0) return;
@@ -1475,7 +1468,7 @@ int Unit::Practice(int sk)
             skills.SetExp(sk, exp);
         }
         practiced = 1;
-        event("Gets " + to_string(bonus) + " days of practice with " + SkillStrs(sk) + ".", "practice");
+        event("Gets " + std::to_string(bonus) + " days of practice with " + SkillStrs(sk) + ".", "practice");
     }
 
     return bonus;
@@ -1653,7 +1646,7 @@ void Unit::Short(int needed, int hunger)
                 needed -= Globals->MAINTENANCE_COST;
             hunger -= Globals->UPKEEP_MINIMUM_FOOD;
             if (needed < 1 && hunger < 1) {
-                if (n) error(to_string(n) + " starve to death.");
+                if (n) error(std::to_string(n) + " starve to death.");
                 return;
             }
         }
@@ -1686,7 +1679,7 @@ void Unit::Short(int needed, int hunger)
                 needed -= Globals->LEADER_COST;
             hunger -= Globals->UPKEEP_MINIMUM_FOOD;
             if (needed < 1 && hunger < 1) {
-                if (n) error(to_string(n) + " starve to death.");
+                if (n) error(std::to_string(n) + " starve to death.");
                 return;
             }
         }
@@ -2464,12 +2457,12 @@ void Unit::DiscardUnfinishedShips() {
     if (discard > 0) event("discards all unfinished ships.", "discard");
 }
 
-void Unit::event(const string& message, const string& category, ARegion *r)
+void Unit::event(const std::string& message, const std::string& category, ARegion *r)
 {
     faction->event(message, category, r, this);
 }
 
-void Unit::error(const string& s) {
+void Unit::error(const std::string& s) {
     faction->error(s, this);
 }
 
@@ -2658,7 +2651,7 @@ void Unit::SkillStarvation()
                 items.SetNum(i->type, 0);
             }
         }
-        error(to_string(count) + " starve to death.");
+        error(std::to_string(count) + " starve to death.");
         return;
     }
     count = rng::get_random(count)+1;
@@ -2666,7 +2659,7 @@ void Unit::SkillStarvation()
         if (can_forget[i]) {
             if (--count == 0) {
                 Skill *s = GetSkillObject(i);
-                error(string("Starves and forgets one level of ") + SkillDefs[i].name + ".");
+                error(std::string("Starves and forgets one level of ") + SkillDefs[i].name + ".");
                 switch(GetLevelByDays(s->days)) {
                     case 1:
                         s->days -= 30;

--- a/unittest/build_order_test.cpp
+++ b/unittest/build_order_test.cpp
@@ -9,8 +9,6 @@ using json = nlohmann::json;
 
 namespace ut = boost::ut;
 
-using namespace std;
-
 // This suite will test various aspects of the Build Order functionality.
 ut::suite<"Build Order"> build_order_suite = [] {
     using namespace ut;
@@ -20,7 +18,7 @@ ut::suite<"Build Order"> build_order_suite = [] {
         UnitTestHelper helper;
         helper.initialize_game();
         helper.setup_turn();
-        string name("Test Faction");
+        std::string name("Test Faction");
         Faction *faction = helper.create_faction(name);
         Unit *leader = helper.get_first_unit(faction);
         Unit *unit = helper.create_unit(faction, leader->object->region);
@@ -43,7 +41,7 @@ ut::suite<"Build Order"> build_order_suite = [] {
         unit4->object->incomplete = 10; // Set the tower to be incomplete for testin
 
         // Test a simple build order
-        stringstream ss;
+        std::stringstream ss;
         ss << "#atlantis 3 \"mypassword\"\n";
         ss << "unit 2\n";
         ss << "build tower\n"; // this should start a new tower and not carry over to the next month orders

--- a/unittest/fleet_build_test.cpp
+++ b/unittest/fleet_build_test.cpp
@@ -9,8 +9,6 @@ using json = nlohmann::json;
 
 namespace ut = boost::ut;
 
-using namespace std;
-
 // This suite will test various aspects of the Build Order functionality.
 ut::suite<"Fleet Builds"> fleet_build_suite = [] {
     using namespace ut;
@@ -19,7 +17,7 @@ ut::suite<"Fleet Builds"> fleet_build_suite = [] {
         UnitTestHelper helper;
         helper.initialize_game();
         helper.setup_turn();
-        string name("Test Faction");
+        std::string name("Test Faction");
         Faction *faction = helper.create_faction(name);
         Unit *leader = helper.get_first_unit(faction);
         Unit *unit = helper.create_unit(faction, leader->object->region);
@@ -41,7 +39,7 @@ ut::suite<"Fleet Builds"> fleet_build_suite = [] {
         unit->object->flying = false;
 
         // Now set up some build orders
-        stringstream ss;
+        std::stringstream ss;
         ss << "#atlantis 3 \"mypassword\"\n";
         ss << "unit 2\n";
         ss << "build raft\n"; // this should create a new fleet with a raft and move the unit into it.
@@ -69,7 +67,7 @@ ut::suite<"Fleet Builds"> fleet_build_suite = [] {
         helper.initialize_game();
         helper.setup_turn();
         Globals->NEW_SHIP_JOINS_FLEET_BEHAVIOR  = GameDefs::NewShipJoinsFleetBehavior::ONLY_FLYING_CROSS_JOIN;
-        string name("Test Faction");
+        std::string name("Test Faction");
         Faction *faction = helper.create_faction(name);
         Unit *leader = helper.get_first_unit(faction);
         Unit *unit = helper.create_unit(faction, leader->object->region);
@@ -91,7 +89,7 @@ ut::suite<"Fleet Builds"> fleet_build_suite = [] {
         unit->object->flying = false;
 
         // Now set up some build orders
-        stringstream ss;
+        std::stringstream ss;
         ss << "#atlantis 3 \"mypassword\"\n";
         ss << "unit 2\n";
         ss << "build raft\n"; // this should create a new fleet with a raft and move the unit into it.
@@ -121,7 +119,7 @@ ut::suite<"Fleet Builds"> fleet_build_suite = [] {
         helper.initialize_game();
         helper.setup_turn();
         Globals->NEW_SHIP_JOINS_FLEET_BEHAVIOR  = GameDefs::NewShipJoinsFleetBehavior::ALL_CROSS_JOIN;
-        string name("Test Faction");
+        std::string name("Test Faction");
         Faction *faction = helper.create_faction(name);
         Unit *leader = helper.get_first_unit(faction);
         Unit *unit = helper.create_unit(faction, leader->object->region);
@@ -143,7 +141,7 @@ ut::suite<"Fleet Builds"> fleet_build_suite = [] {
         unit->object->flying = false;
 
         // Now set up some build orders
-        stringstream ss;
+        std::stringstream ss;
         ss << "#atlantis 3 \"mypassword\"\n";
         ss << "unit 2\n";
         ss << "build raft\n"; // this should join the raft to the flying fleet and make it non-flying

--- a/unittest/indent_formatter_test.cpp
+++ b/unittest/indent_formatter_test.cpp
@@ -9,7 +9,6 @@
 // using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
-using namespace std;
 
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"Indent Formatter"> indent_formatter_suite = []
@@ -18,110 +17,110 @@ ut::suite<"Indent Formatter"> indent_formatter_suite = []
 
   "increment indents"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::incr << "test\n";
     ss.flush();
-    expect(eq(ss.str(), string("  test\n")));
+    expect(eq(ss.str(), std::string("  test\n")));
   };
 
   "incr and decr control indent level"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::incr << "test\n";
     ss << indent::incr << "test\n";
     ss << indent::decr << "test\n";
     ss.flush();
-    expect(eq(ss.str(), string("  test\n    test\n  test\n")));
+    expect(eq(ss.str(), std::string("  test\n    test\n  test\n")));
   };
 
   "decreasing indent when it's already 0 leaves it at 0"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::wrap(20, 5, 0) << indent::decr << "test\n";
-    expect(eq(ss.str(), string("test\n")));
+    expect(eq(ss.str(), std::string("test\n")));
   };
 
   "clear removes formatter"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::incr << "test\n";
     ss << indent::incr << "test\n";
     ss << indent::clear << "test\n";
-    expect(eq(ss.str(), string("  test\n    test\ntest\n")));
+    expect(eq(ss.str(), std::string("  test\n    test\ntest\n")));
   };
 
   "default wraps at first space before 70 characters then indents wrapped lines"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::incr << "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 \n";
     expect(eq(
       ss.str(),
-      string("  123456789 123456789 123456789 123456789 123456789 123456789\n    123456789 123456789 \n")
+      std::string("  123456789 123456789 123456789 123456789 123456789 123456789\n    123456789 123456789 \n")
     ));
   };
 
   "wrap with no indent still wraps correctly"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::wrap << "--123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 \n";
     expect(eq(
       ss.str(),
-      string("--123456789 123456789 123456789 123456789 123456789 123456789\n  123456789 123456789 \n")
+      std::string("--123456789 123456789 123456789 123456789 123456789 123456789\n  123456789 123456789 \n")
     ));
   };
 
 
   "wrap at shorter values works"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::wrap(5) << "test bar\n";
-    expect(eq(ss.str(), string("test\n  bar\n")));
+    expect(eq(ss.str(), std::string("test\n  bar\n")));
   };
 
   "wrap with different lookback works"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     // since the lookback is only 2, this cannot break at the first space, so should just break at the wrap point.
     // and then indent, then break the second wrapped line also at the wrap point and indent until done.
     ss << indent::wrap(5, 2) << "t esttestbar\n";
-    expect(eq(ss.str(), string("t est\n  tes\n  tba\n  r\n")));
+    expect(eq(ss.str(), std::string("t est\n  tes\n  tba\n  r\n")));
   };
 
   "wrap with different wrapped line indent works"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::wrap(5, 2, 1) << "t esttestbar\n";
-    expect(eq(ss.str(), string("t est\n test\n bar\n")));
+    expect(eq(ss.str(), std::string("t est\n test\n bar\n")));
   };
 
   "comment prefixes line with semicolon"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::comment << "test\n";
-    expect(eq(ss.str(), string(";test\n")));
+    expect(eq(ss.str(), std::string(";test\n")));
   };
 
   "comment is not counted in wrapping and persists on wrapped lines"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::wrap(5, 2) << indent::comment << "t esttestbar\n";
-    expect(eq(ss.str(), string(";t est\n;  tes\n;  tba\n;  r\n")));
+    expect(eq(ss.str(), std::string(";t est\n;  tes\n;  tba\n;  r\n")));
   };
 
   "flushes correctly"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::incr << "test";
     ss.flush();
-    expect(eq(ss.str(), string("  test")));
+    expect(eq(ss.str(), std::string("  test")));
   };
 
   "push and pop indent works"_test = []
   {
-    stringstream ss;
+    std::stringstream ss;
     ss << indent::incr << "test\n";
     ss << indent::push_indent(0) << "test\n";
     ss << indent::pop_indent() << "test\n";
-    expect(eq(ss.str(), string("  test\ntest\n  test\n")));
+    expect(eq(ss.str(), std::string("  test\ntest\n  test\n")));
   };
 };

--- a/unittest/json_report_test.cpp
+++ b/unittest/json_report_test.cpp
@@ -12,8 +12,6 @@ using json = nlohmann::json;
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
 
-using namespace std;
-
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"JSON Report"> json_report_suite = []
 {
@@ -25,7 +23,7 @@ ut::suite<"JSON Report"> json_report_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
 
     helper.setup_reports();
@@ -36,7 +34,7 @@ ut::suite<"JSON Report"> json_report_suite = []
     faction->build_json_report(json_report, &game, nullptr);
 
     // pick some of the data out of the report for checking
-    string data_name = json_report["name"];
+    std::string data_name = json_report["name"];
     auto data_num = json_report["number"];
     auto new_items = json_report["item_reports"].size();
     auto regions = json_report["regions"].size();
@@ -48,8 +46,8 @@ ut::suite<"JSON Report"> json_report_suite = []
     expect(skill_reports == 3_ul); // should have exactly 3 skill reports
 
     // Verify that the game date is correct.
-    string expected_month("January");
-    string data_month = json_report["date"]["month"];
+    std::string expected_month("January");
+    std::string data_month = json_report["date"]["month"];
     expect(data_month == expected_month);
 
     // Verify the basic region info is correct.
@@ -70,8 +68,8 @@ ut::suite<"JSON Report"> json_report_suite = []
 
     auto count = json_report["errors"].size();
     expect(count == 1_ul);
-    string error = json_report["errors"][0]["message"];
-    string expected = "This is an error";
+    std::string error = json_report["errors"][0]["message"];
+    std::string expected = "This is an error";
     expect(error == expected);
   };
 
@@ -82,15 +80,15 @@ ut::suite<"JSON Report"> json_report_suite = []
     helper.setup_turn();
 
     Faction *faction = helper.create_faction("Test Faction");
-    for (auto i = 0; i < 1003; i++) faction->error("This is error #" + to_string(i+1));
+    for (auto i = 0; i < 1003; i++) faction->error("This is error #" + std::to_string(i+1));
 
     json json_report;
     faction->build_json_report(json_report, &helper.game_object(), nullptr);
 
     auto count = json_report["errors"].size();
     expect(count == 1001_ul);
-    string error = json_report["errors"][1000]["message"];
-    string expected = "Too many errors!";
+    std::string error = json_report["errors"][1000]["message"];
+    std::string expected = "Too many errors!";
     expect(error == expected);
 
     error = json_report["errors"][999]["message"];
@@ -115,10 +113,10 @@ ut::suite<"JSON Report"> json_report_suite = []
     expect(count == 2_ul);
 
     // make sure they are in the right order
-    string event = json_report["events"][0]["message"];
-    string type = json_report["events"][0]["category"];
-    string expected = "This is event 1";
-    string expected_type = "type1";
+    std::string event = json_report["events"][0]["message"];
+    std::string type = json_report["events"][0]["category"];
+    std::string expected = "This is event 1";
+    std::string expected_type = "type1";
     expect(event == expected);
     expect(type == expected_type);
 
@@ -147,12 +145,12 @@ ut::suite<"JSON Report"> json_report_suite = []
     json json_report;
     region->build_json_report(json_report, faction, helper.get_month(), regions);
 
-    string expected_provice("Testing Wilds"); // name given in the unit test setup
-    string province = json_report["province"];
+    std::string expected_provice("Testing Wilds"); // name given in the unit test setup
+    std::string province = json_report["province"];
     expect(province == expected_provice);
 
-    string expected_terrain("plain"); // should be the terrain set up in the unit test
-    string terrain = json_report["terrain"];
+    std::string expected_terrain("plain"); // should be the terrain set up in the unit test
+    std::string terrain = json_report["terrain"];
     expect(terrain == expected_terrain);
 
     auto x = json_report["coordinates"]["x"];
@@ -162,16 +160,16 @@ ut::suite<"JSON Report"> json_report_suite = []
     expect(y == 0_i);
     expect(z == 0_i);
 
-    string expected_label("surface");
-    string label = json_report["coordinates"]["label"];
+    std::string expected_label("surface");
+    std::string label = json_report["coordinates"]["label"];
     expect(label == expected_label);
 
-    string settlement_name = json_report["settlement"]["name"];
-    string expected_settlement_name("Basictown"); // name given in the unit test setup
+    std::string settlement_name = json_report["settlement"]["name"];
+    std::string expected_settlement_name("Basictown"); // name given in the unit test setup
     expect(settlement_name == expected_settlement_name);
 
-    string settlement_size = json_report["settlement"]["size"];
-    string expected_settlement_size("city");
+    std::string settlement_size = json_report["settlement"]["size"];
+    std::string expected_settlement_size("city");
     expect(settlement_size == expected_settlement_size);
 
     auto wages = json_report["wages"];
@@ -274,7 +272,7 @@ ut::suite<"JSON Report"> json_report_suite = []
     Faction *faction = helper.create_faction("Test Faction");
     Unit *leader = helper.get_first_unit(faction);
     leader->set_name("My Leader");
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "@work\n";
@@ -289,15 +287,15 @@ ut::suite<"JSON Report"> json_report_suite = []
     json json_unit_report;
     leader->build_json_report(json_unit_report, -1, 1, 1, 1, AttitudeType::ALLY, 1);
 
-    string name = json_unit_report["name"];
-    string expected_name = "My Leader";
+    std::string name = json_unit_report["name"];
+    std::string expected_name = "My Leader";
     expect(name == expected_name);
 
     auto id = json_unit_report["number"];
     expect(id == 2_i);
 
-    string faction_name = json_unit_report["faction"]["name"];
-    string expected_faction_name = "Test Faction";
+    std::string faction_name = json_unit_report["faction"]["name"];
+    std::string expected_faction_name = "Test Faction";
     expect(faction_name == expected_faction_name);
 
     auto faction_id = json_unit_report["faction"]["number"];
@@ -323,8 +321,8 @@ ut::suite<"JSON Report"> json_report_suite = []
     expect(work_order == expected_work_order);
 
     // verify the turn order
-    string turn_order = json_unit_report["orders"][1]["order"];
-    string expected_turn_order = "TURN";
+    std::string turn_order = json_unit_report["orders"][1]["order"];
+    std::string expected_turn_order = "TURN";
     expect(turn_order == expected_turn_order);
     auto turn_orders_count = json_unit_report["orders"][1]["nested"].size();
     expect(turn_orders_count == 2_ul);

--- a/unittest/n07_victory_test.cpp
+++ b/unittest/n07_victory_test.cpp
@@ -8,7 +8,6 @@
 // using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
-using namespace std;
 
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
@@ -23,7 +22,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     Unit *leader = helper.get_first_unit(faction);
     ARegion *region = helper.get_region(0, 0, 0);
@@ -34,7 +33,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
 
     helper.create_building(region, nullptr, O_ENTITY_CAGE);
 
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 3\n";
     ss << "sacrifice 10 lead\n";
@@ -71,7 +70,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     Unit *leader = helper.get_first_unit(faction);
     ARegion *region = helper.get_region(0, 0, 0);
@@ -82,7 +81,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
 
     helper.create_building(region, nullptr, O_ENTITY_CAGE);
 
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 3\n";
     ss << "sacrifice 5 lead\n";
@@ -117,7 +116,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     ARegion *region = helper.get_region(1, 1, 0);
     Unit *leader = helper.get_first_unit(faction);
@@ -126,7 +125,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, nullptr, O_RITUAL_ALTAR);
 
     // Try to move the unit into the region with the ritual altar.
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move SE\n";
@@ -158,7 +157,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     ARegion *region = helper.get_region(1, 1, 0);
     Unit *leader = helper.get_first_unit(faction);
@@ -170,7 +169,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, nullptr, O_RITUAL_ALTAR);
 
     // Try to teleport the unit into the region with the ritual altar.
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "cast Teleportation REGION 1 1\n";
@@ -204,7 +203,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(1, 1, 0);
@@ -215,7 +214,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, nullptr, O_RITUAL_ALTAR);
 
     // Try to move the unit into the region with the ritual altar.
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move SE\n";
@@ -249,7 +248,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(1, 1, 0);
@@ -287,7 +286,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(1, 1, 0);
@@ -298,7 +297,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, nullptr, O_RITUAL_ALTAR);
 
     // Try to move the unit into the region with the ritual altar.
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move SE\n";
@@ -337,7 +336,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -348,7 +347,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, nullptr, O_RITUAL_ALTAR);
 
     // Try to move the unit into the region with the ritual altar.
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move SE\n";
@@ -387,7 +386,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     //ARegion *region = helper.get_region(0, 0, 0);
@@ -395,7 +394,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     leader->set_name("My Leader");
 
     // Try to use annihilate
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "annihilate region 1 1 0\n";
@@ -427,7 +426,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -437,7 +436,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, leader, O_ACTIVE_MONOLITH);
 
     // Try to use annihilate
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "annihilate region 0 0 0\n";
@@ -471,7 +470,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -486,7 +485,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, second, O_TOWER);
 
     // Try to use annihilate
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move se 1\n";
@@ -562,7 +561,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     json rulesetData = { {"allowed_annihilates", 2}};
     helper.set_ruleset_specific_data(rulesetData);
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -577,7 +576,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, second, O_TOWER);
 
     // Try to use annihilate
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move se 1\n";
@@ -657,7 +656,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     json rulesetData = { {"allowed_annihilates", 2}, {"random_annihilates", true}};
     helper.set_ruleset_specific_data(rulesetData);
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -672,7 +671,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, second, O_TOWER);
 
     // Try to use annihilate
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move se 1\n";
@@ -751,7 +750,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     json rulesetData = { {"allowed_annihilates", 2}, {"random_annihilates", true}};
     helper.set_ruleset_specific_data(rulesetData);
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -766,7 +765,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, second, O_TOWER);
 
     // Try to use annihilate
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move se 1\n";
@@ -846,7 +845,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     json rulesetData = { {"allowed_annihilates", 2}, {"random_annihilates", true}};
     helper.set_ruleset_specific_data(rulesetData);
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -861,7 +860,7 @@ ut::suite<"NO7 Victory Conditions"> no7victory_suite = []
     helper.create_building(region, second, O_TOWER);
 
     // Try to use annihilate
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 2\n";
     ss << "move se 1\n";

--- a/unittest/name_sanitization_test.cpp
+++ b/unittest/name_sanitization_test.cpp
@@ -12,8 +12,6 @@ using json = nlohmann::json;
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
 
-using namespace std;
-
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"Name Sanitization"> name_sanitization_suite = []
 {
@@ -25,20 +23,20 @@ ut::suite<"Name Sanitization"> name_sanitization_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
 
-    string expected_name("Test Faction (3)");
-    string actual_name(faction->name);
+    std::string expected_name("Test Faction (3)");
+    std::string actual_name(faction->name);
     expect(actual_name == expected_name);
 
-    stringstream ss;
+    std::stringstream ss;
     faction->Writeout(ss);
 
     Faction faction2;
     faction2.Readin(ss);
 
-    string actual_name2(faction2.name);
+    std::string actual_name2(faction2.name);
     expect(actual_name2 == expected_name);
   };
 
@@ -48,23 +46,23 @@ ut::suite<"Name Sanitization"> name_sanitization_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction (3)");
+    std::string name("Test Faction (3)");
     Faction *faction = helper.create_faction(name);
     // Create an unsanitized name that we want to make sure gets sanitized.
     faction->set_name("Test Faction [];boy (3)", false);
 
-    string expected_name("Test Faction [];boy (3)");
-    string actual_name(faction->name);
+    std::string expected_name("Test Faction [];boy (3)");
+    std::string actual_name(faction->name);
     expect(actual_name == expected_name);
 
-    stringstream ss;
+    std::stringstream ss;
     faction->Writeout(ss);
 
     Faction faction2;
     faction2.Readin(ss);
 
-    string sanitized_name("Test Faction boy (3)");
-    string actual_name2(faction2.name);
+    std::string sanitized_name("Test Faction boy (3)");
+    std::string actual_name2(faction2.name);
     expect(actual_name2 == sanitized_name);
   };
 };

--- a/unittest/order_checker_test.cpp
+++ b/unittest/order_checker_test.cpp
@@ -12,8 +12,6 @@ using json = nlohmann::json;
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
 
-using namespace std;
-
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"Order Checker"> order_checker_suite = [] {
     using namespace ut;
@@ -23,21 +21,21 @@ ut::suite<"Order Checker"> order_checker_suite = [] {
         helper.initialize_game();
         helper.setup_turn();
 
-        string name("Test Faction");
+        std::string name("Test Faction");
         Faction *faction = helper.create_faction(name);
         faction->password = "mypassword";
 
-        stringstream ss;
+        std::stringstream ss;
         ss << "#atlantis 3 \"mypassword\"\n";
         ss << "unit 2\n";
         ss << "work\n";
 
-        stringstream ss2;
+        std::stringstream ss2;
         orders_check checker(ss2);
 
         helper.parse_orders(faction->num, ss, &checker);
         expect(checker.numerrors == 0_i);
-        expect(ss2.str().find("No errors found.\n") != string::npos);
+        expect(ss2.str().find("No errors found.\n") != std::string::npos);
     };
 
     "Order checker reports an error for incorrect password"_test = [] {
@@ -45,21 +43,21 @@ ut::suite<"Order Checker"> order_checker_suite = [] {
         helper.initialize_game();
         helper.setup_turn();
 
-        string name("Test Faction");
+        std::string name("Test Faction");
         Faction *faction = helper.create_faction(name);
         faction->password = "mypassword";
 
-        stringstream ss;
+        std::stringstream ss;
         ss << "#atlantis 3 \"wrongpassword\"\n";
         ss << "unit 2\n";
         ss << "work\n";
 
-        stringstream ss2;
+        std::stringstream ss2;
         orders_check checker(ss2);
 
         helper.parse_orders(faction->num, ss, &checker);
         expect(checker.numerrors == 1_i);
-        expect(ss2.str().find("No errors found.") == string::npos);
-        expect(ss2.str().find("*** Error: Incorrect password on #atlantis line. ***\n") != string::npos);
+        expect(ss2.str().find("No errors found.") == std::string::npos);
+        expect(ss2.str().find("*** Error: Incorrect password on #atlantis line. ***\n") != std::string::npos);
     };
 };

--- a/unittest/safe_list_test.cpp
+++ b/unittest/safe_list_test.cpp
@@ -8,7 +8,6 @@
 // using namespace boost::ut; here. Instead, we alias it, and then use the alias inside the
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
-using namespace std;
 
 // This suite will test various aspects of the Faction class in isolation.
 ut::suite<"Safe List"> safe_list_suite = []
@@ -104,7 +103,7 @@ ut::suite<"Safe List"> safe_list_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -126,7 +125,7 @@ ut::suite<"Safe List"> safe_list_suite = []
     helper.create_fleet(region, fourth, I_CLOUDSHIP, 1); // this fleet won't sail and should get an error
     helper.create_fleet(region, fifth, I_CLOUDSHIP, 1);
 
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 3\n";
     ss << "SAIL S\n";
@@ -170,7 +169,7 @@ ut::suite<"Safe List"> safe_list_suite = []
     helper.initialize_game();
     helper.setup_turn();
 
-    string name("Test Faction");
+    std::string name("Test Faction");
     Faction *faction = helper.create_faction(name);
     // Since this is such a tightly defined world, we know this is legal
     ARegion *region = helper.get_region(0, 0, 0);
@@ -191,7 +190,7 @@ ut::suite<"Safe List"> safe_list_suite = []
     helper.create_building(region, nullptr, O_FORT);
     helper.create_building(region, nullptr, O_FORT);
 
-    stringstream ss;
+    std::stringstream ss;
     ss << "#atlantis 3\n";
     ss << "unit 3\n";
     ss << "ENTER 2\n";

--- a/unittest/string_filters_test.cpp
+++ b/unittest/string_filters_test.cpp
@@ -12,8 +12,6 @@ using json = nlohmann::json;
 // closure to make the user defined literals and all the other niceness available.
 namespace ut = boost::ut;
 
-using namespace std;
-
 // This suite tests the string_filters.hpp utility functions for string manipulation
 ut::suite<"StringFilters"> string_filters_suite = []
 {
@@ -21,25 +19,25 @@ ut::suite<"StringFilters"> string_filters_suite = []
 
   "legal_characters removes illegal characters"_test = []
   {
-    string input = "Hello, World! [@#$\n^&*]";
-    string expected = "Hello, World! @#$^&*";
-    string actual = filter::legal_characters(input);
+    std::string input = "Hello, World! [@#$\n^&*]";
+    std::string expected = "Hello, World! @#$^&*";
+    std::string actual = filter::legal_characters(input);
     expect(actual == expected);
   };
 
   "legal_characters returns empty string for spaces-only result"_test = []
   {
-    string input = "   \t\n\r";
-    string expected = "";
-    string actual = filter::legal_characters(input);
+    std::string input = "   \t\n\r";
+    std::string expected = "";
+    std::string actual = filter::legal_characters(input);
     expect(actual == expected);
   };
 
   "strip_number removes text after bracket/parenthesis and one preceeding space"_test = []
   {
-    string input = "Hello, World! (123)";
-    string expected = "Hello, World!";
-    string actual = filter::strip_number(input);
+    std::string input = "Hello, World! (123)";
+    std::string expected = "Hello, World!";
+    std::string actual = filter::strip_number(input);
     expect(actual == expected);
 
     input = "Test String [456]";
@@ -62,47 +60,47 @@ ut::suite<"StringFilters"> string_filters_suite = []
 
   "strip_number handles no brackets/parentheses"_test = []
   {
-    string input = "Hello, World!";
-    string expected = "Hello, World!";
-    string actual = filter::strip_number(input);
+    std::string input = "Hello, World!";
+    std::string expected = "Hello, World!";
+    std::string actual = filter::strip_number(input);
     expect(actual == expected);
   };
 
   "strip_number handles brackets/parentheses at start"_test = []
   {
-    string input = "(Hello) World!";
-    string expected = "";
-    string actual = filter::strip_number(input);
+    std::string input = "(Hello) World!";
+    std::string expected = "";
+    std::string actual = filter::strip_number(input);
     expect(actual == expected);
   };
 
   "pipe syntax works for legal_characters"_test = []
   {
-    string input = "Hello, World! [@#$]";
-    string expected = "Hello, World! @#$";
-    string actual = input | filter::legal_characters;
+    std::string input = "Hello, World! [@#$]";
+    std::string expected = "Hello, World! @#$";
+    std::string actual = input | filter::legal_characters;
     expect(actual == expected);
   };
 
   "pipe syntax works for strip_number"_test = []
   {
-    string input = "Hello, World! (123)";
-    string expected = "Hello, World!";
-    string actual = input | filter::strip_number;
+    std::string input = "Hello, World! (123)";
+    std::string expected = "Hello, World!";
+    std::string actual = input | filter::strip_number;
     expect(actual == expected);
   };
 
   "filters can be chained with pipe syntax"_test = []
   {
-    string input = "Hello, World! (123)";
-    string expected = "Hello, World!";
-    string actual = (input | filter::strip_number) | filter::legal_characters;
+    std::string input = "Hello, World! (123)";
+    std::string expected = "Hello, World!";
+    std::string actual = (input | filter::strip_number) | filter::legal_characters;
     expect(actual == expected);
 
     // With illegal characters before stripping - this won't strip the number as the () get filtered out first
     input = "Hello, [World]! (123)";
-    string expected2 = "Hello, World! 123";
-    string actual2 = (input | filter::legal_characters) | filter::strip_number;
+    std::string expected2 = "Hello, World! 123";
+    std::string actual2 = (input | filter::legal_characters) | filter::strip_number;
     expect(actual2 == expected2);
   };
 };


### PR DESCRIPTION
There were a couple places where strings that didn't need to be wrapped in std::string were being wrapped.  This removes those and also removes all cases of
'using namespace std;'

That latter had been on my plate, and Enno doing a bunch of it as part of the string cleanup prompted me to do the rest of it.