### PR TITLE
Fix the small bug in PR#284 causing news to change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,7 @@ if (NOT COMPILER_HAS_RANGES)
 endif(NOT COMPILER_HAS_RANGES)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    add_compile_options(-g -Wextra -Wall -Werror -pedantic -Wparentheses -Wno-psabi
-        -Wpointer-arith -Wignored-qualifiers)
+    add_compile_options(-g -Wextra -Wall -Werror -pedantic -Wno-psabi)
 elseif(MSVC)
     #add_compile_options(/WX /MP /FC /D_CRT_SECURE_NO_WARNINGS)
     add_compile_options(/MP /FC /D_CRT_SECURE_NO_WARNINGS /wd4244 /wd4267 /wd4700)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GAME ?= standard
 
 CPLUS ?= g++
 CC ?= gcc
-CFLAGS = -g -I. -I.. -Wextra -Wall -Werror -std=c++20 -pedantic -Wparentheses -Wpointer-arith -Wignored-qualifiers -Wno-psabi
+CFLAGS = -g -I. -I.. -Wextra -Wall -Werror -std=c++20 -pedantic -Wno-psabi
 
 RULESET_OBJECTS = extra.o map.o monsters.o rules.o world.o
 

--- a/battle.cpp
+++ b/battle.cpp
@@ -377,7 +377,7 @@ void AddBattleFact(
 ) {
     if (!Globals->WORLD_EVENTS) return;
 
-    auto fact = new BattleFact;
+    auto fact = new BattleFact();
 
     fact->location = EventLocation::Create(region);
 

--- a/events-battle.cpp
+++ b/events-battle.cpp
@@ -210,7 +210,7 @@ static Event monsterHunt(BattleFact* fact) {
     };
 }
 
-const Event monsterAggresion(BattleFact* fact) {
+static Event monsterAggresion(BattleFact* fact) {
     std::ostringstream buffer;
 
     auto mark = fact->location.GetSignificantLandmark();
@@ -253,7 +253,7 @@ const Event monsterAggresion(BattleFact* fact) {
     };
 }
 
-const Event pvpBattle(BattleFact* fact) {
+static Event pvpBattle(BattleFact* fact) {
     std::ostringstream buffer;
 
     int total = fact->attacker.total + fact->defender.total;

--- a/events.cpp
+++ b/events.cpp
@@ -18,9 +18,7 @@ std::string townType(const int type) {
     }
 }
 
-FactBase::~FactBase() {
-
-}
+FactBase::~FactBase() { }
 
 void BattleSide::AssignUnit(Unit* unit) {
     this->factionName = unit->faction->name;
@@ -209,7 +207,7 @@ bool compareLandmarks(const Landmark &first, const Landmark &second) {
     return first.y < second.y;
 }
 
-const EventLocation EventLocation::Create(ARegion* region) {
+EventLocation EventLocation::Create(ARegion* region) {
     EventLocation loc;
 
     loc.x = region->xloc;

--- a/events.h
+++ b/events.h
@@ -110,17 +110,18 @@ struct EventLocation {
     std::string province;
     std::string settlement;
     int settlementType;
-
     std::vector<Landmark> landmarks;
 
     events::LandmarkType GetLandmarkType();
     const std::string GetTerrainName(const bool plural = false);
-    static const EventLocation Create(ARegion* region);
+    static EventLocation Create(ARegion* region);
     const Landmark *GetSignificantLandmark();
 };
 
 class BattleFact : public FactBase {
 public:
+    ~BattleFact() = default;
+
     void GetEvents(std::list<Event> &events);
 
     EventLocation location;


### PR DESCRIPTION
There is a difference in how struct/class initialization happens, especially when there is no user-provided constructor when an object is construction as
`auto a = new Class` vs `auto a = new Class()`

When the explicit constructor was removed in preference of using the default constructor + member initialization the code was also changed to use the first of those formats instead of the second when constructing a BattleFact
for pvp.   Unfortunately this resulted in the output being
non-deterministic.   Reverting the construction to the
second format fixes this.

Also, re-added and explicit definition of the destructor to the BattleFact class (using = default) since it is required due to the parent class having a pure virtual destructor.  While that didn't contribute to the problem it was technically wrong.

Lastly, cleaned up a couple more uses of const that were redundant.